### PR TITLE
Match mobile screens to UI build

### DIFF
--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -6,10 +6,9 @@ import { Tag } from '../ui/Tag';
 import { MetricTile } from '../ui/MetricTile';
 import { Skeleton } from '../ui/skeleton';
 import { Button } from '../ui/Button';
-import { Play, Calendar, TrendingUp, Award, MapPin, Clock, Navigation, CalendarPlus, X, Bell, ChevronRight } from 'lucide-react';
+import { QrCode, Play, Calendar, TrendingUp, Award, ChevronRight, MapPin, Clock, Navigation, CalendarPlus, X, Bell } from 'lucide-react';
 import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover';
 import { GameEvent } from '../../state/store';
-import { ScanQRCard } from '../ScanQRCard';
 
 type EventState = 'loading' | 'error' | 'empty' | 'ready';
 
@@ -114,7 +113,27 @@ export function Home({
           </div>
         </header>
 
-        <ScanQRCard onScanQR={onScanQR} style={{ marginTop: '20px' }} />
+        <Card className="bg-gradient-to-r from-[#8c1c38] to-[#a82847] border border-[#f4bf4f]/30" style={{ marginTop: '20px' }}>
+          <div className="flex items-center gap-3">
+            <div className="flex-shrink-0 w-12 h-12 bg-[#f4bf4f] rounded-xl flex items-center justify-center" style={{ margin: '5px 0 5px 5px' }}>
+              <QrCode className="text-[#2d0a0f]" size={24} />
+            </div>
+            <div className="flex-1">
+              <button
+                onClick={onScanQR}
+                className="w-full text-left text-white hover:opacity-90 transition"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div>
+                    <p className="font-semibold text-base">Scansiona QR</p>
+                    <p className="text-sm text-[#f4bf4f]/90">Registra un turno dal biglietto</p>
+                  </div>
+                  <ChevronRight className="text-white" size={22} />
+                </div>
+              </button>
+            </div>
+          </div>
+        </Card>
 
         <section className="space-y-3">
           <div className="flex items-center justify-between">

--- a/apps/mobile/src/components/screens/TurniATCL.tsx
+++ b/apps/mobile/src/components/screens/TurniATCL.tsx
@@ -4,7 +4,6 @@ import { Button } from '../ui/Button';
 import { Badge } from '../ui/Badge';
 import { QrCode, MapPin, Calendar, TrendingUp, Theater } from 'lucide-react';
 import { TurnRecord, RoleId, roles } from '../../state/store';
-import { ScanQRCard } from '../ScanQRCard';
 
 interface TurniATCLProps {
   turns: TurnRecord[];
@@ -39,8 +38,17 @@ export function TurniATCL({ turns, onScanQR }: TurniATCLProps) {
       
       {/* Main Content */}
       <div className="w-full max-w-md mx-auto px-6 space-y-6 pt-6 pb-8">
-        {/* QR Scan Card */}
-        <ScanQRCard onScanQR={onScanQR} />
+        {/* Scan Button */}
+        <Button
+          variant="primary"
+          size="lg"
+          fullWidth
+          onClick={onScanQR}
+          style={{ padding: "0 5px" }}
+        >
+          <QrCode size={20} />
+          Registra nuovo turno (Scansiona QR)
+        </Button>
         
         {/* Stats Summary */}
         <Card>


### PR DESCRIPTION
## Summary
- align Home and Turni ATCL screens with Turni-di-Palco-UI design (inline scan CTA, QR button)
- remove dependency on ScanQRCard in those pages to match reference

## Testing
- not run (not requested)