### PR TITLE
Add node_modules cleanup to self-hosted build workflow

### DIFF
--- a/.github/workflows/local-build-self-hosted.yml
+++ b/.github/workflows/local-build-self-hosted.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Clean existing node_modules
+        run: |
+          Get-ChildItem -Path . -Filter node_modules -Directory -Recurse -ErrorAction SilentlyContinue |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- remove existing node_modules directories before dependency installation in the self-hosted workflow
- aim to avoid stale esbuild binaries causing install failures

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694156703b6c83269f99fa514dff50e7)