### PR TITLE
Automate PWA cache version hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Monorepo per PWA, mobile UI e CMS. La PWA Ã¨ sviluppata con Vite/TypeScript ed Ã
 - `docs and references/`: PDF di design/GDD.
 
 ## PWA notes
-- Service worker: `apps/pwa/public/sw.js` pre-cacha shell/offline, bump `CACHE_NAME` per invalidare.
+- Service worker: `apps/pwa/public/sw.js` pre-cacha shell/offline. `npm run build:pwa` esegue `node tools/update-cache-version.js` per calcolare l'hash degli asset core (`apps/pwa/public/**`, escluso `sw.js`) e aggiornare `CACHE_NAME` (rinomina in base all'hash). Puoi lanciare lo script manualmente quando modifichi asset statici per forzare l'update della cache.
 - Manifest: `apps/pwa/public/manifest.webmanifest`.
 - Icone: `apps/pwa/public/icons/pwa-192.png`, `pwa-512.png` (placeholder).
 

--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "turni-di-palco-v16";
+const CACHE_NAME = "turni-di-palco-v042eba68";
 const OFFLINE_URL = "/index.html";
 const CORE_ASSETS = [
   "/",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev:pwa": "npm --workspace apps/pwa run dev",
     "dev:pwa:https": "npm --workspace apps/pwa run dev:https",
-    "build:pwa": "npm --workspace apps/pwa run build",
+    "build:pwa": "node tools/update-cache-version.js && npm --workspace apps/pwa run build",
     "preview:pwa": "npm --workspace apps/pwa run preview",
     "test:pwa": "npm --workspace apps/pwa run test",
     "dev:mobile": "npm --workspace apps/mobile run dev",

--- a/tools/update-cache-version.js
+++ b/tools/update-cache-version.js
@@ -1,0 +1,62 @@
+const { createHash } = require('crypto');
+const { promises: fs } = require('fs');
+const path = require('path');
+
+const PUBLIC_DIR = path.resolve('apps/pwa/public');
+const SERVICE_WORKER_PATH = path.join(PUBLIC_DIR, 'sw.js');
+const CACHE_PREFIX = 'turni-di-palco-v';
+
+async function collectFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(dir, entry.name);
+      if (entryPath === SERVICE_WORKER_PATH) return [];
+      if (entry.isDirectory()) {
+        return collectFiles(entryPath);
+      }
+      return [entryPath];
+    })
+  );
+  return files.flat();
+}
+
+async function calculateHash(filePaths) {
+  const hash = createHash('sha256');
+  for (const filePath of filePaths.sort()) {
+    const content = await fs.readFile(filePath);
+    const relativePath = path.relative(PUBLIC_DIR, filePath);
+    hash.update(relativePath);
+    hash.update('\0');
+    hash.update(content);
+  }
+  return hash.digest('hex').slice(0, 8);
+}
+
+async function updateServiceWorker(cacheSuffix) {
+  const swContent = await fs.readFile(SERVICE_WORKER_PATH, 'utf8');
+  const nextCacheName = `${CACHE_PREFIX}${cacheSuffix}`;
+  const updatedContent = swContent.replace(
+    /const CACHE_NAME = "[^"]*";/,
+    `const CACHE_NAME = "${nextCacheName}";`
+  );
+
+  if (updatedContent === swContent) {
+    throw new Error('CACHE_NAME not updated; pattern not found in service worker');
+  }
+
+  await fs.writeFile(SERVICE_WORKER_PATH, updatedContent);
+  return nextCacheName;
+}
+
+async function main() {
+  const files = await collectFiles(PUBLIC_DIR);
+  const hash = await calculateHash(files);
+  const cacheName = await updateServiceWorker(hash);
+  console.log(`Updated CACHE_NAME to ${cacheName}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a tools script that hashes PWA public assets and bumps service worker cache name
- hook the cache versioning script into the PWA build command
- document the cache refresh process in the PWA notes

## Testing
- node tools/update-cache-version.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694124b6e8d48326a7cf91855f3d64e7)