### PR TITLE
Use URL-safe mobile package name

### DIFF
--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -1,11 +1,11 @@
 {
-      "name": "Mobile UI for Turni di Palco",
+      "name": "turni-mobile",
       "version": "0.1.0",
       "lockfileVersion": 3,
       "requires": true,
       "packages": {
             "": {
-                  "name": "Mobile UI for Turni di Palco",
+                  "name": "turni-mobile",
                   "version": "0.1.0",
                   "dependencies": {
                         "@radix-ui/react-accordion": "^1.2.3",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 
   {
-      "name": "Mobile UI for Turni di Palco",
+      "name": "turni-mobile",
       "version": "0.1.0",
       "private": true,
       "dependencies": {


### PR DESCRIPTION
Fix mobile package name to a URL-safe value (turni-mobile) to unblock Render build.