### PR TITLE
Refactor: Consolidate CSS into shared styling file

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -13,7 +13,7 @@ import { ActivityDetail } from './components/screens/ActivityDetail';
 import { Profilo } from './components/screens/Profilo';
 import { Carriera } from './components/screens/Carriera';
 import { GameStateProvider, useGameState } from './state/store';
-import './styles/globals.css';
+
 
 type Screen =
   | 'welcome'

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -1,7 +1,7 @@
 
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
-import "./index.css";
+import "../../../shared/styles/main.css";
 
 // On the dev server (5173) keep SW caches out of the way to avoid stale bundles.
 const isDevServer = window.location.port === "5173";

--- a/apps/pwa/src/avatar.ts
+++ b/apps/pwa/src/avatar.ts
@@ -1,5 +1,4 @@
-import "./styles/tokens.css";
-import "./style.css";
+import "../../../shared/styles/main.css";
 import { registerServiceWorker } from "./pwa/register-sw";
 import { deriveRpmThumbnail, getAvatarVisual, loadState, saveState } from "./state";
 

--- a/apps/pwa/src/dev.ts
+++ b/apps/pwa/src/dev.ts
@@ -1,5 +1,4 @@
-import "./styles/tokens.css";
-import "./style.css";
+import "../../../shared/styles/main.css";
 import { registerServiceWorker } from "./pwa/register-sw";
 import { renderAppBar } from "./components/app-bar";
 import {

--- a/apps/pwa/src/events.ts
+++ b/apps/pwa/src/events.ts
@@ -1,5 +1,4 @@
-import "./styles/tokens.css";
-import "./style.css";
+import "../../../shared/styles/main.css";
 import { mockEvents, resolveRole } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");

--- a/apps/pwa/src/game.ts
+++ b/apps/pwa/src/game.ts
@@ -1,5 +1,4 @@
-import "./styles/tokens.css";
-import "./style.css";
+import "../../../shared/styles/main.css";
 import { registerServiceWorker } from "./pwa/register-sw";
 import { formatRewards, getAvatarVisual, loadState, resolveRole } from "./state";
 

--- a/apps/pwa/src/main.ts
+++ b/apps/pwa/src/main.ts
@@ -1,5 +1,4 @@
-import "./styles/tokens.css";
-import "./style.css";
+import "../../../shared/styles/main.css";
 import { registerServiceWorker } from "./pwa/register-sw";
 import { renderAppBar } from "./components/app-bar";
 

--- a/apps/pwa/src/map.ts
+++ b/apps/pwa/src/map.ts
@@ -1,5 +1,4 @@
-import "./styles/tokens.css";
-import "./style.css";
+import "../../../shared/styles/main.css";
 import { registerServiceWorker } from "./pwa/register-sw";
 import L, { Map as LeafletMap, LayerGroup } from "leaflet";
 import "leaflet/dist/leaflet.css";
@@ -192,8 +191,7 @@ function renderEvents() {
   eventList.innerHTML = mockEvents
     .map(
       (item) =>
-        `<li><div><strong>${item.name}</strong> - ${item.theatre}</div><div class="muted">${item.date} | Focus: ${
-          item.focusRole ? resolveRole(item.focusRole).name : "Any"
+        `<li><div><strong>${item.name}</strong> - ${item.theatre}</div><div class="muted">${item.date} | Focus: ${item.focusRole ? resolveRole(item.focusRole).name : "Any"
         }</div></li>`
     )
     .join("");
@@ -233,8 +231,7 @@ function renderMapMarkers() {
   const bounds: L.LatLngExpression[] = [];
   mockEvents.forEach((event) => {
     const marker = L.marker([event.lat, event.lng], { icon: markerIcon }).bindPopup(
-      `<strong>${event.name}</strong><br/>${event.theatre}<br/>${event.date}<br/>Focus: ${
-        event.focusRole ? resolveRole(event.focusRole).name : "Any"
+      `<strong>${event.name}</strong><br/>${event.theatre}<br/>${event.date}<br/>Focus: ${event.focusRole ? resolveRole(event.focusRole).name : "Any"
       }`
     );
     markerLayer.addLayer(marker);

--- a/apps/pwa/src/profile.ts
+++ b/apps/pwa/src/profile.ts
@@ -1,5 +1,4 @@
-import "./styles/tokens.css";
-import "./style.css";
+import "../../../shared/styles/main.css";
 import { formatRewards, getAvatarVisual, loadState, resolveRole } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");

--- a/apps/pwa/src/turns.ts
+++ b/apps/pwa/src/turns.ts
@@ -1,5 +1,4 @@
-import "./styles/tokens.css";
-import "./style.css";
+import "../../../shared/styles/main.css";
 import { formatRewards, loadState, resolveRole } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -1,0 +1,2947 @@
+
+/* Source: tokens.css */
+:root {
+  /* Typography */
+  --font-family-base: "-apple-system", "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+  --font-family-mono: "JetBrains Mono", "Fira Code", Consolas, monospace;
+  --font-size-xs: 0.8rem;
+  --font-size-sm: 0.95rem;
+  --font-size-md: 1rem;
+  --font-size-lg: 1.2rem;
+  --font-size-xl: 1.6rem;
+  --font-size-2xl: 2rem;
+  --line-height-base: 1.6;
+  --line-height-tight: 1.2;
+
+  /* Spacing scale */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-7: 1.75rem;
+  --space-8: 2rem;
+  --space-9: 2.25rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+
+  /* Palette */
+  --color-brand-600: #4f86ff;
+  --color-brand-500: #638cff;
+  --color-brand-400: #4eceff;
+  --color-brand-200: #d8e4ff;
+  --color-surface-900: #05070d;
+  --color-surface-800: #0b1021;
+  --color-surface-700: #04070f;
+  --color-ink: #0b1021;
+  --color-neutral-50: #f8fafc;
+  --color-neutral-100: #e9edf5;
+  --color-neutral-200: #e5e7eb;
+  --color-neutral-250: #cad3e0;
+  --color-neutral-300: #d1d5db;
+  --color-neutral-350: #cbd5e1;
+  --color-neutral-375: #cdd8ee;
+  --color-neutral-500: #9ca3af;
+  --color-sky-200: #93c5fd;
+  --color-sky-300: #7dd3fc;
+  --color-indigo-200: #a5b4fc;
+  --color-info-50: #dbeafe;
+  --color-info-100: #bfdbfe;
+  --color-success-400: #34d399;
+  --color-success-100: #bbf7d0;
+  --color-warning-300: #fcd34d;
+  --color-danger-200: #fda4af;
+  --color-danger-300: #fca5a5;
+  --color-danger-400: #f87171;
+
+  /* Shared gradients & components */
+  --gradient-brand: linear-gradient(135deg, var(--color-brand-500), var(--color-brand-400));
+  --gradient-hero: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+  --gradient-panel: linear-gradient(160deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.03));
+
+  --chip-surface: rgba(255, 255, 255, 0.08);
+  --chip-border: rgba(255, 255, 255, 0.14);
+  --pill-surface: rgba(255, 255, 255, 0.06);
+  --pill-border: rgba(255, 255, 255, 0.1);
+  --pill-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+}
+
+body {
+  color-scheme: dark;
+  --bg-body: var(--color-surface-900);
+  --bg-card: rgba(255, 255, 255, 0.06);
+  --bg-card-strong: rgba(255, 255, 255, 0.08);
+  --bg-panel: var(--gradient-panel);
+  --bg-hero: var(--gradient-hero);
+  --bg-map: var(--color-surface-800);
+
+  --border-regular: rgba(255, 255, 255, 0.14);
+  --border-strong: rgba(255, 255, 255, 0.16);
+  --border-subtle: rgba(255, 255, 255, 0.1);
+  --border-soft: rgba(255, 255, 255, 0.12);
+
+  --text-primary: var(--color-neutral-100);
+  --text-secondary: var(--color-neutral-250);
+  --text-muted: var(--color-neutral-500);
+  --text-inverse: var(--color-ink);
+  --text-eyebrow: var(--color-sky-200);
+  --text-quiet: var(--color-neutral-350);
+
+  --selection-bg: rgba(147, 197, 253, 0.25);
+  --focus-ring: rgba(59, 130, 246, 0.4);
+
+  --surface-faint: rgba(255, 255, 255, 0.04);
+  --surface-veil-soft: rgba(255, 255, 255, 0.05);
+  --surface-veil: var(--bg-card);
+  --surface-veil-strong: var(--bg-card-strong);
+  --surface-veil-heavy: rgba(255, 255, 255, 0.12);
+  --surface-veil-bright: rgba(255, 255, 255, 0.18);
+  --surface-veil-highlight: rgba(255, 255, 255, 0.25);
+  --surface-veil-contrast: rgba(255, 255, 255, 0.28);
+  --surface-veil-stronger: rgba(255, 255, 255, 0.3);
+
+  --chip-surface: rgba(255, 255, 255, 0.08);
+  --chip-border: rgba(255, 255, 255, 0.14);
+  --pill-surface: rgba(255, 255, 255, 0.06);
+  --pill-border: rgba(255, 255, 255, 0.1);
+  --pill-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+
+  --shadow-card: 0 10px 40px rgba(0, 0, 0, 0.35);
+  --shadow-elevated: 0 18px 60px rgba(0, 0, 0, 0.45);
+  --shadow-brand: 0 10px 20px rgba(79, 134, 255, 0.3);
+  --shadow-brand-strong: 0 14px 30px rgba(79, 134, 255, 0.35);
+  --shadow-panel: 0 16px 50px rgba(0, 0, 0, 0.42);
+  --shadow-soft-elevated: 0 12px 30px rgba(0, 0, 0, 0.4);
+  --shadow-map: 0 18px 60px rgba(0, 0, 0, 0.5);
+  --shadow-text-contrast: 0 2px 6px rgba(0, 0, 0, 0.25);
+
+  --backdrop-strong: rgba(5, 7, 13, 0.4);
+  --backdrop-heavy: rgba(5, 7, 13, 0.45);
+  --backdrop-muted: rgba(5, 7, 13, 0.32);
+  --overlay-top-strong: linear-gradient(180deg, rgba(0, 0, 0, 0.5), transparent);
+  --overlay-bottom-strong: linear-gradient(0deg, rgba(0, 0, 0, 0.5), transparent);
+  --panel-backdrop: linear-gradient(180deg, rgba(20, 28, 58, 0.55), rgba(10, 16, 26, 0.8));
+
+  --glow-primary: rgba(74, 144, 255, 0.22);
+  --glow-secondary: rgba(120, 119, 237, 0.24);
+  --glow-tertiary: rgba(16, 185, 129, 0.12);
+  --map-glow-primary: rgba(99, 140, 255, 0.25);
+  --map-glow-secondary: rgba(78, 206, 255, 0.18);
+  --map-glow-tertiary: rgba(16, 185, 129, 0.18);
+
+  --border-success: rgba(52, 211, 153, 0.5);
+  --border-warning: rgba(252, 211, 77, 0.5);
+  --border-danger: rgba(248, 113, 113, 0.5);
+  --inset-bright: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  --inset-soft: inset 0 1px 0 rgba(255, 255, 255, 0.16);
+  --inset-faint: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+
+  --gradient-body: radial-gradient(circle at 20% 20%, var(--glow-primary), transparent 32%),
+    radial-gradient(circle at 72% 15%, var(--glow-secondary), transparent 32%),
+    radial-gradient(circle at 30% 70%, var(--glow-tertiary), transparent 32%);
+}
+
+body[data-theme="light"] {
+  color-scheme: light;
+  --bg-body: #f7f9fc;
+  --bg-card: #ffffff;
+  --bg-card-strong: #f1f5f9;
+  --bg-panel: linear-gradient(160deg, rgba(15, 23, 42, 0.06), rgba(15, 23, 42, 0.03));
+  --bg-hero: linear-gradient(135deg, rgba(15, 23, 42, 0.06), rgba(15, 23, 42, 0.02));
+  --bg-map: #e8f0ff;
+
+  --border-regular: #cbd5e1;
+  --border-strong: #94a3b8;
+  --border-subtle: #e2e8f0;
+  --border-soft: #e2e8f0;
+
+  --text-primary: #0f172a;
+  --text-secondary: #334155;
+  --text-muted: #475569;
+  --text-inverse: #ffffff;
+  --text-eyebrow: #0f172a;
+  --text-quiet: #475569;
+
+  --selection-bg: rgba(99, 140, 255, 0.18);
+  --focus-ring: rgba(99, 140, 255, 0.35);
+
+  --surface-faint: #e2e8f0;
+  --surface-veil-soft: #ecf1fc;
+  --surface-veil: #edf2fb;
+  --surface-veil-strong: #e5ecfb;
+  --surface-veil-heavy: #dbeafe;
+  --surface-veil-bright: #d8e4ff;
+  --surface-veil-highlight: rgba(15, 23, 42, 0.12);
+  --surface-veil-contrast: rgba(15, 23, 42, 0.18);
+  --surface-veil-stronger: rgba(15, 23, 42, 0.2);
+
+  --chip-surface: #e8f0ff;
+  --chip-border: #cbd5e1;
+  --pill-surface: #e2e8f0;
+  --pill-border: #cbd5e1;
+  --pill-shadow: 0 6px 20px rgba(15, 23, 42, 0.1);
+
+  --shadow-card: 0 10px 40px rgba(15, 23, 42, 0.14);
+  --shadow-elevated: 0 18px 60px rgba(15, 23, 42, 0.18);
+  --shadow-brand: 0 10px 20px rgba(79, 134, 255, 0.35);
+  --shadow-brand-strong: 0 14px 30px rgba(79, 134, 255, 0.32);
+  --shadow-panel: 0 16px 50px rgba(15, 23, 42, 0.18);
+  --shadow-soft-elevated: 0 12px 30px rgba(15, 23, 42, 0.16);
+  --shadow-map: 0 18px 60px rgba(15, 23, 42, 0.22);
+  --shadow-text-contrast: 0 2px 6px rgba(15, 23, 42, 0.25);
+
+  --backdrop-strong: rgba(255, 255, 255, 0.85);
+  --backdrop-heavy: rgba(255, 255, 255, 0.92);
+  --backdrop-muted: rgba(255, 255, 255, 0.7);
+  --overlay-top-strong: linear-gradient(180deg, rgba(255, 255, 255, 0.82), transparent);
+  --overlay-bottom-strong: linear-gradient(0deg, rgba(255, 255, 255, 0.84), transparent);
+  --panel-backdrop: linear-gradient(180deg, rgba(232, 240, 255, 0.85), rgba(240, 245, 255, 0.92));
+
+  --glow-primary: rgba(99, 140, 255, 0.18);
+  --glow-secondary: rgba(78, 206, 255, 0.16);
+  --glow-tertiary: rgba(16, 185, 129, 0.14);
+  --map-glow-primary: rgba(99, 140, 255, 0.18);
+  --map-glow-secondary: rgba(78, 206, 255, 0.16);
+  --map-glow-tertiary: rgba(16, 185, 129, 0.12);
+
+  --border-success: rgba(52, 211, 153, 0.45);
+  --border-warning: rgba(252, 211, 77, 0.45);
+  --border-danger: rgba(248, 113, 113, 0.45);
+  --inset-bright: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  --inset-soft: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  --inset-faint: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+
+  --gradient-body: radial-gradient(circle at 20% 20%, var(--glow-primary), transparent 32%),
+    radial-gradient(circle at 72% 15%, var(--glow-secondary), transparent 32%),
+    radial-gradient(circle at 30% 70%, var(--glow-tertiary), transparent 32%);
+}
+
+
+/* Source: layout.css */
+:root {
+  --bp-sm: 640px;
+  --bp-md: 960px;
+  --bp-lg: 1280px;
+  --layout-max: 1200px;
+  --layout-gap: clamp(1rem, 1vw + 1rem, 1.6rem);
+  --layout-gutter: clamp(1.25rem, 3vw + 0.5rem, 2.75rem);
+  --layout-gutter-tight: clamp(1rem, 2vw + 0.5rem, 2rem);
+  --grid-min: 280px;
+}
+
+.layout-shell,
+.page {
+  width: min(var(--layout-max), 100%);
+  margin: 0 auto;
+  padding: clamp(1.75rem, 3vw + 1.25rem, 3rem) var(--layout-gutter)
+    clamp(2.25rem, 3vw + 1.5rem, 3.5rem);
+  display: grid;
+  gap: var(--layout-gap);
+}
+
+.layout-stack {
+  display: grid;
+  gap: var(--layout-gap);
+}
+
+.layout-grid,
+.grid {
+  display: grid;
+  gap: var(--layout-gap);
+  grid-template-columns: repeat(auto-fit, minmax(var(--grid-min), 1fr));
+  align-items: start;
+}
+
+.layout-grid.wide {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.layout-grid.sidebar {
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.9fr);
+}
+
+.layout-grid.tight {
+  gap: clamp(0.75rem, 1vw + 0.6rem, 1.25rem);
+}
+
+.layout-span-2,
+.span-2 {
+  grid-column: span 2;
+}
+
+@media (max-width: 960px) {
+  .layout-grid.sidebar {
+    grid-template-columns: 1fr;
+  }
+
+  .layout-span-2,
+  .span-2 {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .layout-shell,
+  .page {
+    padding-inline: var(--layout-gutter-tight);
+  }
+
+  :root {
+    --grid-min: 240px;
+  }
+}
+
+
+/* Source: style.css */
+
+
+:root {
+  color: var(--text-primary);
+  background-color: var(--bg-body);
+  font-family: var(--font-family-base);
+  line-height: var(--line-height-base);
+  font-weight: 400;
+  min-height: 100%;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background:
+    var(--gradient-body),
+    var(--bg-body);
+  color: var(--text-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+html,
+body,
+#app {
+  height: 100%;
+}
+
+::selection {
+  background: var(--selection-bg);
+  color: var(--color-neutral-50);
+}
+
+h1,
+h2,
+h3 {
+  margin: 0 0 0.35em;
+  line-height: var(--line-height-tight);
+  letter-spacing: -0.02em;
+}
+
+p {
+  margin: 0 0 1em;
+  color: var(--text-secondary);
+}
+
+code {
+  background: var(--surface-veil);
+  border-radius: 6px;
+  padding: 0.1em 0.4em;
+  font-family: var(--font-family-mono);
+}
+
+.map-app {
+  position: relative;
+  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.page-game {
+  max-width: 1280px;
+}
+
+.app-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--surface-veil);
+  border: 1px solid var(--border-strong);
+  border-radius: 16px;
+  padding: 0.75rem 1rem;
+  box-shadow: var(--shadow-card);
+  backdrop-filter: blur(14px);
+}
+
+.app-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.brand-mark {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: var(--gradient-brand);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: var(--color-neutral-50);
+  letter-spacing: 0.04em;
+  box-shadow: var(--shadow-brand);
+}
+
+.top-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.top-stats {
+  display: inline-flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.stat-pill {
+  --pill-py: 0.35rem;
+  --pill-px: 0.55rem;
+  --pill-fz: 0.95rem;
+  --pill-radius: 10px;
+  --pill-bg: rgba(255, 255, 255, 0.08);
+  --pill-border: rgba(255, 255, 255, 0.14);
+  --pill-text: #e9edf5;
+  --pill-muted: #cad3e0;
+  --pill-positive: #34d399;
+  --pill-warning: #f59e0b;
+  --pill-danger: #f87171;
+
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.35rem 0.55rem;
+  border-radius: 10px;
+  background: var(--surface-veil-strong);
+  border: 1px solid var(--border-regular);
+  font-size: 0.95rem;
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.nav-tabs {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.chip {
+  --chip-py: 0.5rem;
+  --chip-px: 0.8rem;
+  --chip-fz: 0.95rem;
+  --chip-radius: 999px;
+  --chip-bg: rgba(255, 255, 255, 0.08);
+  --chip-border: rgba(255, 255, 255, 0.14);
+  --chip-hover-border: rgba(255, 255, 255, 0.25);
+  --chip-active-bg: rgba(99, 140, 255, 0.18);
+  --chip-active-border: rgba(99, 140, 255, 0.65);
+
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem 0.8rem;
+  border-radius: 999px;
+  background: var(--chip-surface);
+  border: 1px solid var(--chip-border);
+  color: var(--text-primary);
+  text-decoration: none;
+  font-size: var(--chip-fz);
+}
+
+.chip:hover,
+.chip:focus-visible {
+  border-color: var(--chip-hover-border);
+}
+
+.chip-ghost {
+  --chip-bg: transparent;
+  --chip-border: rgba(255, 255, 255, 0.2);
+}
+
+.chip:hover {
+  border-color: var(--surface-veil-highlight);
+}
+
+.profile-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 14px;
+  background: var(--chip-surface);
+  border: 1px solid var(--chip-border);
+}
+
+.profile-chip img {
+  display: block;
+}
+
+.profile-chip-text {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.profile-chip .avatar-display {
+  margin-right: 0.1rem;
+}
+
+.chip-title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.hero {
+  background: var(--bg-hero);
+  border: 1px solid var(--border-strong);
+  border-radius: 22px;
+  padding: clamp(1.35rem, 1vw + 1.45rem, 2.1rem);
+  display: grid;
+  gap: clamp(0.9rem, 0.8vw + 0.6rem, 1.35rem);
+  backdrop-filter: blur(18px) saturate(1.35);
+  box-shadow:
+    var(--shadow-elevated),
+    var(--inset-bright);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  color: var(--text-eyebrow);
+  margin: 0 0 0.4rem;
+}
+
+.lede {
+  max-width: 720px;
+  font-size: 1.05rem;
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 0.35rem 0 0;
+}
+
+.button {
+  border: 1px solid var(--border-strong);
+  border-radius: 14px;
+  padding: 0.8rem 1.25rem;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease, background 120ms ease;
+  background: var(--surface-veil);
+  color: var(--text-primary);
+  backdrop-filter: blur(12px) saturate(1.4);
+}
+
+.button:hover {
+  border-color: rgba(255, 255, 255, 0.28);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.08) inset;
+}
+
+.button:active {
+  transform: translateY(1px);
+}
+
+.button.primary {
+  background: var(--gradient-brand);
+  color: var(--color-neutral-50);
+  box-shadow:
+    var(--shadow-brand-strong),
+    0 0 0 1px var(--border-subtle) inset;
+  border-color: transparent;
+}
+
+.button.primary:hover {
+  filter: brightness(1.05);
+}
+
+.button.ghost {
+  background: var(--surface-veil-strong);
+  color: var(--color-info-50);
+  border-color: var(--border-regular);
+}
+
+.button:focus-visible,
+.chip:focus-visible,
+.drawer-tabs .chip:focus-visible,
+.nav-tabs a:focus-visible {
+  outline: 2px solid rgba(99, 140, 255, 0.85);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(99, 140, 255, 0.25);
+}
+
+.button:focus-visible {
+  border-color: rgba(99, 140, 255, 0.65);
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: var(--surface-veil);
+  padding: 0.45rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  font-size: 0.9rem;
+}
+
+.app-stage {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(0, 0.9fr);
+  gap: var(--layout-gap);
+}
+
+.app-stage .side-stack {
+  display: grid;
+  gap: var(--layout-gap);
+}
+
+.app-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  gap: var(--layout-gap);
+}
+
+.column {
+  display: grid;
+  gap: var(--layout-gap);
+}
+
+@media (max-width: 960px) {
+  .app-stage,
+  .app-layout {
+  grid-template-columns: 1fr;
+  }
+}
+
+.panel {
+  border-radius: 18px;
+  border: 1px solid var(--border-regular);
+  background: var(--bg-panel);
+  padding: 1.1rem 1.25rem 1.2rem;
+  box-shadow:
+    var(--shadow-panel),
+    var(--inset-soft);
+  backdrop-filter: blur(14px) saturate(1.3);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.panel-title {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.stat-board {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.6rem;
+  margin: 0.8rem 0;
+}
+
+.stat-chip {
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-soft);
+  background: var(--surface-veil-soft);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.map-panel {
+  position: relative;
+  border-radius: 22px;
+  overflow: hidden;
+  box-shadow:
+    var(--shadow-map),
+    var(--inset-bright);
+  border: 1px solid var(--border-regular);
+  background: var(--panel-backdrop);
+}
+
+.map-surface {
+  position: relative;
+  min-height: 420px;
+  background:
+    radial-gradient(circle at 30% 30%, var(--map-glow-primary), transparent 45%),
+    radial-gradient(circle at 75% 40%, var(--map-glow-secondary), transparent 45%),
+    radial-gradient(circle at 40% 70%, var(--map-glow-tertiary), transparent 45%),
+    var(--bg-map);
+}
+
+.map-placeholder {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  gap: 0.6rem;
+  text-align: center;
+  pointer-events: none;
+}
+
+.map-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+  background: var(--color-ink);
+}
+
+.leaflet-container {
+  width: 100%;
+  height: 100%;
+}
+
+.map-surface.ready .map-placeholder {
+  display: none;
+}
+
+.map-topbar {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  right: 1rem;
+  max-width: calc(100% - 2rem);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.8rem;
+  border-radius: 18px;
+  background: var(--backdrop-strong);
+  border: 1px solid var(--border-regular);
+  box-shadow: var(--shadow-elevated);
+  backdrop-filter: blur(12px) saturate(1.2);
+  z-index: 10;
+}
+
+.map-actions {
+  position: absolute;
+  top: 5rem;
+  left: 1rem;
+  right: auto;
+  max-width: 420px;
+  width: calc(100% - 2rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 0.45rem;
+  align-items: flex-start;
+  padding: 0.55rem 0.7rem;
+  border-radius: 14px;
+  background: var(--backdrop-muted);
+  border: 1px solid var(--border-soft);
+  box-shadow: var(--shadow-soft-elevated);
+  backdrop-filter: blur(12px) saturate(1.1);
+  z-index: 9;
+}
+
+.map-actions .pill-row {
+  margin: 0;
+}
+
+.map-drawer {
+  position: absolute;
+  left: auto;
+  right: 1rem;
+  bottom: 1rem;
+  max-width: 420px;
+  width: calc(100% - 2rem);
+  max-height: 70vh;
+  overflow-y: auto;
+  border-radius: 18px;
+  background: var(--backdrop-heavy);
+  border: 1px solid var(--border-soft);
+  box-shadow: var(--shadow-elevated);
+  backdrop-filter: blur(14px) saturate(1.2);
+  padding: 0.8rem 0.9rem;
+  z-index: 8;
+}
+
+.drawer-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.drawer-tabs {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.drawer-tabs .chip.active {
+  background: var(--surface-veil-bright);
+  border-color: var(--surface-veil-contrast);
+}
+
+.drawer-body {
+  margin-top: 0.5rem;
+}
+
+.drawer-section {
+  display: none;
+}
+
+.drawer-section.active {
+  display: block;
+}
+
+.map-overlay {
+  position: absolute;
+  left: 0;
+  right: 0;
+  padding: 0.75rem 0.85rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.map-overlay.top {
+  top: 0;
+  background: var(--overlay-top-strong);
+}
+
+.map-overlay.bottom {
+  bottom: 0;
+  background: var(--overlay-bottom-strong);
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.map-controls {
+  display: flex;
+  gap: 0.4rem;
+}
+
+@media (max-width: 768px) {
+  .map-topbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .map-actions {
+    max-width: unset;
+    right: 1rem;
+  }
+
+  .map-drawer {
+    left: 1rem;
+    right: 1rem;
+    max-width: unset;
+    max-height: 50vh;
+  }
+}
+
+.button.small {
+  padding: 0.55rem 0.8rem;
+  font-size: 0.95rem;
+}
+
+.result-box.slim {
+  margin: 0;
+}
+.card {
+  border-radius: 18px;
+  border: 1px solid var(--border-regular);
+  background: var(--bg-panel);
+  padding: 1.3rem;
+  min-height: 240px;
+  box-shadow:
+    var(--shadow-elevated),
+    inset 0 1px 0 var(--surface-veil-bright);
+  backdrop-filter: blur(16px) saturate(1.35);
+}
+
+.card h2 {
+  font-size: 1.25rem;
+}
+
+.span-2 {
+  grid-column: span 2;
+}
+
+.list {
+  padding-left: 1.1rem;
+  margin: 0;
+  color: var(--color-neutral-300);
+}
+
+.list li + li {
+  margin-top: 0.35rem;
+}
+
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.75rem;
+}
+
+.pill {
+  background: var(--pill-surface);
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.9rem;
+  color: var(--color-brand-200);
+  border: 1px solid var(--pill-border);
+  backdrop-filter: blur(12px);
+}
+
+.pill.ghost {
+  border: 1px solid var(--surface-veil-bright);
+  color: var(--color-neutral-375);
+}
+
+.tiny {
+  font-size: 0.9rem;
+}
+
+.map-overlay .pill-row {
+  margin: 0;
+}
+.result-box {
+  margin-top: 0.75rem;
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-soft);
+  background: var(--surface-veil);
+  font-family: "JetBrains Mono", "Fira Code", Consolas, monospace;
+  color: var(--color-neutral-200);
+  backdrop-filter: blur(12px);
+}
+
+.result-box[data-state="ok"] {
+  border-color: var(--border-success);
+  color: var(--color-success-100);
+}
+
+.result-box[data-state="warn"] {
+  border-color: var(--border-warning);
+  color: var(--color-warning-300);
+}
+
+.result-box[data-state="error"] {
+  border-color: var(--border-danger);
+  color: var(--color-danger-300);
+}
+
+.status {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.status dl {
+  margin: 0;
+}
+
+.status-line {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.35rem 0;
+  border-bottom: 1px solid var(--surface-veil-strong);
+}
+
+.status-line dt {
+  color: var(--color-neutral-350);
+}
+
+.status-line dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+[data-state="info"] {
+  color: var(--color-neutral-200);
+}
+
+[data-state="online"] {
+  color: var(--color-success-400);
+}
+
+[data-state="offline"] {
+  color: var(--color-danger-200);
+}
+
+[data-state="ready"],
+[data-state="ready"] {
+  color: var(--color-indigo-200);
+}
+
+[data-state="update"] {
+  color: var(--color-warning-300);
+}
+
+[data-state="error"] {
+  color: var(--color-danger-400);
+}
+
+.muted {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.field input,
+.field select {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-veil-soft);
+  color: var(--color-neutral-200);
+}
+
+.field input:focus,
+.field select:focus {
+  outline: 2px solid var(--focus-ring);
+  border-color: var(--focus-ring);
+}
+
+.stat-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.75rem;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.stat-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--surface-faint);
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+}
+
+.stat-list strong {
+  color: var(--color-info-100);
+}
+
+.log-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.log-list li {
+  padding-bottom: 0.25rem;
+  border-bottom: 1px dashed var(--surface-veil-strong);
+}
+
+.avatar-display {
+  width: 82px;
+  height: 82px;
+  border-radius: 20px;
+  background: conic-gradient(from 120deg, var(--border-subtle), var(--surface-veil-soft));
+  border: 1px solid var(--surface-veil-bright);
+  display: grid;
+  place-items: center;
+  position: relative;
+  overflow: hidden;
+  box-shadow:
+    var(--shadow-soft-elevated),
+    var(--inset-bright);
+}
+
+.avatar-display img {
+  position: absolute;
+  inset: 6px;
+  width: calc(100% - 12px);
+  height: calc(100% - 12px);
+  border-radius: 16px;
+  object-fit: cover;
+  filter: saturate(1.05);
+}
+
+.avatar-display::before {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border-radius: 16px;
+  background: radial-gradient(circle at 30% 30%, var(--surface-veil-stronger), transparent 50%),
+    linear-gradient(145deg, var(--avatar-color, var(--color-sky-300)), var(--surface-veil));
+  filter: saturate(1.2);
+}
+
+.avatar-display.large {
+  width: 96px;
+  height: 96px;
+}
+
+.avatar-display.mini {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+}
+
+.avatar-display.has-image::before {
+  background: var(--surface-faint);
+}
+
+.avatar-display.has-image .avatar-icon {
+  display: none;
+}
+
+.rpm-frame {
+  position: relative;
+  border-radius: 18px;
+  border: 1px solid var(--border-soft);
+  background: var(--surface-veil-soft);
+  overflow: hidden;
+  box-shadow:
+    var(--shadow-elevated),
+    var(--inset-soft);
+}
+
+.rpm-frame iframe {
+  width: 100%;
+  min-height: 620px;
+  border: none;
+  display: block;
+}
+
+.avatar-icon {
+  position: relative;
+  z-index: 1;
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--color-ink);
+  text-shadow: var(--shadow-text-contrast);
+}
+
+.avatar-config {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.form-grid.compact {
+  gap: 0.5rem;
+}
+
+.page-game .hero {
+  background: var(--bg-hero);
+  border: 1px solid var(--border-strong);
+}
+
+@media (max-width: 640px) {
+  .card {
+    min-height: auto;
+  }
+
+  .avatar-config {
+    grid-template-columns: 1fr;
+    justify-items: start;
+  }
+}
+
+
+/* Source: index.css */
+/*! tailwindcss v4.1.3 | MIT License | https://tailwindcss.com */
+@layer properties {
+  @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
+    *, :before, :after, ::backdrop {
+      --tw-space-y-reverse: 0;
+      --tw-border-style: solid;
+      --tw-gradient-position: initial;
+      --tw-gradient-from: #0000;
+      --tw-gradient-via: #0000;
+      --tw-gradient-to: #0000;
+      --tw-gradient-stops: initial;
+      --tw-gradient-via-stops: initial;
+      --tw-gradient-from-position: 0%;
+      --tw-gradient-via-position: 50%;
+      --tw-gradient-to-position: 100%;
+      --tw-shadow: 0 0 #0000;
+      --tw-shadow-color: initial;
+      --tw-shadow-alpha: 100%;
+      --tw-inset-shadow: 0 0 #0000;
+      --tw-inset-shadow-color: initial;
+      --tw-inset-shadow-alpha: 100%;
+      --tw-ring-color: initial;
+      --tw-ring-shadow: 0 0 #0000;
+      --tw-inset-ring-color: initial;
+      --tw-inset-ring-shadow: 0 0 #0000;
+      --tw-ring-inset: initial;
+      --tw-ring-offset-width: 0px;
+      --tw-ring-offset-color: #fff;
+      --tw-ring-offset-shadow: 0 0 #0000;
+      --tw-outline-style: solid;
+      --tw-duration: initial;
+      --tw-scale-x: 1;
+      --tw-scale-y: 1;
+      --tw-scale-z: 1;
+    }
+  }
+}
+
+@layer theme {
+  :root, :host {
+    --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    --color-white: #fff;
+    --spacing: .25rem;
+    --container-xs: 20rem;
+    --container-md: 28rem;
+    --text-xs: .75rem;
+    --text-xs--line-height: calc(1 / .75);
+    --text-sm: .875rem;
+    --text-sm--line-height: calc(1.25 / .875);
+    --text-base: 1rem;
+    --text-base--line-height: calc(1.5 / 1);
+    --text-lg: 1.125rem;
+    --text-lg--line-height: calc(1.75 / 1.125);
+    --text-2xl: 1.5rem;
+    --text-2xl--line-height: calc(2 / 1.5);
+    --text-3xl: 1.875rem;
+    --text-3xl--line-height: calc(2.25 / 1.875);
+    --radius-2xl: 1rem;
+    --radius-3xl: 1.5rem;
+    --animate-pulse: pulse 2s cubic-bezier(.4, 0, .6, 1) infinite;
+    --default-transition-duration: .15s;
+    --default-transition-timing-function: cubic-bezier(.4, 0, .2, 1);
+    --default-font-family: var(--font-sans);
+    --default-font-feature-settings: var(--font-sans--font-feature-settings);
+    --default-font-variation-settings: var(--font-sans--font-variation-settings);
+    --default-mono-font-family: var(--font-mono);
+    --default-mono-font-feature-settings: var(--font-mono--font-feature-settings);
+    --default-mono-font-variation-settings: var(--font-mono--font-variation-settings);
+  }
+}
+
+@layer base {
+  *, :after, :before, ::backdrop {
+    box-sizing: border-box;
+    border: 0 solid;
+    margin: 0;
+    padding: 0;
+  }
+
+  ::file-selector-button {
+    box-sizing: border-box;
+    border: 0 solid;
+    margin: 0;
+    padding: 0;
+  }
+
+  html, :host {
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    line-height: 1.5;
+    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
+    font-feature-settings: var(--default-font-feature-settings, normal);
+    font-variation-settings: var(--default-font-variation-settings, normal);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  body {
+    line-height: inherit;
+  }
+
+  hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+
+  abbr:where([title]) {
+    -webkit-text-decoration: underline dotted;
+    text-decoration: underline dotted;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  a {
+    color: inherit;
+    -webkit-text-decoration: inherit;
+    -webkit-text-decoration: inherit;
+    text-decoration: inherit;
+  }
+
+  b, strong {
+    font-weight: bolder;
+  }
+
+  code, kbd, samp, pre {
+    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+    font-feature-settings: var(--default-mono-font-feature-settings, normal);
+    font-variation-settings: var(--default-mono-font-variation-settings, normal);
+    font-size: 1em;
+  }
+
+  small {
+    font-size: 80%;
+  }
+
+  sub, sup {
+    vertical-align: baseline;
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+  }
+
+  sub {
+    bottom: -.25em;
+  }
+
+  sup {
+    top: -.5em;
+  }
+
+  table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+
+  :-moz-focusring {
+    outline: auto;
+  }
+
+  progress {
+    vertical-align: baseline;
+  }
+
+  summary {
+    display: list-item;
+  }
+
+  ol, ul, menu {
+    list-style: none;
+  }
+
+  img, svg, video, canvas, audio, iframe, embed, object {
+    vertical-align: middle;
+    display: block;
+  }
+
+  img, video {
+    max-width: 100%;
+    height: auto;
+  }
+
+  button, input, select, optgroup, textarea {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    opacity: 1;
+    background-color: #0000;
+    border-radius: 0;
+  }
+
+  ::file-selector-button {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    opacity: 1;
+    background-color: #0000;
+    border-radius: 0;
+  }
+
+  :where(select:is([multiple], [size])) optgroup {
+    font-weight: bolder;
+  }
+
+  :where(select:is([multiple], [size])) optgroup option {
+    padding-inline-start: 20px;
+  }
+
+  ::file-selector-button {
+    margin-inline-end: 4px;
+  }
+
+  ::placeholder {
+    opacity: 1;
+    color: currentColor;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    ::placeholder {
+      color: color-mix(in oklab, currentColor 50%, transparent);
+    }
+  }
+
+  textarea {
+    resize: vertical;
+  }
+
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+
+  ::-webkit-date-and-time-value {
+    min-height: 1lh;
+    text-align: inherit;
+  }
+
+  ::-webkit-datetime-edit {
+    display: inline-flex;
+  }
+
+  ::-webkit-datetime-edit-fields-wrapper {
+    padding: 0;
+  }
+
+  ::-webkit-datetime-edit {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-year-field {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-month-field {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-day-field {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-hour-field {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-minute-field {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-second-field {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-millisecond-field {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-meridiem-field {
+    padding-block: 0;
+  }
+
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+
+  button, input:where([type="button"], [type="reset"], [type="submit"]) {
+    appearance: button;
+  }
+
+  ::file-selector-button {
+    appearance: button;
+  }
+
+  ::-webkit-inner-spin-button {
+    height: auto;
+  }
+
+  ::-webkit-outer-spin-button {
+    height: auto;
+  }
+
+  [hidden]:where(:not([hidden="until-found"])) {
+    display: none !important;
+  }
+
+  * {
+    border-color: oklch(.922 0 0);
+    outline-color: color-mix(in oklab, oklch(.708 0 0) 50%, transparent);
+  }
+
+  body {
+    background-color: oklch(1 0 0);
+    color: oklch(.145 0 0);
+  }
+}
+
+@layer utilities {
+  .absolute {
+    position: absolute;
+  }
+
+  .fixed {
+    position: fixed;
+  }
+
+  .relative {
+    position: relative;
+  }
+
+  .sticky {
+    position: sticky;
+  }
+
+  .inset-0 {
+    inset: calc(var(--spacing) * 0);
+  }
+
+  .top-0 {
+    top: calc(var(--spacing) * 0);
+  }
+
+  .right-0 {
+    right: calc(var(--spacing) * 0);
+  }
+
+  .bottom-0 {
+    bottom: calc(var(--spacing) * 0);
+  }
+
+  .left-0 {
+    left: calc(var(--spacing) * 0);
+  }
+
+  .z-10 {
+    z-index: 10;
+  }
+
+  .z-50 {
+    z-index: 50;
+  }
+
+  .mx-auto {
+    margin-inline: auto;
+  }
+
+  .-mt-2 {
+    margin-top: calc(var(--spacing) * -2);
+  }
+
+  .mt-0\.5 {
+    margin-top: calc(var(--spacing) * .5);
+  }
+
+  .mt-1 {
+    margin-top: calc(var(--spacing) * 1);
+  }
+
+  .mt-6 {
+    margin-top: calc(var(--spacing) * 6);
+  }
+
+  .mt-8 {
+    margin-top: calc(var(--spacing) * 8);
+  }
+
+  .mb-1 {
+    margin-bottom: calc(var(--spacing) * 1);
+  }
+
+  .mb-2 {
+    margin-bottom: calc(var(--spacing) * 2);
+  }
+
+  .mb-3 {
+    margin-bottom: calc(var(--spacing) * 3);
+  }
+
+  .mb-4 {
+    margin-bottom: calc(var(--spacing) * 4);
+  }
+
+  .mb-6 {
+    margin-bottom: calc(var(--spacing) * 6);
+  }
+
+  .mb-8 {
+    margin-bottom: calc(var(--spacing) * 8);
+  }
+
+  .block {
+    display: block;
+  }
+
+  .flex {
+    display: flex;
+  }
+
+  .grid {
+    display: grid;
+  }
+
+  .inline-flex {
+    display: inline-flex;
+  }
+
+  .h-1 {
+    height: calc(var(--spacing) * 1);
+  }
+
+  .h-1\.5 {
+    height: calc(var(--spacing) * 1.5);
+  }
+
+  .h-2 {
+    height: calc(var(--spacing) * 2);
+  }
+
+  .h-2\.5 {
+    height: calc(var(--spacing) * 2.5);
+  }
+
+  .h-3 {
+    height: calc(var(--spacing) * 3);
+  }
+
+  .h-5 {
+    height: calc(var(--spacing) * 5);
+  }
+
+  .h-6 {
+    height: calc(var(--spacing) * 6);
+  }
+
+  .h-8 {
+    height: calc(var(--spacing) * 8);
+  }
+
+  .h-10 {
+    height: calc(var(--spacing) * 10);
+  }
+
+  .h-12 {
+    height: calc(var(--spacing) * 12);
+  }
+
+  .h-14 {
+    height: calc(var(--spacing) * 14);
+  }
+
+  .h-16 {
+    height: calc(var(--spacing) * 16);
+  }
+
+  .h-20 {
+    height: calc(var(--spacing) * 20);
+  }
+
+  .h-24 {
+    height: calc(var(--spacing) * 24);
+  }
+
+  .h-32 {
+    height: calc(var(--spacing) * 32);
+  }
+
+  .h-64 {
+    height: calc(var(--spacing) * 64);
+  }
+
+  .h-full {
+    height: 100%;
+  }
+
+  .min-h-screen {
+    min-height: 100vh;
+  }
+
+  .w-5 {
+    width: calc(var(--spacing) * 5);
+  }
+
+  .w-6 {
+    width: calc(var(--spacing) * 6);
+  }
+
+  .w-8 {
+    width: calc(var(--spacing) * 8);
+  }
+
+  .w-10 {
+    width: calc(var(--spacing) * 10);
+  }
+
+  .w-12 {
+    width: calc(var(--spacing) * 12);
+  }
+
+  .w-14 {
+    width: calc(var(--spacing) * 14);
+  }
+
+  .w-16 {
+    width: calc(var(--spacing) * 16);
+  }
+
+  .w-20 {
+    width: calc(var(--spacing) * 20);
+  }
+
+  .w-24 {
+    width: calc(var(--spacing) * 24);
+  }
+
+  .w-32 {
+    width: calc(var(--spacing) * 32);
+  }
+
+  .w-64 {
+    width: calc(var(--spacing) * 64);
+  }
+
+  .w-full {
+    width: 100%;
+  }
+
+  .max-w-md {
+    max-width: var(--container-md);
+  }
+
+  .max-w-xs {
+    max-width: var(--container-xs);
+  }
+
+  .min-w-0 {
+    min-width: calc(var(--spacing) * 0);
+  }
+
+  .flex-1 {
+    flex: 1;
+  }
+
+  .flex-shrink-0 {
+    flex-shrink: 0;
+  }
+
+  .-rotate-90 {
+    rotate: -90deg;
+  }
+
+  .rotate-180 {
+    rotate: 180deg;
+  }
+
+  .animate-pulse {
+    animation: var(--animate-pulse);
+  }
+
+  .cursor-pointer {
+    cursor: pointer;
+  }
+
+  .grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .flex-col {
+    flex-direction: column;
+  }
+
+  .flex-wrap {
+    flex-wrap: wrap;
+  }
+
+  .items-baseline {
+    align-items: baseline;
+  }
+
+  .items-center {
+    align-items: center;
+  }
+
+  .items-start {
+    align-items: flex-start;
+  }
+
+  .justify-around {
+    justify-content: space-around;
+  }
+
+  .justify-between {
+    justify-content: space-between;
+  }
+
+  .justify-center {
+    justify-content: center;
+  }
+
+  .gap-1 {
+    gap: calc(var(--spacing) * 1);
+  }
+
+  .gap-2 {
+    gap: calc(var(--spacing) * 2);
+  }
+
+  .gap-3 {
+    gap: calc(var(--spacing) * 3);
+  }
+
+  .gap-4 {
+    gap: calc(var(--spacing) * 4);
+  }
+
+  :where(.space-y-2 > :not(:last-child)) {
+    --tw-space-y-reverse: 0;
+    margin-block-start: calc(calc(var(--spacing) * 2) * var(--tw-space-y-reverse));
+    margin-block-end: calc(calc(var(--spacing) * 2) * calc(1 - var(--tw-space-y-reverse)));
+  }
+
+  :where(.space-y-3 > :not(:last-child)) {
+    --tw-space-y-reverse: 0;
+    margin-block-start: calc(calc(var(--spacing) * 3) * var(--tw-space-y-reverse));
+    margin-block-end: calc(calc(var(--spacing) * 3) * calc(1 - var(--tw-space-y-reverse)));
+  }
+
+  :where(.space-y-4 > :not(:last-child)) {
+    --tw-space-y-reverse: 0;
+    margin-block-start: calc(calc(var(--spacing) * 4) * var(--tw-space-y-reverse));
+    margin-block-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--tw-space-y-reverse)));
+  }
+
+  :where(.space-y-5 > :not(:last-child)) {
+    --tw-space-y-reverse: 0;
+    margin-block-start: calc(calc(var(--spacing) * 5) * var(--tw-space-y-reverse));
+    margin-block-end: calc(calc(var(--spacing) * 5) * calc(1 - var(--tw-space-y-reverse)));
+  }
+
+  :where(.space-y-6 > :not(:last-child)) {
+    --tw-space-y-reverse: 0;
+    margin-block-start: calc(calc(var(--spacing) * 6) * var(--tw-space-y-reverse));
+    margin-block-end: calc(calc(var(--spacing) * 6) * calc(1 - var(--tw-space-y-reverse)));
+  }
+
+  .overflow-hidden {
+    overflow: hidden;
+  }
+
+  .overflow-y-auto {
+    overflow-y: auto;
+  }
+
+  .rounded {
+    border-radius: .25rem;
+  }
+
+  .rounded-2xl {
+    border-radius: var(--radius-2xl);
+  }
+
+  .rounded-3xl {
+    border-radius: var(--radius-3xl);
+  }
+
+  .rounded-full {
+    border-radius: 3.40282e38px;
+  }
+
+  .rounded-lg {
+    border-radius: .625rem;
+  }
+
+  .rounded-xl {
+    border-radius: 1.025rem;
+  }
+
+  .rounded-tl-lg {
+    border-top-left-radius: .625rem;
+  }
+
+  .rounded-tr-lg {
+    border-top-right-radius: .625rem;
+  }
+
+  .rounded-br-lg {
+    border-bottom-right-radius: .625rem;
+  }
+
+  .rounded-bl-lg {
+    border-bottom-left-radius: .625rem;
+  }
+
+  .border {
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+  }
+
+  .border-2 {
+    border-style: var(--tw-border-style);
+    border-width: 2px;
+  }
+
+  .border-t {
+    border-top-style: var(--tw-border-style);
+    border-top-width: 1px;
+  }
+
+  .border-t-4 {
+    border-top-style: var(--tw-border-style);
+    border-top-width: 4px;
+  }
+
+  .border-r-4 {
+    border-right-style: var(--tw-border-style);
+    border-right-width: 4px;
+  }
+
+  .border-b {
+    border-bottom-style: var(--tw-border-style);
+    border-bottom-width: 1px;
+  }
+
+  .border-b-4 {
+    border-bottom-style: var(--tw-border-style);
+    border-bottom-width: 4px;
+  }
+
+  .border-l-4 {
+    border-left-style: var(--tw-border-style);
+    border-left-width: 4px;
+  }
+
+  .border-\[\#2d2728\] {
+    border-color: #2d2728;
+  }
+
+  .border-\[\#7a7577\] {
+    border-color: #7a7577;
+  }
+
+  .border-\[\#52c41a\]\/30 {
+    border-color: oklab(72.5551% -.163398 .144626 / .3);
+  }
+
+  .border-\[\#a82847\] {
+    border-color: #a82847;
+  }
+
+  .border-\[\#f4bf4f\] {
+    border-color: #f4bf4f;
+  }
+
+  .border-\[\#f4bf4f\]\/20 {
+    border-color: oklab(83.2337% .0168459 .13923 / .2);
+  }
+
+  .border-\[\#f4bf4f\]\/30 {
+    border-color: oklab(83.2337% .0168459 .13923 / .3);
+  }
+
+  .border-\[\#ff4d4f\] {
+    border-color: #ff4d4f;
+  }
+
+  .bg-\[\#0f0d0e\] {
+    background-color: #0f0d0e;
+  }
+
+  .bg-\[\#1a1617\] {
+    background-color: #1a1617;
+  }
+
+  .bg-\[\#7a7577\] {
+    background-color: #7a7577;
+  }
+
+  .bg-\[\#52c41a\] {
+    background-color: #52c41a;
+  }
+
+  .bg-\[\#52c41a\]\/10 {
+    background-color: oklab(72.5551% -.163398 .144626 / .1);
+  }
+
+  .bg-\[\#52c41a\]\/20 {
+    background-color: oklab(72.5551% -.163398 .144626 / .2);
+  }
+
+  .bg-\[\#241f20\] {
+    background-color: #241f20;
+  }
+
+  .bg-\[\#f4bf4f\] {
+    background-color: #f4bf4f;
+  }
+
+  .bg-\[\#f4bf4f\]\/10 {
+    background-color: oklab(83.2337% .0168459 .13923 / .1);
+  }
+
+  .bg-transparent {
+    background-color: #0000;
+  }
+
+  .bg-gradient-to-b {
+    --tw-gradient-position: to bottom in oklab;
+    background-image: linear-gradient(var(--tw-gradient-stops));
+  }
+
+  .bg-gradient-to-br {
+    --tw-gradient-position: to bottom right in oklab;
+    background-image: linear-gradient(var(--tw-gradient-stops));
+  }
+
+  .bg-gradient-to-r {
+    --tw-gradient-position: to right in oklab;
+    background-image: linear-gradient(var(--tw-gradient-stops));
+  }
+
+  .bg-gradient-to-t {
+    --tw-gradient-position: to top in oklab;
+    background-image: linear-gradient(var(--tw-gradient-stops));
+  }
+
+  .from-\[\#0f0d0e\] {
+    --tw-gradient-from: #0f0d0e;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .from-\[\#1a1617\] {
+    --tw-gradient-from: #1a1617;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .from-\[\#2d0a0f\] {
+    --tw-gradient-from: #2d0a0f;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .from-\[\#8c1c38\] {
+    --tw-gradient-from: #8c1c38;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .from-\[\#52c41a\] {
+    --tw-gradient-from: #52c41a;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .from-\[\#241f20\] {
+    --tw-gradient-from: #241f20;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .from-\[\#a82847\] {
+    --tw-gradient-from: #a82847;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .from-\[\#e6a23c\] {
+    --tw-gradient-from: #e6a23c;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .from-\[\#f4bf4f\] {
+    --tw-gradient-from: #f4bf4f;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .via-\[\#1a1617\] {
+    --tw-gradient-via: #1a1617;
+    --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
+    --tw-gradient-stops: var(--tw-gradient-via-stops);
+  }
+
+  .to-\[\#0f0d0e\] {
+    --tw-gradient-to: #0f0d0e;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .to-\[\#1a1617\] {
+    --tw-gradient-to: #1a1617;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .to-\[\#2d0a0f\] {
+    --tw-gradient-to: #2d0a0f;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .to-\[\#6b1529\] {
+    --tw-gradient-to: #6b1529;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .to-\[\#241f20\] {
+    --tw-gradient-to: #241f20;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .to-\[\#389e0d\] {
+    --tw-gradient-to: #389e0d;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .to-\[\#a82847\] {
+    --tw-gradient-to: #a82847;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .to-\[\#e6a23c\] {
+    --tw-gradient-to: #e6a23c;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .to-\[\#f4bf4f\] {
+    --tw-gradient-to: #f4bf4f;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .to-transparent {
+    --tw-gradient-to: transparent;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .bg-clip-text {
+    background-clip: text;
+  }
+
+  .p-2 {
+    padding: calc(var(--spacing) * 2);
+  }
+
+  .p-3 {
+    padding: calc(var(--spacing) * 3);
+  }
+
+  .p-4 {
+    padding: calc(var(--spacing) * 4);
+  }
+
+  .p-5 {
+    padding: calc(var(--spacing) * 5);
+  }
+
+  .p-6 {
+    padding: calc(var(--spacing) * 6);
+  }
+
+  .px-2 {
+    padding-inline: calc(var(--spacing) * 2);
+  }
+
+  .px-3 {
+    padding-inline: calc(var(--spacing) * 3);
+  }
+
+  .px-4 {
+    padding-inline: calc(var(--spacing) * 4);
+  }
+
+  .px-6 {
+    padding-inline: calc(var(--spacing) * 6);
+  }
+
+  .px-8 {
+    padding-inline: calc(var(--spacing) * 8);
+  }
+
+  .py-0\.5 {
+    padding-block: calc(var(--spacing) * .5);
+  }
+
+  .py-1 {
+    padding-block: calc(var(--spacing) * 1);
+  }
+
+  .py-2 {
+    padding-block: calc(var(--spacing) * 2);
+  }
+
+  .py-3 {
+    padding-block: calc(var(--spacing) * 3);
+  }
+
+  .py-4 {
+    padding-block: calc(var(--spacing) * 4);
+  }
+
+  .py-6 {
+    padding-block: calc(var(--spacing) * 6);
+  }
+
+  .py-12 {
+    padding-block: calc(var(--spacing) * 12);
+  }
+
+  .pb-8 {
+    padding-bottom: calc(var(--spacing) * 8);
+  }
+
+  .pb-20 {
+    padding-bottom: calc(var(--spacing) * 20);
+  }
+
+  .pb-24 {
+    padding-bottom: calc(var(--spacing) * 24);
+  }
+
+  .text-center {
+    text-align: center;
+  }
+
+  .text-left {
+    text-align: left;
+  }
+
+  .text-right {
+    text-align: right;
+  }
+
+  .text-2xl {
+    font-size: var(--text-2xl);
+    line-height: var(--tw-leading, var(--text-2xl--line-height));
+  }
+
+  .text-3xl {
+    font-size: var(--text-3xl);
+    line-height: var(--tw-leading, var(--text-3xl--line-height));
+  }
+
+  .text-base {
+    font-size: var(--text-base);
+    line-height: var(--tw-leading, var(--text-base--line-height));
+  }
+
+  .text-lg {
+    font-size: var(--text-lg);
+    line-height: var(--tw-leading, var(--text-lg--line-height));
+  }
+
+  .text-sm {
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+  }
+
+  .text-xs {
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+  }
+
+  .text-\[\#0f0d0e\] {
+    color: #0f0d0e;
+  }
+
+  .text-\[\#2d0a0f\] {
+    color: #2d0a0f;
+  }
+
+  .text-\[\#7a7577\] {
+    color: #7a7577;
+  }
+
+  .text-\[\#52c41a\] {
+    color: #52c41a;
+  }
+
+  .text-\[\#b8b2b3\] {
+    color: #b8b2b3;
+  }
+
+  .text-\[\#f4bf4f\] {
+    color: #f4bf4f;
+  }
+
+  .text-\[\#faad14\] {
+    color: #faad14;
+  }
+
+  .text-\[\#ff4d4f\] {
+    color: #ff4d4f;
+  }
+
+  .text-transparent {
+    color: #0000;
+  }
+
+  .text-white {
+    color: var(--color-white);
+  }
+
+  .capitalize {
+    text-transform: capitalize;
+  }
+
+  .uppercase {
+    text-transform: uppercase;
+  }
+
+  .opacity-30 {
+    opacity: .3;
+  }
+
+  .opacity-60 {
+    opacity: .6;
+  }
+
+  .shadow-lg {
+    --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, #0000001a), 0 4px 6px -4px var(--tw-shadow-color, #0000001a);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+
+  .shadow-md {
+    --tw-shadow: 0 4px 6px -1px var(--tw-shadow-color, #0000001a), 0 2px 4px -2px var(--tw-shadow-color, #0000001a);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+
+  .outline {
+    outline-style: var(--tw-outline-style);
+    outline-width: 1px;
+  }
+
+  .transition-all {
+    transition-property: all;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+
+  .transition-colors {
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+
+  .duration-200 {
+    --tw-duration: .2s;
+    transition-duration: .2s;
+  }
+
+  .duration-300 {
+    --tw-duration: .3s;
+    transition-duration: .3s;
+  }
+
+  .duration-500 {
+    --tw-duration: .5s;
+    transition-duration: .5s;
+  }
+
+  .placeholder\:text-\[\#7a7577\]::placeholder {
+    color: #7a7577;
+  }
+
+  .checked\:bg-\[\#a82847\]:checked {
+    background-color: #a82847;
+  }
+
+  @media (hover: hover) {
+    .hover\:border-\[\#7a7577\]:hover {
+      border-color: #7a7577;
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:bg-\[\#2d2728\]:hover {
+      background-color: #2d2728;
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:bg-\[\#241f20\]:hover {
+      background-color: #241f20;
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:bg-\[\#a82847\]\/10:hover {
+      background-color: oklab(48.9627% .160151 .0340395 / .1);
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:bg-\[\#ff4d4f\]\/10:hover {
+      background-color: oklab(67.3245% .195098 .088769 / .1);
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:bg-white\/10:hover {
+      background-color: #ffffff1a;
+    }
+
+    @supports (color: color-mix(in lab, red, red)) {
+      .hover\:bg-white\/10:hover {
+        background-color: color-mix(in oklab, var(--color-white) 10%, transparent);
+      }
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:from-\[\#6b1529\]:hover {
+      --tw-gradient-from: #6b1529;
+      --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:to-\[\#8c1c38\]:hover {
+      --tw-gradient-to: #8c1c38;
+      --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:text-\[\#b8b2b3\]:hover {
+      color: #b8b2b3;
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:text-\[\#e6a23c\]:hover {
+      color: #e6a23c;
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:shadow-lg:hover {
+      --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, #0000001a), 0 4px 6px -4px var(--tw-shadow-color, #0000001a);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+
+  .focus\:border-\[\#f4bf4f\]:focus {
+    border-color: #f4bf4f;
+  }
+
+  .focus\:ring-2:focus {
+    --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+
+  .focus\:ring-\[\#f4bf4f\]:focus {
+    --tw-ring-color: #f4bf4f;
+  }
+
+  .focus\:outline-none:focus {
+    --tw-outline-style: none;
+    outline-style: none;
+  }
+
+  .active\:scale-95:active {
+    --tw-scale-x: 95%;
+    --tw-scale-y: 95%;
+    --tw-scale-z: 95%;
+    scale: var(--tw-scale-x) var(--tw-scale-y);
+  }
+
+  .active\:scale-\[0\.98\]:active {
+    scale: .98;
+  }
+
+  .disabled\:cursor-not-allowed:disabled {
+    cursor: not-allowed;
+  }
+
+  .disabled\:opacity-50:disabled {
+    opacity: .5;
+  }
+}
+
+:root {
+  --color-burgundy-950: #2d0a0f;
+  --color-burgundy-900: #4a0e1a;
+  --color-burgundy-800: #6b1529;
+  --color-burgundy-700: #8c1c38;
+  --color-burgundy-600: #a82847;
+  --color-burgundy-500: #c23456;
+  --color-gold-400: #f4bf4f;
+  --color-gold-500: #e6a23c;
+  --color-gold-600: #d48806;
+  --color-bg-primary: #0f0d0e;
+  --color-bg-surface: #1a1617;
+  --color-bg-surface-elevated: #241f20;
+  --color-bg-surface-hover: #2d2728;
+  --color-text-primary: #f5f5f5;
+  --color-text-secondary: #b8b2b3;
+  --color-text-tertiary: #7a7577;
+  --color-success: #52c41a;
+  --color-error: #ff4d4f;
+  --color-warning: #faad14;
+  --space-xs: .25rem;
+  --space-sm: .5rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --space-2xl: 3rem;
+  --radius-sm: .5rem;
+  --radius-md: .75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.5rem;
+  --shadow-sm: 0 1px 2px 0 #0000004d;
+  --shadow-md: 0 4px 6px -1px #0006, 0 2px 4px -1px #0000004d;
+  --shadow-lg: 0 10px 15px -3px #00000080, 0 4px 6px -2px #0006;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-family: -apple-system, BlinkMacSystemFont, SF Pro Display, Segoe UI, Inter, system-ui, sans-serif;
+  line-height: 1.5;
+}
+
+h1 {
+  letter-spacing: -.02em;
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+h2 {
+  letter-spacing: -.01em;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+h4 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+p {
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+small {
+  font-size: .875rem;
+  line-height: 1.4;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--color-bg-surface);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--color-bg-surface-hover);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--color-text-tertiary);
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-gold-400);
+  outline-offset: 2px;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pulse {
+  50% {
+    opacity: .5;
+  }
+}
+
+.animate-fade-in {
+  animation: .3s ease-out fadeIn;
+}
+
+.animate-slide-up {
+  animation: .4s ease-out slideUp;
+}
+
+@property --tw-space-y-reverse {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --tw-border-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
+
+@property --tw-gradient-position {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-gradient-from {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #0000;
+}
+
+@property --tw-gradient-via {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #0000;
+}
+
+@property --tw-gradient-to {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #0000;
+}
+
+@property --tw-gradient-stops {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-gradient-via-stops {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-gradient-from-position {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+
+@property --tw-gradient-via-position {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 50%;
+}
+
+@property --tw-gradient-to-position {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+
+@property --tw-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+
+@property --tw-shadow-color {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+
+@property --tw-inset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+
+@property --tw-inset-shadow-color {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-inset-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+
+@property --tw-ring-color {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+
+@property --tw-inset-ring-color {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-inset-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+
+@property --tw-ring-inset {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-ring-offset-width {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --tw-ring-offset-color {
+  syntax: "*";
+  inherits: false;
+  initial-value: #fff;
+}
+
+@property --tw-ring-offset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+
+@property --tw-outline-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
+
+@property --tw-duration {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-scale-x {
+  syntax: "*";
+  inherits: false;
+  initial-value: 1;
+}
+
+@property --tw-scale-y {
+  syntax: "*";
+  inherits: false;
+  initial-value: 1;
+}
+
+@property --tw-scale-z {
+  syntax: "*";
+  inherits: false;
+  initial-value: 1;
+}
+
+
+/* virtual-fs:file:///styles/globals.css */
+:root {
+  --color-burgundy-950: #2d0a0f;
+  --color-burgundy-900: #4a0e1a;
+  --color-burgundy-800: #6b1529;
+  --color-burgundy-700: #8c1c38;
+  --color-burgundy-600: #a82847;
+  --color-burgundy-500: #c23456;
+  --color-gold-400: #f4bf4f;
+  --color-gold-500: #e6a23c;
+  --color-gold-600: #d48806;
+  --color-bg-primary: #0f0d0e;
+  --color-bg-surface: #1a1617;
+  --color-bg-surface-elevated: #241f20;
+  --color-bg-surface-hover: #2d2728;
+  --color-text-primary: #f5f5f5;
+  --color-text-secondary: #b8b2b3;
+  --color-text-tertiary: #7a7577;
+  --color-success: #52c41a;
+  --color-error: #ff4d4f;
+  --color-warning: #faad14;
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --space-2xl: 3rem;
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.5rem;
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -1px rgba(0, 0, 0, 0.3);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.5), 0 4px 6px -2px rgba(0, 0, 0, 0.4);
+}
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+body {
+  font-family:
+    -apple-system,
+    BlinkMacSystemFont,
+    "SF Pro Display",
+    "Segoe UI",
+    "Inter",
+    system-ui,
+    sans-serif;
+  background-color: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+h1 {
+  font-size: 2rem;
+  line-height: 1.2;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+h2 {
+  font-size: 1.5rem;
+  line-height: 1.3;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+h3 {
+  font-size: 1.25rem;
+  line-height: 1.4;
+  font-weight: 600;
+}
+h4 {
+  font-size: 1.125rem;
+  line-height: 1.4;
+  font-weight: 600;
+}
+p {
+  font-size: 1rem;
+  line-height: 1.6;
+}
+small {
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+::-webkit-scrollbar {
+  width: 8px;
+}
+::-webkit-scrollbar-track {
+  background: var(--color-bg-surface);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--color-bg-surface-hover);
+  border-radius: 4px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--color-text-tertiary);
+}
+:focus-visible {
+  outline: 2px solid var(--color-gold-400);
+  outline-offset: 2px;
+}
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+.animate-fade-in {
+  animation: fadeIn 0.3s ease-out;
+}
+.animate-slide-up {
+  animation: slideUp 0.4s ease-out;
+}
+/*# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsic3R5bGVzL2dsb2JhbHMuY3NzIl0sCiAgInNvdXJjZXNDb250ZW50IjogWyJAX19kaXNhYmxlZF9pbXBvcnQgXCJ0YWlsd2luZGNzc1wiO1xuXG4vKiBEZXNpZ24gU3lzdGVtIFRva2VucyAqL1xuOnJvb3Qge1xuICAvKiBDb2xvcnMgLSBUaGVhdHJlIEluc3BpcmVkICovXG4gIC0tY29sb3ItYnVyZ3VuZHktOTUwOiAjMmQwYTBmO1xuICAtLWNvbG9yLWJ1cmd1bmR5LTkwMDogIzRhMGUxYTtcbiAgLS1jb2xvci1idXJndW5keS04MDA6ICM2YjE1Mjk7XG4gIC0tY29sb3ItYnVyZ3VuZHktNzAwOiAjOGMxYzM4O1xuICAtLWNvbG9yLWJ1cmd1bmR5LTYwMDogI2E4Mjg0NztcbiAgLS1jb2xvci1idXJndW5keS01MDA6ICNjMjM0NTY7XG4gIFxuICAtLWNvbG9yLWdvbGQtNDAwOiAjZjRiZjRmO1xuICAtLWNvbG9yLWdvbGQtNTAwOiAjZTZhMjNjO1xuICAtLWNvbG9yLWdvbGQtNjAwOiAjZDQ4ODA2O1xuICBcbiAgLyogTmV1dHJhbHMgLSBEYXJrIFRoZW1lICovXG4gIC0tY29sb3ItYmctcHJpbWFyeTogIzBmMGQwZTtcbiAgLS1jb2xvci1iZy1zdXJmYWNlOiAjMWExNjE3O1xuICAtLWNvbG9yLWJnLXN1cmZhY2UtZWxldmF0ZWQ6ICMyNDFmMjA7XG4gIC0tY29sb3ItYmctc3VyZmFjZS1ob3ZlcjogIzJkMjcyODtcbiAgXG4gIC0tY29sb3ItdGV4dC1wcmltYXJ5OiAjZjVmNWY1O1xuICAtLWNvbG9yLXRleHQtc2Vjb25kYXJ5OiAjYjhiMmIzO1xuICAtLWNvbG9yLXRleHQtdGVydGlhcnk6ICM3YTc1Nzc7XG4gIFxuICAvKiBTZW1hbnRpYyBDb2xvcnMgKi9cbiAgLS1jb2xvci1zdWNjZXNzOiAjNTJjNDFhO1xuICAtLWNvbG9yLWVycm9yOiAjZmY0ZDRmO1xuICAtLWNvbG9yLXdhcm5pbmc6ICNmYWFkMTQ7XG4gIFxuICAvKiBTcGFjaW5nIFNjYWxlICovXG4gIC0tc3BhY2UteHM6IDAuMjVyZW07XG4gIC0tc3BhY2Utc206IDAuNXJlbTtcbiAgLS1zcGFjZS1tZDogMXJlbTtcbiAgLS1zcGFjZS1sZzogMS41cmVtO1xuICAtLXNwYWNlLXhsOiAycmVtO1xuICAtLXNwYWNlLTJ4bDogM3JlbTtcbiAgXG4gIC8qIEJvcmRlciBSYWRpdXMgKi9cbiAgLS1yYWRpdXMtc206IDAuNXJlbTtcbiAgLS1yYWRpdXMtbWQ6IDAuNzVyZW07XG4gIC0tcmFkaXVzLWxnOiAxcmVtO1xuICAtLXJhZGl1cy14bDogMS41cmVtO1xuICBcbiAgLyogU2hhZG93cyAqL1xuICAtLXNoYWRvdy1zbTogMCAxcHggMnB4IDAgcmdiYSgwLCAwLCAwLCAwLjMpO1xuICAtLXNoYWRvdy1tZDogMCA0cHggNnB4IC0xcHggcmdiYSgwLCAwLCAwLCAwLjQpLCAwIDJweCA0cHggLTFweCByZ2JhKDAsIDAsIDAsIDAuMyk7XG4gIC0tc2hhZG93LWxnOiAwIDEwcHggMTVweCAtM3B4IHJnYmEoMCwgMCwgMCwgMC41KSwgMCA0cHggNnB4IC0ycHggcmdiYSgwLCAwLCAwLCAwLjQpO1xufVxuXG4vKiBSZXNldCAmIEJhc2UgU3R5bGVzICovXG4qIHtcbiAgbWFyZ2luOiAwO1xuICBwYWRkaW5nOiAwO1xuICBib3gtc2l6aW5nOiBib3JkZXItYm94O1xufVxuXG5ib2R5IHtcbiAgZm9udC1mYW1pbHk6IC1hcHBsZS1zeXN0ZW0sIEJsaW5rTWFjU3lzdGVtRm9udCwgJ1NGIFBybyBEaXNwbGF5JywgJ1NlZ29lIFVJJywgJ0ludGVyJywgc3lzdGVtLXVpLCBzYW5zLXNlcmlmO1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1jb2xvci1iZy1wcmltYXJ5KTtcbiAgY29sb3I6IHZhcigtLWNvbG9yLXRleHQtcHJpbWFyeSk7XG4gIGxpbmUtaGVpZ2h0OiAxLjU7XG4gIC13ZWJraXQtZm9udC1zbW9vdGhpbmc6IGFudGlhbGlhc2VkO1xuICAtbW96LW9zeC1mb250LXNtb290aGluZzogZ3JheXNjYWxlO1xufVxuXG4vKiBUeXBvZ3JhcGh5IFNjYWxlICovXG5oMSB7XG4gIGZvbnQtc2l6ZTogMnJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuMjtcbiAgZm9udC13ZWlnaHQ6IDcwMDtcbiAgbGV0dGVyLXNwYWNpbmc6IC0wLjAyZW07XG59XG5cbmgyIHtcbiAgZm9udC1zaXplOiAxLjVyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjM7XG4gIGZvbnQtd2VpZ2h0OiA3MDA7XG4gIGxldHRlci1zcGFjaW5nOiAtMC4wMWVtO1xufVxuXG5oMyB7XG4gIGZvbnQtc2l6ZTogMS4yNXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuNDtcbiAgZm9udC13ZWlnaHQ6IDYwMDtcbn1cblxuaDQge1xuICBmb250LXNpemU6IDEuMTI1cmVtO1xuICBsaW5lLWhlaWdodDogMS40O1xuICBmb250LXdlaWdodDogNjAwO1xufVxuXG5wIHtcbiAgZm9udC1zaXplOiAxcmVtO1xuICBsaW5lLWhlaWdodDogMS42O1xufVxuXG5zbWFsbCB7XG4gIGZvbnQtc2l6ZTogMC44NzVyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjQ7XG59XG5cbi8qIFNjcm9sbGJhciBTdHlsaW5nICovXG46Oi13ZWJraXQtc2Nyb2xsYmFyIHtcbiAgd2lkdGg6IDhweDtcbn1cblxuOjotd2Via2l0LXNjcm9sbGJhci10cmFjayB7XG4gIGJhY2tncm91bmQ6IHZhcigtLWNvbG9yLWJnLXN1cmZhY2UpO1xufVxuXG46Oi13ZWJraXQtc2Nyb2xsYmFyLXRodW1iIHtcbiAgYmFja2dyb3VuZDogdmFyKC0tY29sb3ItYmctc3VyZmFjZS1ob3Zlcik7XG4gIGJvcmRlci1yYWRpdXM6IDRweDtcbn1cblxuOjotd2Via2l0LXNjcm9sbGJhci10aHVtYjpob3ZlciB7XG4gIGJhY2tncm91bmQ6IHZhcigtLWNvbG9yLXRleHQtdGVydGlhcnkpO1xufVxuXG4vKiBBY2Nlc3NpYmlsaXR5ICovXG46Zm9jdXMtdmlzaWJsZSB7XG4gIG91dGxpbmU6IDJweCBzb2xpZCB2YXIoLS1jb2xvci1nb2xkLTQwMCk7XG4gIG91dGxpbmUtb2Zmc2V0OiAycHg7XG59XG5cbi8qIEFuaW1hdGlvbnMgKi9cbkBrZXlmcmFtZXMgZmFkZUluIHtcbiAgZnJvbSB7XG4gICAgb3BhY2l0eTogMDtcbiAgICB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoMTBweCk7XG4gIH1cbiAgdG8ge1xuICAgIG9wYWNpdHk6IDE7XG4gICAgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKDApO1xuICB9XG59XG5cbkBrZXlmcmFtZXMgc2xpZGVVcCB7XG4gIGZyb20ge1xuICAgIG9wYWNpdHk6IDA7XG4gICAgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKDIwcHgpO1xuICB9XG4gIHRvIHtcbiAgICBvcGFjaXR5OiAxO1xuICAgIHRyYW5zZm9ybTogdHJhbnNsYXRlWSgwKTtcbiAgfVxufVxuXG5Aa2V5ZnJhbWVzIHB1bHNlIHtcbiAgMCUsIDEwMCUge1xuICAgIG9wYWNpdHk6IDE7XG4gIH1cbiAgNTAlIHtcbiAgICBvcGFjaXR5OiAwLjU7XG4gIH1cbn1cblxuLmFuaW1hdGUtZmFkZS1pbiB7XG4gIGFuaW1hdGlvbjogZmFkZUluIDAuM3MgZWFzZS1vdXQ7XG59XG5cbi5hbmltYXRlLXNsaWRlLXVwIHtcbiAgYW5pbWF0aW9uOiBzbGlkZVVwIDAuNHMgZWFzZS1vdXQ7XG59XG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQUEsbUJBQW1CO0FBR25CO0FBRUUsd0JBQXNCO0FBQ3RCLHdCQUFzQjtBQUN0Qix3QkFBc0I7QUFDdEIsd0JBQXNCO0FBQ3RCLHdCQUFzQjtBQUN0Qix3QkFBc0I7QUFFdEIsb0JBQWtCO0FBQ2xCLG9CQUFrQjtBQUNsQixvQkFBa0I7QUFHbEIsc0JBQW9CO0FBQ3BCLHNCQUFvQjtBQUNwQiwrQkFBNkI7QUFDN0IsNEJBQTBCO0FBRTFCLHdCQUFzQjtBQUN0QiwwQkFBd0I7QUFDeEIseUJBQXVCO0FBR3ZCLG1CQUFpQjtBQUNqQixpQkFBZTtBQUNmLG1CQUFpQjtBQUdqQixjQUFZO0FBQ1osY0FBWTtBQUNaLGNBQVk7QUFDWixjQUFZO0FBQ1osY0FBWTtBQUNaLGVBQWE7QUFHYixlQUFhO0FBQ2IsZUFBYTtBQUNiLGVBQWE7QUFDYixlQUFhO0FBR2IsZUFBYSxFQUFFLElBQUksSUFBSSxFQUFFLEtBQUssQ0FBQyxFQUFFLENBQUMsRUFBRSxDQUFDLEVBQUU7QUFDdkMsZUFBYSxFQUFFLElBQUksSUFBSSxLQUFLLEtBQUssQ0FBQyxFQUFFLENBQUMsRUFBRSxDQUFDLEVBQUUsSUFBSSxFQUFFLEVBQUUsSUFBSSxJQUFJLEtBQUssS0FBSyxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQUMsRUFBRTtBQUM3RSxlQUFhLEVBQUUsS0FBSyxLQUFLLEtBQUssS0FBSyxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQUMsRUFBRSxJQUFJLEVBQUUsRUFBRSxJQUFJLElBQUksS0FBSyxLQUFLLENBQUMsRUFBRSxDQUFDLEVBQUUsQ0FBQyxFQUFFO0FBQ2pGO0FBR0E7QUFDRSxVQUFRO0FBQ1IsV0FBUztBQUNULGNBQVk7QUFDZDtBQUVBO0FBQ0U7QUFBQSxJQUFhLGFBQWE7QUFBQSxJQUFFLGtCQUFrQjtBQUFBLElBQUUsZ0JBQWdCO0FBQUEsSUFBRSxVQUFVO0FBQUEsSUFBRSxPQUFPO0FBQUEsSUFBRSxTQUFTO0FBQUEsSUFBRTtBQUNsRyxvQkFBa0IsSUFBSTtBQUN0QixTQUFPLElBQUk7QUFDWCxlQUFhO0FBQ2IsMEJBQXdCO0FBQ3hCLDJCQUF5QjtBQUMzQjtBQUdBO0FBQ0UsYUFBVztBQUNYLGVBQWE7QUFDYixlQUFhO0FBQ2Isa0JBQWdCO0FBQ2xCO0FBRUE7QUFDRSxhQUFXO0FBQ1gsZUFBYTtBQUNiLGVBQWE7QUFDYixrQkFBZ0I7QUFDbEI7QUFFQTtBQUNFLGFBQVc7QUFDWCxlQUFhO0FBQ2IsZUFBYTtBQUNmO0FBRUE7QUFDRSxhQUFXO0FBQ1gsZUFBYTtBQUNiLGVBQWE7QUFDZjtBQUVBO0FBQ0UsYUFBVztBQUNYLGVBQWE7QUFDZjtBQUVBO0FBQ0UsYUFBVztBQUNYLGVBQWE7QUFDZjtBQUdBO0FBQ0UsU0FBTztBQUNUO0FBRUE7QUFDRSxjQUFZLElBQUk7QUFDbEI7QUFFQTtBQUNFLGNBQVksSUFBSTtBQUNoQixpQkFBZTtBQUNqQjtBQUVBLHlCQUF5QjtBQUN2QixjQUFZLElBQUk7QUFDbEI7QUFHQTtBQUNFLFdBQVMsSUFBSSxNQUFNLElBQUk7QUFDdkIsa0JBQWdCO0FBQ2xCO0FBR0EsV0FBVztBQUNUO0FBQ0UsYUFBUztBQUNULGVBQVcsV0FBVztBQUN4QjtBQUNBO0FBQ0UsYUFBUztBQUNULGVBQVcsV0FBVztBQUN4QjtBQUNGO0FBRUEsV0FBVztBQUNUO0FBQ0UsYUFBUztBQUNULGVBQVcsV0FBVztBQUN4QjtBQUNBO0FBQ0UsYUFBUztBQUNULGVBQVcsV0FBVztBQUN4QjtBQUNGO0FBRUEsV0FBVztBQUNUO0FBQ0UsYUFBUztBQUNYO0FBQ0E7QUFDRSxhQUFTO0FBQ1g7QUFDRjtBQUVBLENBQUM7QUFDQyxhQUFXLE9BQU8sS0FBSztBQUN6QjtBQUVBLENBQUM7QUFDQyxhQUFXLFFBQVEsS0FBSztBQUMxQjsiLAogICJuYW1lcyI6IFtdCn0K */
+


### PR DESCRIPTION
## Intent
Consolidate CSS definitions into a single shared file shared/styles/main.css to unify PWA and Mobile app styling and simplify maintenance.

## Key Changes
- Created shared/styles/main.css.
- Updated PWA and Mobile entry points to import the shared CSS.
- Removed redundant local CSS imports.

## Testing
- Verified file paths and imports in local environment.