### PR TITLE
Stop esbuild processes before dependency cleanup

### DIFF
--- a/.github/workflows/local-build-self-hosted.yml
+++ b/.github/workflows/local-build-self-hosted.yml
@@ -22,6 +22,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Terminate lingering esbuild processes
+        run: Get-Process esbuild -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+
+      - name: Clean existing node_modules
+        run: |
+          Get-ChildItem -Path . -Filter node_modules -Directory -Recurse -ErrorAction SilentlyContinue |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- stop lingering esbuild processes before cleaning node_modules in the self-hosted workflow to avoid locked binaries during install
- retain node_modules cleanup to ensure fresh dependencies

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694156703b6c83269f99fa514dff50e7)