### PR TITLE
Add reusable PWA UI components

### DIFF
--- a/apps/pwa/src/components/README.md
+++ b/apps/pwa/src/components/README.md
@@ -1,0 +1,24 @@
+# Componenti UI PWA
+
+Set di componenti a template string pensati per riutilizzare i token stilistici della PWA.
+Ogni componente restituisce markup HTML pronto per essere inserito nelle pagine vanilla JS/TS.
+
+## Tokens
+- Definiti in `tokens.ts` con palette, raggi e spaziature condivise.
+- Le varianti dei componenti impostano CSS custom properties per mantenere lo stile coerente con `style.css`.
+
+## Componenti
+- `renderChip(props)`: pill/link con varianti `solid` o `ghost`, dimensioni `sm|md`, icona opzionale e stato (`default|active|muted`).
+- `renderStatPill(props)`: indicatore di statistica con varianti di stato (`default|positive|warning|danger`), dimensioni `sm|md` e icona opzionale.
+- `renderAppBar(props)`: intestazione brand + navigazione; compone internamente chip ghost piccoli.
+
+### Esempi rapidi
+```ts
+import { renderChip } from "./components/chip";
+import { renderStatPill } from "./components/stat-pill";
+
+const nav = renderChip({ label: "Home", href: "/", icon: "🏠", state: "active" });
+const stat = renderStatPill({ label: "XP", value: 120, state: "positive", icon: "⭐" });
+```
+
+Incorpora il markup concatenandolo nelle sezioni HTML delle pagine (`innerHTML`) o usando `insertAdjacentHTML`.

--- a/apps/pwa/src/components/app-bar.ts
+++ b/apps/pwa/src/components/app-bar.ts
@@ -1,0 +1,25 @@
+import { renderChip, ChipProps } from "./chip";
+
+export type AppBarProps = {
+  eyebrow?: string;
+  subtitle?: string;
+  brandMark?: string;
+  actions?: ChipProps[];
+};
+
+export function renderAppBar({ eyebrow = "Turni di Palco", subtitle, brandMark = "TdP", actions = [] }: AppBarProps) {
+  const chips = actions.map((chip) => renderChip({ ...chip, variant: chip.variant ?? "ghost", size: chip.size ?? "sm" })).join("");
+
+  return `
+    <header class="app-bar">
+      <div class="app-brand">
+        <span class="brand-mark">${brandMark}</span>
+        <div>
+          <p class="eyebrow">${eyebrow}</p>
+          <p class="muted tiny">${subtitle ?? ""}</p>
+        </div>
+      </div>
+      <div class="chip-row">${chips}</div>
+    </header>
+  `;
+}

--- a/apps/pwa/src/components/chip.ts
+++ b/apps/pwa/src/components/chip.ts
@@ -1,0 +1,62 @@
+import { colorTokens, radiusTokens, spacingTokens, typographyTokens } from "./tokens";
+
+export type ChipVariant = "solid" | "ghost";
+export type ChipSize = "sm" | "md";
+export type ChipState = "default" | "active" | "muted";
+
+export type ChipProps = {
+  label: string;
+  href?: string;
+  icon?: string;
+  size?: ChipSize;
+  variant?: ChipVariant;
+  state?: ChipState;
+  title?: string;
+  dataAttributes?: Record<string, string>;
+};
+
+type ChipSizeConfig = { paddingY: string; paddingX: string; fontSize: string };
+
+const sizeConfig: Record<ChipSize, ChipSizeConfig> = {
+  sm: {
+    paddingY: spacingTokens.xs,
+    paddingX: spacingTokens.sm,
+    fontSize: typographyTokens.tiny,
+  },
+  md: {
+    paddingY: spacingTokens.sm,
+    paddingX: spacingTokens.md,
+    fontSize: typographyTokens.small,
+  },
+};
+
+function dataAttributeString(dataAttributes?: Record<string, string>) {
+  if (!dataAttributes) return "";
+  return Object.entries(dataAttributes)
+    .map(([key, value]) => ` data-${key}="${value}"`)
+    .join("");
+}
+
+export function renderChip({
+  label,
+  href,
+  icon,
+  size = "md",
+  variant = "solid",
+  state = "default",
+  title,
+  dataAttributes,
+}: ChipProps): string {
+  const tag = href ? "a" : "button";
+  const classes = ["chip"];
+  if (variant === "ghost") classes.push("chip-ghost");
+  if (size === "sm") classes.push("chip-sm");
+  const iconMarkup = icon ? `<span class="chip-icon">${icon}</span>` : "";
+  const aria = title ? ` aria-label="${title}" title="${title}"` : "";
+  const attrs = href ? `href="${href}"` : "type=\"button\"";
+  const sizeVars = sizeConfig[size];
+  const dataAttrs = dataAttributeString(dataAttributes);
+  const style = `style="--chip-py:${sizeVars.paddingY};--chip-px:${sizeVars.paddingX};--chip-fz:${sizeVars.fontSize};--chip-radius:${radiusTokens.pill};--chip-bg:${colorTokens.surface};--chip-border:${colorTokens.surfaceBorder};--chip-hover-border:${colorTokens.surfaceHoverBorder};--chip-active-bg:${colorTokens.accentTint};--chip-active-border:${colorTokens.accentBorder};"`;
+
+  return `<${tag} class="${classes.join(" ")}" data-state="${state}" ${attrs}${aria} ${style}${dataAttrs}>${iconMarkup}<span>${label}</span></${tag}>`;
+}

--- a/apps/pwa/src/components/stat-pill.ts
+++ b/apps/pwa/src/components/stat-pill.ts
@@ -1,0 +1,53 @@
+import { colorTokens, radiusTokens, spacingTokens, typographyTokens } from "./tokens";
+
+export type StatPillSize = "sm" | "md";
+export type StatPillState = "default" | "positive" | "warning" | "danger";
+
+export type StatPillProps = {
+  label: string;
+  value: string | number;
+  icon?: string;
+  size?: StatPillSize;
+  state?: StatPillState;
+  valueAttributes?: Record<string, string>;
+};
+
+type PillSizeConfig = { paddingY: string; paddingX: string; fontSize: string };
+
+const sizeConfig: Record<StatPillSize, PillSizeConfig> = {
+  sm: {
+    paddingY: spacingTokens.xs,
+    paddingX: spacingTokens.sm,
+    fontSize: typographyTokens.tiny,
+  },
+  md: {
+    paddingY: spacingTokens.sm,
+    paddingX: spacingTokens.md,
+    fontSize: typographyTokens.small,
+  },
+};
+
+function valueAttributeString(valueAttributes?: Record<string, string>) {
+  if (!valueAttributes) return "";
+  return Object.entries(valueAttributes)
+    .map(([key, value]) => ` ${key}="${value}"`)
+    .join("");
+}
+
+export function renderStatPill({
+  label,
+  value,
+  icon,
+  size = "md",
+  state = "default",
+  valueAttributes,
+}: StatPillProps): string {
+  const classes = ["stat-pill"];
+  if (size === "sm") classes.push("stat-pill-sm");
+  const iconMarkup = icon ? `<span class="pill-icon">${icon}</span>` : "";
+  const sizeVars = sizeConfig[size];
+  const valueAttrs = valueAttributeString(valueAttributes);
+  const style = `style="--pill-py:${sizeVars.paddingY};--pill-px:${sizeVars.paddingX};--pill-fz:${sizeVars.fontSize};--pill-radius:${radiusTokens.pill};--pill-bg:${colorTokens.surface};--pill-border:${colorTokens.surfaceBorder};--pill-text:${colorTokens.text};--pill-muted:${colorTokens.muted};--pill-positive:${colorTokens.success};--pill-warning:${colorTokens.warning};--pill-danger:${colorTokens.danger};"`;
+
+  return `<div class="${classes.join(" ")}" data-state="${state}" ${style}>${iconMarkup}<span>${label}</span><strong${valueAttrs}>${value}</strong></div>`;
+}

--- a/apps/pwa/src/components/tokens.ts
+++ b/apps/pwa/src/components/tokens.ts
@@ -1,0 +1,30 @@
+export const colorTokens = {
+  surface: "rgba(255, 255, 255, 0.08)",
+  surfaceBorder: "rgba(255, 255, 255, 0.14)",
+  surfaceHoverBorder: "rgba(255, 255, 255, 0.25)",
+  accent: "#9cc9ff",
+  accentTint: "rgba(99, 140, 255, 0.18)",
+  accentBorder: "rgba(99, 140, 255, 0.65)",
+  success: "#34d399",
+  warning: "#f59e0b",
+  danger: "#f87171",
+  text: "#e9edf5",
+  muted: "#cad3e0",
+};
+
+export const radiusTokens = {
+  pill: "999px",
+  surface: "16px",
+};
+
+export const spacingTokens = {
+  xs: "0.35rem",
+  sm: "0.5rem",
+  md: "0.75rem",
+  lg: "1rem",
+};
+
+export const typographyTokens = {
+  tiny: "0.88rem",
+  small: "0.95rem",
+};

--- a/apps/pwa/src/dev.ts
+++ b/apps/pwa/src/dev.ts
@@ -1,5 +1,6 @@
 import "./style.css";
 import { registerServiceWorker } from "./pwa/register-sw";
+import { renderAppBar } from "./components/app-bar";
 import {
   AvatarIcon,
   GameState,
@@ -47,6 +48,15 @@ const devEvents: DevEvent[] = [
     focusRole: "luci",
   },
 ];
+
+const devNav = [
+  { label: "Landing", href: "/", icon: "🏠" },
+  { label: "Hub", href: "/game.html", icon: "🎛️" },
+  { label: "Mappa", href: "/map.html", icon: "🗺️" },
+  { label: "Avatar", href: "/avatar.html", icon: "🧑" },
+];
+
+const devAppBar = renderAppBar({ eyebrow: "Turni di Palco", subtitle: "Dev playground", actions: devNav });
 
 const activities: Activity[] = [
   {
@@ -118,21 +128,7 @@ if (!root) {
 
 root.innerHTML = `
   <main class="page">
-    <header class="app-bar">
-      <div class="app-brand">
-        <span class="brand-mark">TdP</span>
-        <div>
-          <p class="eyebrow">Turni di Palco</p>
-          <p class="muted tiny">Dev playground</p>
-        </div>
-      </div>
-      <div class="chip-row">
-        <a class="chip" href="/">Landing</a>
-        <a class="chip" href="/game.html">Hub</a>
-        <a class="chip" href="/map.html">Mappa</a>
-        <a class="chip" href="/avatar.html">Avatar</a>
-      </div>
-    </header>
+    ${devAppBar}
 
     <section class="hero" id="dev">
       <p class="eyebrow">Turni di Palco</p>

--- a/apps/pwa/src/main.ts
+++ b/apps/pwa/src/main.ts
@@ -1,5 +1,15 @@
 import "./style.css";
 import { registerServiceWorker } from "./pwa/register-sw";
+import { renderAppBar } from "./components/app-bar";
+
+const mainNav = [
+  { label: "Home", href: "#hero", state: "active" as const },
+  { label: "Permessi", href: "#permissions" },
+  { label: "Dev playground", href: "/dev.html", icon: "🛠️" },
+  { label: "Pagina gioco", href: "/game.html", icon: "🎮" },
+];
+
+const appBar = renderAppBar({ eyebrow: "Turni di Palco", subtitle: "PWA shell", actions: mainNav });
 
 const root = document.querySelector<HTMLDivElement>("#app");
 
@@ -9,21 +19,7 @@ if (!root) {
 
 root.innerHTML = `
   <main class="page">
-    <header class="app-bar">
-      <div class="app-brand">
-        <span class="brand-mark">TdP</span>
-        <div>
-          <p class="eyebrow">Turni di Palco</p>
-          <p class="muted tiny">PWA shell</p>
-        </div>
-      </div>
-      <div class="chip-row">
-        <a class="chip" href="#hero">Home</a>
-        <a class="chip" href="#permissions">Permessi</a>
-        <a class="chip" href="/dev.html">Dev playground</a>
-        <a class="chip" href="/game.html">Pagina gioco</a>
-      </div>
-    </header>
+    ${appBar}
 
     <section class="hero" id="hero">
       <p class="eyebrow">Turni di Palco</p>

--- a/apps/pwa/src/map.ts
+++ b/apps/pwa/src/map.ts
@@ -4,6 +4,8 @@ import L, { Map as LeafletMap, LayerGroup } from "leaflet";
 import "leaflet/dist/leaflet.css";
 import markerIconPng from "leaflet/dist/images/marker-icon.png";
 import markerShadowPng from "leaflet/dist/images/marker-shadow.png";
+import { renderChip } from "./components/chip";
+import { renderStatPill } from "./components/stat-pill";
 import { formatRewards, getAvatarVisual, loadState, mockEvents, resolveRole, Rewards, saveState } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");
@@ -11,6 +13,18 @@ const root = document.querySelector<HTMLDivElement>("#app");
 if (!root) {
   throw new Error("Root container missing");
 }
+
+const topStatsMarkup = [
+  renderStatPill({ label: "XP", value: 0, size: "sm", icon: "⭐", valueAttributes: { "data-top-stat": "xp" } }),
+  renderStatPill({ label: "Cachet", value: 0, size: "sm", icon: "💰", valueAttributes: { "data-top-stat": "cachet" } }),
+  renderStatPill({ label: "Rep", value: 0, size: "sm", icon: "📣", valueAttributes: { "data-top-stat": "rep" } }),
+].join("");
+
+const drawerTabsMarkup = [
+  renderChip({ label: "Eventi", size: "sm", variant: "ghost", state: "active", dataAttributes: { "drawer-tab": "events" } }),
+  renderChip({ label: "Turni", size: "sm", variant: "ghost", dataAttributes: { "drawer-tab": "turns" } }),
+  renderChip({ label: "Profilo", size: "sm", variant: "ghost", dataAttributes: { "drawer-tab": "profile" } }),
+].join("");
 
 root.innerHTML = `
   <main class="map-app">
@@ -35,11 +49,7 @@ root.innerHTML = `
             <p class="muted tiny" data-chip-role>Ruolo non impostato</p>
           </div>
         </div>
-        <div class="top-stats">
-          <div class="stat-pill"><span>XP</span><strong data-top-stat="xp">0</strong></div>
-          <div class="stat-pill"><span>Cachet</span><strong data-top-stat="cachet">0</strong></div>
-          <div class="stat-pill"><span>Rep</span><strong data-top-stat="rep">0</strong></div>
-        </div>
+        <div class="top-stats">${topStatsMarkup}</div>
         <a class="button ghost" href="/avatar.html">Avatar</a>
         <a class="button ghost" href="/">Landing</a>
         <a class="button ghost" href="/profile.html">Profilo</a>
@@ -61,11 +71,7 @@ root.innerHTML = `
 
     <section class="map-drawer">
       <div class="drawer-header">
-        <div class="drawer-tabs">
-          <button class="chip" data-drawer-tab="events">Eventi</button>
-          <button class="chip" data-drawer-tab="turns">Turni</button>
-          <button class="chip" data-drawer-tab="profile">Profilo</button>
-        </div>
+        <div class="drawer-tabs">${drawerTabsMarkup}</div>
         <div class="stat-board compact">
           <div class="stat-chip">
             <span>XP</span>
@@ -242,7 +248,9 @@ function renderMapMarkers() {
 
 function setDrawer(sectionId: "events" | "turns" | "profile") {
   drawerTabs.forEach((tab) => {
-    tab.classList.toggle("active", tab.dataset.drawerTab === sectionId);
+    const isActive = tab.dataset.drawerTab === sectionId;
+    tab.classList.toggle("active", isActive);
+    tab.dataset.state = isActive ? "active" : "default";
   });
   drawerSections.forEach((section) => {
     section.classList.toggle("active", section.dataset.section === sectionId);

--- a/apps/pwa/src/style.css
+++ b/apps/pwa/src/style.css
@@ -119,14 +119,60 @@ code {
 }
 
 .stat-pill {
+  --pill-py: 0.35rem;
+  --pill-px: 0.55rem;
+  --pill-fz: 0.95rem;
+  --pill-radius: 10px;
+  --pill-bg: rgba(255, 255, 255, 0.08);
+  --pill-border: rgba(255, 255, 255, 0.14);
+  --pill-text: #e9edf5;
+  --pill-muted: #cad3e0;
+  --pill-positive: #34d399;
+  --pill-warning: #f59e0b;
+  --pill-danger: #f87171;
+
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
-  padding: 0.35rem 0.55rem;
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  font-size: 0.95rem;
+  gap: 0.35rem;
+  padding: var(--pill-py) var(--pill-px);
+  border-radius: var(--pill-radius);
+  background: var(--pill-bg);
+  border: 1px solid var(--pill-border);
+  font-size: var(--pill-fz);
+  color: var(--pill-text);
+}
+
+.stat-pill strong {
+  color: var(--pill-text);
+}
+
+.pill-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 1.35em;
+  height: 1.35em;
+  color: var(--pill-muted);
+}
+
+.stat-pill-sm {
+  --pill-py: 0.3rem;
+  --pill-px: 0.5rem;
+  --pill-fz: 0.9rem;
+}
+
+.stat-pill[data-state="positive"] {
+  --pill-border: color-mix(in srgb, var(--pill-positive) 55%, transparent);
+  --pill-bg: color-mix(in srgb, var(--pill-positive) 14%, transparent);
+}
+
+.stat-pill[data-state="warning"] {
+  --pill-border: color-mix(in srgb, var(--pill-warning) 55%, transparent);
+  --pill-bg: color-mix(in srgb, var(--pill-warning) 14%, transparent);
+}
+
+.stat-pill[data-state="danger"] {
+  --pill-border: color-mix(in srgb, var(--pill-danger) 55%, transparent);
+  --pill-bg: color-mix(in srgb, var(--pill-danger) 16%, transparent);
 }
 
 .chip-row {
@@ -143,20 +189,64 @@ code {
 }
 
 .chip {
+  --chip-py: 0.5rem;
+  --chip-px: 0.8rem;
+  --chip-fz: 0.95rem;
+  --chip-radius: 999px;
+  --chip-bg: rgba(255, 255, 255, 0.08);
+  --chip-border: rgba(255, 255, 255, 0.14);
+  --chip-hover-border: rgba(255, 255, 255, 0.25);
+  --chip-active-bg: rgba(99, 140, 255, 0.18);
+  --chip-active-border: rgba(99, 140, 255, 0.65);
+
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  padding: 0.5rem 0.8rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  padding: var(--chip-py) var(--chip-px);
+  border-radius: var(--chip-radius);
+  background: var(--chip-bg);
+  border: 1px solid var(--chip-border);
   color: #e9edf5;
   text-decoration: none;
-  font-size: 0.95rem;
+  font-size: var(--chip-fz);
 }
 
-.chip:hover {
-  border-color: rgba(255, 255, 255, 0.25);
+.chip:hover,
+.chip:focus-visible {
+  border-color: var(--chip-hover-border);
+}
+
+.chip-ghost {
+  --chip-bg: transparent;
+  --chip-border: rgba(255, 255, 255, 0.2);
+}
+
+.chip-sm {
+  --chip-py: 0.4rem;
+  --chip-px: 0.65rem;
+  --chip-fz: 0.9rem;
+}
+
+.chip[data-state="active"] {
+  --chip-bg: var(--chip-active-bg);
+  --chip-border: var(--chip-active-border);
+  box-shadow: 0 10px 20px rgba(79, 134, 255, 0.3);
+}
+
+.chip.active {
+  --chip-bg: var(--chip-active-bg);
+  --chip-border: var(--chip-active-border);
+}
+
+.chip[data-state="muted"] {
+  opacity: 0.7;
+}
+
+.chip-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 1.3em;
+  height: 1.3em;
 }
 
 .profile-chip {
@@ -465,8 +555,8 @@ code {
 }
 
 .drawer-tabs .chip.active {
-  background: rgba(255, 255, 255, 0.18);
-  border-color: rgba(255, 255, 255, 0.28);
+  background: var(--chip-active-bg);
+  border-color: var(--chip-active-border);
 }
 
 .drawer-body {


### PR DESCRIPTION
## Summary
- add token-driven Chip, StatPill, and AppBar components with shared README
- refactor landing, dev playground, and map topbar/drawer to use the new components and expose icon/size/state variants
- refresh chip/stat-pill styling with CSS variables for tokens and active state handling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694124b3beec83269a5894e3a74bf1b3)