### PR TITLE
Allow Render host in Vite dev/preview

### DIFF
--- a/apps/pwa/vite.config.ts
+++ b/apps/pwa/vite.config.ts
@@ -39,10 +39,12 @@ export default defineConfig({
     host: true,
     port: 5173,
     https: httpsOption,
+    allowedHosts: ["turni-di-palco.onrender.com"],
   },
   preview: {
     host: true,
     port: 4173,
     https: httpsOption,
+    allowedHosts: ["turni-di-palco.onrender.com"],
   },
 });


### PR DESCRIPTION
Add Render domain to Vite server/preview allowedHosts so HTTPS preview works on Render without host blocking.