### PR TITLE
Remove Figma reference from mobile README

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,11 +1,15 @@
 
-  # Mobile UI for Turni di Palco
+# Mobile UI for Turni di Palco
 
-  This is a code bundle for Mobile UI for Turni di Palco. The original project is available at https://www.figma.com/design/FCdyc7UQxGMdvg0TmiRom8/Mobile-UI-for-Turni-di-Palco.
+Code bundle for the Turni di Palco mobile experience.
 
-  ## Running the code
+## Running the code
 
-  Run `npm i` to install the dependencies.
+- Run `npm i` to install the dependencies.
+- Run `npm run dev` to start the development server.
 
-  Run `npm run dev` to start the development server.
+## Authentication and state persistence
+
+- The login view only edits the profile email; there is no backend authentication and no password handling.
+- All gameplay and profile data are stored locally in the browser under the `tdp-mobile-ui-state` key via `window.localStorage` (see `src/state/store.tsx`).
   


### PR DESCRIPTION
## Summary
- remove the link to the original Figma design from the mobile README

## Testing
- not run (documentation change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69403c6673f88326b43f29c308dff27e)