### PR TITLE
Mobile UI fixes and polish

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -233,7 +233,7 @@ function AppShell() {
   const showBottomNav = ['home', 'turni', 'attivita', 'profilo', 'carriera'].includes(currentScreen);
 
   return (
-    <div className="min-h-screen bg-[#0f0d0e] flex items-start justify-center">
+    <div className="min-h-screen app-gradient flex items-start justify-center">
       <div className="w-full">
         <div className="w-full max-w-[393px] relative mx-auto min-h-screen">{renderScreen()}</div>
       </div>

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -85,8 +85,8 @@ function AppShell() {
     setCurrentScreen('event-confirmation');
   };
 
-  const handleEventConfirm = (roleId: string) => {
-    const resolvedRoleId = (roleId as typeof state.profile.roleId) || state.profile.roleId;
+  const handleEventConfirm = () => {
+    const resolvedRoleId = state.profile.roleId;
     const record = registerTurn(scannedEventId, resolvedRoleId);
     if (record) {
       setCurrentScreen('home');
@@ -176,15 +176,17 @@ function AppShell() {
           />
         );
 
-      case 'event-confirmation':
+      case 'event-confirmation': {
+        const selectedRole = roles.find((role) => role.id === state.profile.roleId);
         return (
           <EventConfirmation
             event={selectedEvent}
-            roles={roles}
+            role={selectedRole}
             onConfirm={handleEventConfirm}
             onCancel={() => setCurrentScreen('turni')}
           />
         );
+      }
 
       case 'attivita':
         return <Attivita activities={activities} onStartActivity={handleStartActivity} />;

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -12,6 +12,7 @@ import { Attivita } from './components/screens/Attivita';
 import { ActivityDetail } from './components/screens/ActivityDetail';
 import { Profilo } from './components/screens/Profilo';
 import { Carriera } from './components/screens/Carriera';
+import { TitoliOttenuti } from './components/screens/TitoliOttenuti';
 import { GameStateProvider, useGameState } from './state/store';
 
 
@@ -27,7 +28,8 @@ type Screen =
   | 'attivita'
   | 'activity-detail'
   | 'profilo'
-  | 'carriera';
+  | 'carriera'
+  | 'titoli-ottenuti';
 
 type Tab = 'home' | 'turni' | 'attivita' | 'profilo';
 
@@ -107,6 +109,10 @@ function AppShell() {
 
   const handleViewCarriera = () => {
     setCurrentScreen('carriera');
+  };
+
+  const handleViewTitoli = () => {
+    setCurrentScreen('titoli-ottenuti');
   };
 
   const handleLogout = () => {
@@ -205,6 +211,7 @@ function AppShell() {
             xpSulCampo={state.profile.xpField}
             reputationGlobal={state.profile.reputation}
             onViewCarriera={handleViewCarriera}
+            onViewTitoli={handleViewTitoli}
             onSettings={() => undefined}
             onLogout={handleLogout}
           />
@@ -225,12 +232,15 @@ function AppShell() {
           />
         );
 
+      case 'titoli-ottenuti':
+        return <TitoliOttenuti onBack={() => setCurrentScreen('profilo')} />;
+
       default:
         return null;
     }
   };
 
-  const showBottomNav = ['home', 'turni', 'attivita', 'profilo', 'carriera'].includes(currentScreen);
+  const showBottomNav = ['home', 'turni', 'attivita', 'profilo', 'carriera', 'titoli-ottenuti'].includes(currentScreen);
 
   return (
     <div className="min-h-screen app-gradient flex items-start justify-center">

--- a/apps/mobile/src/components/BottomNav.tsx
+++ b/apps/mobile/src/components/BottomNav.tsx
@@ -26,7 +26,7 @@ export function BottomNav({ activeTab, onTabChange }: BottomNavProps) {
               <button
                 key={tab.id}
                 onClick={() => onTabChange(tab.id)}
-                className={`flex h-[44px] ${tab.widthClass} flex-col items-center justify-end gap-[4px] rounded-[10px] text-[12px] leading-[16px] transition-colors ${
+                className={`flex h-[44px] min-w-[44px] ${tab.widthClass} flex-col items-center justify-end gap-[4px] rounded-[10px] text-[12px] leading-[16px] transition-colors ${
                   isActive ? 'text-[#f4bf4f]' : 'text-[#7a7577] hover:text-[#b8b2b3]'
                 }`}
               >

--- a/apps/mobile/src/components/ScanQRCard.tsx
+++ b/apps/mobile/src/components/ScanQRCard.tsx
@@ -10,8 +10,9 @@ interface ScanQRCardProps {
 
 export function ScanQRCard({ onScanQR, className = '', style }: ScanQRCardProps) {
   return (
-    <Card className={`bg-gradient-to-r from-[#8c1c38] to-[#a82847] border border-[#f4bf4f]/30 ${className}`} style={style}>
-      <div className="flex items-center gap-3">
+    <Card className={`relative overflow-hidden border border-[#2d2728] ${className}`} style={style}>
+      <div className="absolute inset-0 bg-gradient-to-r from-[#8c1c38]/35 to-[#a82847]/35 pointer-events-none" />
+      <div className="relative flex items-center gap-3">
         <div className="flex-shrink-0 w-12 h-12 bg-[#f4bf4f] rounded-xl flex items-center justify-center ml-1 my-1">
           <QrCode className="text-[#2d0a0f]" size={24} />
         </div>

--- a/apps/mobile/src/components/ScanQRCard.tsx
+++ b/apps/mobile/src/components/ScanQRCard.tsx
@@ -25,8 +25,8 @@ export function ScanQRCard({ onScanQR, className = '', style }: ScanQRCardProps)
         </div>
         <div className="flex-1 flex items-center justify-between">
           <div className="flex flex-col items-start">
-            <p className="text-[16px] leading-[25.6px] font-semibold text-white">Scansiona QR</p>
-            <p className="text-[16px] leading-[25.6px] text-[#f4bf4f]/90">Registra un turno dal biglietto</p>
+            <p className="text-[16px] leading-[25.6px] font-semibold text-white !m-0">Scansiona QR</p>
+            <p className="text-[16px] leading-[25.6px] text-white !m-0">Registra un turno dal biglietto</p>
           </div>
           <ChevronRight className="text-white" size={22} />
         </div>

--- a/apps/mobile/src/components/ScanQRCard.tsx
+++ b/apps/mobile/src/components/ScanQRCard.tsx
@@ -25,8 +25,8 @@ export function ScanQRCard({ onScanQR, className = '', style }: ScanQRCardProps)
         </div>
         <div className="flex-1 flex items-center justify-between">
           <div className="flex flex-col items-start">
-            <p className="text-[16px] leading-[25.6px] font-semibold text-white !m-0">Scansiona QR</p>
-            <p className="text-[16px] leading-[25.6px] text-white !m-0">Registra un turno dal biglietto</p>
+            <p className="text-[16px] leading-[25.6px] font-semibold !text-[#ffffff] !m-0">Scansiona QR</p>
+            <p className="text-[16px] leading-[25.6px] !text-[#ffffff] !m-0">Registra un turno dal biglietto</p>
           </div>
           <ChevronRight className="text-white" size={22} />
         </div>

--- a/apps/mobile/src/components/ScanQRCard.tsx
+++ b/apps/mobile/src/components/ScanQRCard.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Card } from './ui/Card';
 import { QrCode, ChevronRight } from 'lucide-react';
 
 interface ScanQRCardProps {
@@ -10,24 +9,28 @@ interface ScanQRCardProps {
 
 export function ScanQRCard({ onScanQR, className = '', style }: ScanQRCardProps) {
   return (
-    <Card className={`relative overflow-hidden border border-[#2d2728] ${className}`} style={style}>
-      <div className="absolute inset-0 bg-gradient-to-r from-[#8c1c38]/35 to-[#a82847]/35 pointer-events-none" />
-      <div className="relative flex items-center gap-3">
-        <div className="flex-shrink-0 w-12 h-12 bg-[#f4bf4f] rounded-xl flex items-center justify-center ml-1 my-1">
+    <button
+      type="button"
+      onClick={onScanQR}
+      className={`w-full border border-[#f4bf4f]/30 rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-px transition-all duration-200 hover:opacity-95 active:scale-[0.99] ${className}`}
+      style={{
+        backgroundImage:
+          'linear-gradient(180deg, rgba(140, 28, 56, 1) 0%, rgba(168, 40, 71, 1) 100%), linear-gradient(90deg, rgba(26, 22, 23, 1) 0%, rgba(26, 22, 23, 1) 100%)',
+        ...style,
+      }}
+    >
+      <div className="flex items-center gap-3 h-[58px] pl-[5px] pr-0">
+        <div className="bg-[#f4bf4f] rounded-[16.4px] size-[48px] flex items-center justify-center">
           <QrCode className="text-[#2d0a0f]" size={24} />
         </div>
-        <div className="flex-1">
-          <button onClick={onScanQR} className="w-full text-left text-white hover:opacity-90 transition">
-            <div className="flex items-center justify-between gap-2">
-              <div>
-                <p className="font-semibold text-base">Scansiona QR</p>
-                <p className="text-sm text-[#f4bf4f]/90">Registra un turno dal biglietto</p>
-              </div>
-              <ChevronRight className="text-white" size={22} />
-            </div>
-          </button>
+        <div className="flex-1 flex items-center justify-between">
+          <div className="flex flex-col items-start">
+            <p className="text-[16px] leading-[25.6px] font-semibold text-white">Scansiona QR</p>
+            <p className="text-[16px] leading-[25.6px] text-[#f4bf4f]/90">Registra un turno dal biglietto</p>
+          </div>
+          <ChevronRight className="text-white" size={22} />
         </div>
       </div>
-    </Card>
+    </button>
   );
 }

--- a/apps/mobile/src/components/screens/ActivityDetail.tsx
+++ b/apps/mobile/src/components/screens/ActivityDetail.tsx
@@ -16,7 +16,7 @@ export function ActivityDetail({ activity, onStart, onClose }: ActivityDetailPro
     <div className="fixed inset-0 bg-[#0f0d0e] z-50 overflow-y-auto pb-24">
       <div className="sticky top-0 bg-[#1a1617] border-b border-[#2d2728] p-4 flex items-center justify-between z-10">
         <h3 className="text-white">Dettagli attività</h3>
-        <button onClick={onClose} className="p-2 hover:bg-[#241f20] rounded-lg transition-colors">
+        <button onClick={onClose} className="flex items-center justify-center size-[44px] hover:bg-[#241f20] rounded-lg transition-colors">
           <X className="text-[#f4bf4f]" size={24} />
         </button>
       </div>

--- a/apps/mobile/src/components/screens/ActivityDetail.tsx
+++ b/apps/mobile/src/components/screens/ActivityDetail.tsx
@@ -13,7 +13,7 @@ interface ActivityDetailProps {
 
 export function ActivityDetail({ activity, onStart, onClose }: ActivityDetailProps) {
   return (
-    <div className="fixed inset-0 bg-[#0f0d0e] z-50 overflow-y-auto pb-24">
+    <div className="fixed inset-0 app-gradient z-50 overflow-y-auto pb-24">
       <div className="sticky top-0 bg-[#1a1617] border-b border-[#2d2728] p-4 flex items-center justify-between z-10">
         <h3 className="text-white">Dettagli attività</h3>
         <button onClick={onClose} className="flex items-center justify-center size-[44px] hover:bg-[#241f20] rounded-lg transition-colors">

--- a/apps/mobile/src/components/screens/Attivita.tsx
+++ b/apps/mobile/src/components/screens/Attivita.tsx
@@ -16,7 +16,7 @@ const difficultyLabels: Record<Activity['difficulty'], string> = {
 export function Attivita({ activities, onStartActivity }: AttivitaProps) {
   return (
     <div
-      className="min-h-screen bg-[#0f0d0e]"
+      className="min-h-screen app-gradient"
       style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 100px)' }}
     >
       <div className="w-full max-w-[393px] mx-auto pt-[36px] pb-0 mt-[17px] flex flex-col gap-[24px]">

--- a/apps/mobile/src/components/screens/Attivita.tsx
+++ b/apps/mobile/src/components/screens/Attivita.tsx
@@ -102,12 +102,14 @@ export function Attivita({ activities, onStartActivity }: AttivitaProps) {
           </div>
         </section>
 
-        <Card className="text-center">
-          <p className="text-sm text-[#7a7577]">Nuove attività in arrivo</p>
-          <p className="text-sm text-[#b8b2b3]">
-            Stiamo preparando nuove sfide e minigames
-          </p>
-        </Card>
+        {totalActivities === 0 ? (
+          <Card className="text-center">
+            <p className="text-sm text-[#7a7577]">Nuove attività in arrivo</p>
+            <p className="text-sm text-[#b8b2b3]">
+              Stiamo preparando nuove sfide e minigames
+            </p>
+          </Card>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/mobile/src/components/screens/Attivita.tsx
+++ b/apps/mobile/src/components/screens/Attivita.tsx
@@ -1,5 +1,8 @@
-﻿import React from 'react';
+import React from 'react';
 import { Clock, Coins, Play, TrendingUp } from 'lucide-react';
+import { Card } from '../ui/Card';
+import { Badge } from '../ui/Badge';
+import { Tag } from '../ui/Tag';
 import { Activity } from '../../state/store';
 
 interface AttivitaProps {
@@ -10,100 +13,101 @@ interface AttivitaProps {
 const difficultyLabels: Record<Activity['difficulty'], string> = {
   Facile: 'Principiante',
   Medio: 'Intermedio',
-  Difficile: 'Avanzato'
+  Difficile: 'Avanzato',
 };
 
 export function Attivita({ activities, onStartActivity }: AttivitaProps) {
+  const totalActivities = activities.length;
+
   return (
     <div
       className="min-h-screen app-gradient"
-      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 100px)' }}
+      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 96px)' }}
     >
-      <div className="w-full max-w-[393px] mx-auto pt-[36px] pb-0 mt-[17px] flex flex-col gap-[24px]">
-        <div className="flex flex-col items-start px-[25px]">
-          <p className="text-[24px] leading-[31.2px] font-bold tracking-[-0.24px] text-white">
-            Attività simulate
-          </p>
-          <p className="text-[16px] leading-[25.6px] text-[#b8b2b3]">
+      <div className="w-full max-w-md mx-auto px-6 pt-6 pb-8 space-y-6">
+        <header className="space-y-2">
+          <h2 className="text-white">Attività simulate</h2>
+          <p className="text-[#b8b2b3]">
             Migliora le tue skill e guadagna ricompense
           </p>
-        </div>
+        </header>
 
-        <div className="flex flex-col gap-[20px] items-start px-[25px]">
-          <div className="bg-[#1a1617] border border-[rgba(244,191,79,0.3)] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] w-[325px] p-px">
-            <div className="flex h-[76px] items-center justify-center px-[5px] py-[4px]">
-              <div className="flex flex-col items-start">
-                <p className="text-[18px] leading-[25.2px] font-semibold text-white">
-                  Allenati ogni giorno
-                </p>
-                <p className="text-[14px] leading-[25.6px] text-[#b8b2b3] w-[319px]">
-                  Completa le attività per migliorare le tue competenze e prepararti per gli eventi reali
-                </p>
-              </div>
+        <Card className="border border-[#f4bf4f]/30 bg-gradient-to-br from-[#1a1617] to-[#241f20]">
+          <div className="flex items-start gap-4">
+            <div className="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-xl flex items-center justify-center">
+              <TrendingUp className="text-[#f4bf4f]" size={22} />
+            </div>
+            <div className="space-y-1">
+              <h3 className="text-white">Allenati ogni giorno</h3>
+              <p className="text-sm text-[#b8b2b3]">
+                Completa le attività per migliorare le tue competenze e prepararti per gli eventi reali
+              </p>
             </div>
           </div>
+        </Card>
 
-          <div className="flex flex-col gap-[25px] items-start">
-            <p className="text-[20px] leading-[28px] font-semibold text-white">
-              Attività disponibili
-            </p>
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-white">Attività disponibili</h3>
+            <Tag size="sm" variant="info">
+              {totalActivities} disponibili
+            </Tag>
+          </div>
 
-            <div className="flex flex-col gap-[20px] items-start">
-              {activities.map((activity) => {
-                const difficultyLabel = difficultyLabels[activity.difficulty] ?? activity.difficulty;
-                return (
-                  <button
-                    key={activity.id}
-                    type="button"
-                    onClick={() => onStartActivity(activity.id)}
-                    className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-[5px] w-[291px] text-left"
-                  >
-                    <div className="flex gap-[16px] items-start">
-                      <div className="bg-gradient-to-b from-[#a82847] to-[#6b1529] rounded-[16.4px] size-[56px] flex items-center justify-center">
-                        <Play className="text-[#f4bf4f]" size={24} />
+          <div className="space-y-3">
+            {activities.map((activity) => {
+              const difficultyLabel = difficultyLabels[activity.difficulty] ?? activity.difficulty;
+              return (
+                <Card
+                  key={activity.id}
+                  hoverable
+                  onClick={() => onStartActivity(activity.id)}
+                >
+                  <div className="flex items-start gap-4">
+                    <div className="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-xl flex items-center justify-center">
+                      <Play className="text-[#f4bf4f]" size={22} />
+                    </div>
+                    <div className="flex-1 space-y-2">
+                      <div className="flex items-start justify-between gap-2">
+                        <h4 className="text-white">{activity.title}</h4>
+                        <Play className="text-[#f4bf4f]" size={18} />
                       </div>
-                      <div className="flex-1 flex flex-col items-start">
-                        <div className="flex w-full items-start justify-between">
-                          <p className="text-[18px] leading-[25.2px] font-semibold text-white">
-                            {activity.title}
-                          </p>
-                          <Play className="text-[#f4bf4f]" size={20} />
-                        </div>
-                        <p className="text-[16px] leading-[25.6px] text-[#b8b2b3]">
-                          {activity.description}
-                        </p>
-                        <div className="flex gap-[12px] items-center h-[20px] text-[14px] leading-[20px] text-[#b8b2b3]">
+                      <p className="text-sm text-[#b8b2b3]">
+                        {activity.description}
+                      </p>
+                      <div className="flex flex-wrap items-center gap-2 text-sm text-[#b8b2b3]">
+                        <span className="inline-flex items-center gap-2">
                           <Clock size={14} />
-                          <span>{activity.duration}</span>
-                          <span>{difficultyLabel}</span>
-                        </div>
-                        <div className="flex gap-[8px] items-start h-[16px]">
-                          <span className="flex items-center gap-[4px] h-[16px] rounded-full bg-gradient-to-b from-[#e6a23c] to-[#f4bf4f] px-[6px] text-[12px] leading-[16px] text-[#0f0d0e]">
-                            <TrendingUp size={12} />
-                            +{activity.xpReward} XP
-                          </span>
-                          <span className="flex items-center gap-[4px] h-[16px] rounded-full bg-[#241f20] px-[6px] text-[12px] leading-[16px] text-[#b8b2b3]">
-                            <Coins size={12} />
-                            +
-                          </span>
-                        </div>
+                          {activity.duration}
+                        </span>
+                        <Badge variant="outline" size="sm">
+                          {difficultyLabel}
+                        </Badge>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant="gold" size="sm">
+                          <TrendingUp size={12} />
+                          +{activity.xpReward} XP
+                        </Badge>
+                        <Badge variant="default" size="sm">
+                          <Coins size={12} />
+                          +{activity.cachetReward}
+                        </Badge>
                       </div>
                     </div>
-                  </button>
-                );
-              })}
-            </div>
-
-            <div className="bg-[#1a1617] border border-[#2d2728] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] w-[291px] p-px">
-              <div className="flex flex-col items-center justify-center h-[68px]">
-                <p className="text-[16px] leading-[25.6px] text-[#7a7577]">Nuove attività in arrivo</p>
-                <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] text-center w-[266px]">
-                  Stiamo preparando nuove sfide e minigames
-                </p>
-              </div>
-            </div>
+                  </div>
+                </Card>
+              );
+            })}
           </div>
-        </div>
+        </section>
+
+        <Card className="text-center">
+          <p className="text-sm text-[#7a7577]">Nuove attività in arrivo</p>
+          <p className="text-sm text-[#b8b2b3]">
+            Stiamo preparando nuove sfide e minigames
+          </p>
+        </Card>
       </div>
     </div>
   );

--- a/apps/mobile/src/components/screens/Carriera.tsx
+++ b/apps/mobile/src/components/screens/Carriera.tsx
@@ -64,7 +64,7 @@ export function Carriera({
           <div className="max-w-md mx-auto">
             <button
               onClick={onBack}
-              className="flex items-center gap-2 text-[#f4bf4f] mb-6 hover:text-[#e6a23c] transition-colors"
+              className="flex items-center gap-2 rounded-md px-2 py-[10px] text-[#f4bf4f] mb-6 hover:text-[#e6a23c] transition-colors"
             >
               <ArrowLeft size={20} />
               <span>Indietro</span>

--- a/apps/mobile/src/components/screens/EventConfirmation.tsx
+++ b/apps/mobile/src/components/screens/EventConfirmation.tsx
@@ -39,7 +39,7 @@ export function EventConfirmation({ event, roles, onConfirm, onCancel }: EventCo
 
   if (isSuccess) {
     return (
-      <div className="min-h-screen bg-[#0f0d0e] flex items-center justify-center p-6">
+      <div className="min-h-screen app-gradient flex items-center justify-center p-6">
         <div className="max-w-md w-full text-center animate-fade-in">
           <div className="w-24 h-24 bg-gradient-to-br from-[#52c41a] to-[#389e0d] rounded-full flex items-center justify-center mx-auto mb-6 animate-pulse">
             <CheckCircle2 className="text-white" size={48} />
@@ -85,7 +85,7 @@ export function EventConfirmation({ event, roles, onConfirm, onCancel }: EventCo
   }
 
   return (
-    <div className="min-h-screen bg-[#0f0d0e] pb-24">
+    <div className="min-h-screen app-gradient pb-24">
       <div className="bg-gradient-to-b from-[#2d0a0f] to-[#0f0d0e] p-6 pb-8">
         <div className="max-w-md mx-auto">
           <h2 className="text-white mb-2">Conferma turno</h2>

--- a/apps/mobile/src/components/screens/EventConfirmation.tsx
+++ b/apps/mobile/src/components/screens/EventConfirmation.tsx
@@ -7,20 +7,19 @@ import { GameEvent, Role, RoleId, computeTurnRewards } from '../../state/store';
 
 interface EventConfirmationProps {
   event?: GameEvent;
-  roles: Role[];
-  onConfirm: (roleId: string) => void;
+  role?: Role;
+  onConfirm: () => void;
   onCancel: () => void;
 }
 
-export function EventConfirmation({ event, roles, onConfirm, onCancel }: EventConfirmationProps) {
-  const [selectedRole, setSelectedRole] = useState<string>(roles[0]?.id ?? '');
+export function EventConfirmation({ event, role, onConfirm, onCancel }: EventConfirmationProps) {
   const [isSuccess, setIsSuccess] = useState(false);
+  const roleId = (role?.id ?? 'attore') as RoleId;
 
   const resolvedRewards = useMemo(() => {
     if (!event) return { xp: 0, reputation: 0, cachet: 0 };
-    const roleId = (selectedRole as RoleId) || roles[0]?.id || 'attore';
     return computeTurnRewards(event, roleId);
-  }, [event, selectedRole, roles]);
+  }, [event, roleId]);
 
   const resolvedEvent = event ?? {
     name: 'Evento non trovato',
@@ -33,7 +32,7 @@ export function EventConfirmation({ event, roles, onConfirm, onCancel }: EventCo
   const handleConfirm = () => {
     setIsSuccess(true);
     setTimeout(() => {
-      onConfirm(selectedRole || roles[0]?.id || '');
+      onConfirm();
     }, 1500);
   };
 
@@ -118,24 +117,17 @@ export function EventConfirmation({ event, roles, onConfirm, onCancel }: EventCo
           </div>
         </Card>
 
-        <div>
-          <label className="block text-white mb-3">Con quale ruolo vuoi registrare questo turno?</label>
-
-          <div className="space-y-2">
-            {roles.map((role) => (
-              <button
-                key={role.id}
-                onClick={() => setSelectedRole(role.id)}
-                className={`w-full p-4 rounded-xl border-2 transition-all text-left ${
-                  selectedRole === role.id ? 'border-[#f4bf4f] bg-[#f4bf4f]/10' : 'border-[#2d2728] bg-[#1a1617] hover:border-[#7a7577]'
-                }`}
-              >
-                <span className={selectedRole === role.id ? 'text-[#f4bf4f]' : 'text-white'}>{role.name}</span>
-                <p className="text-sm text-[#7a7577]">{role.focus}</p>
-              </button>
-            ))}
+        <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20]">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h4 className="text-white mb-1">Ruolo registrato</h4>
+              <p className="text-sm text-[#b8b2b3]">{role?.focus ?? 'Selezionato in fase di registrazione'}</p>
+            </div>
+            <Badge variant="outline" size="md">
+              {role?.name ?? 'Ruolo'}
+            </Badge>
           </div>
-        </div>
+        </Card>
 
         <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20]">
           <h4 className="text-[#f4bf4f] mb-4">Ricompense previste</h4>

--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -6,9 +6,10 @@ import { Tag } from '../ui/Tag';
 import { MetricTile } from '../ui/MetricTile';
 import { Skeleton } from '../ui/skeleton';
 import { Button } from '../ui/Button';
-import { QrCode, Play, Calendar, TrendingUp, Award, ChevronRight, MapPin, Clock, Navigation, CalendarPlus, X, Bell } from 'lucide-react';
+import { Play, Calendar, TrendingUp, Award, ChevronRight, MapPin, Clock, Navigation, CalendarPlus, X, Bell } from 'lucide-react';
 import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover';
 import { GameEvent } from '../../state/store';
+import { ScanQRCard } from '../ScanQRCard';
 
 type EventState = 'loading' | 'error' | 'empty' | 'ready';
 
@@ -113,27 +114,7 @@ export function Home({
           </div>
         </header>
 
-        <Card className="bg-gradient-to-r from-[#8c1c38] to-[#a82847] border border-[#f4bf4f]/30" style={{ marginTop: '20px' }}>
-          <div className="flex items-center gap-3">
-            <div className="flex-shrink-0 w-12 h-12 bg-[#f4bf4f] rounded-xl flex items-center justify-center" style={{ margin: '5px 0 5px 5px' }}>
-              <QrCode className="text-[#2d0a0f]" size={24} />
-            </div>
-            <div className="flex-1">
-              <button
-                onClick={onScanQR}
-                className="w-full text-left text-white hover:opacity-90 transition"
-              >
-                <div className="flex items-center justify-between gap-2">
-                  <div>
-                    <p className="font-semibold text-base">Scansiona QR</p>
-                    <p className="text-sm text-[#f4bf4f]/90">Registra un turno dal biglietto</p>
-                  </div>
-                  <ChevronRight className="text-white" size={22} />
-                </div>
-              </button>
-            </div>
-          </div>
-        </Card>
+        <ScanQRCard onScanQR={onScanQR} className="mt-5" />
 
         <section className="space-y-3">
           <div className="flex items-center justify-between">

--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -62,7 +62,7 @@ export function Home({
           <div className="absolute top-0 right-0">
             <Popover>
               <PopoverTrigger asChild>
-                <button className="p-2 rounded-lg hover:bg-[#241f20] transition">
+                <button className="flex items-center justify-center size-[44px] rounded-lg hover:bg-[#241f20] transition">
                   <Bell size={20} className="text-[#f4bf4f]" />
                 </button>
               </PopoverTrigger>
@@ -141,7 +141,7 @@ export function Home({
             {eventState === 'ready' ? (
               <button
                 onClick={onViewTurni}
-                className="text-sm text-[#f4bf4f] hover:text-[#e6a23c] px-2 py-1 rounded-lg"
+                className="text-sm text-[#f4bf4f] hover:text-[#e6a23c] px-3 py-[12px] rounded-lg"
                 style={{ margin: '20px 0 5px' }}
               >
                 Dettagli
@@ -200,11 +200,11 @@ export function Home({
                   </div>
                 </div>
                 <div className="flex gap-2 pt-1">
-                  <Button variant="secondary" size="sm" className="flex-1 justify-center" onClick={onViewTurni} style={{ backgroundColor: '#a72847' }}>
+                  <Button variant="secondary" size="sm" className="flex-1 justify-center min-h-[44px]" onClick={onViewTurni} style={{ backgroundColor: '#a72847' }}>
                     <Navigation size={16} className="text-white" />
                     <div className="text-white">Naviga</div>
                   </Button>
-                  <Button variant="ghost" size="sm" className="flex-1 justify-center" onClick={onViewTurni}>
+                  <Button variant="ghost" size="sm" className="flex-1 justify-center min-h-[44px]" onClick={onViewTurni}>
                     <CalendarPlus size={16} />
                     Aggiungi
                   </Button>
@@ -219,7 +219,7 @@ export function Home({
             <h3 className="text-white text-lg font-semibold" style={{ margin: '20px 0 5px' }}>Turni ATCL</h3>
             <button
               onClick={onViewTurni}
-              className="text-sm text-[#f4bf4f] hover:text-[#e6a23c] px-2 py-1 rounded-lg"
+              className="text-sm text-[#f4bf4f] hover:text-[#e6a23c] px-3 py-[12px] rounded-lg"
               style={{ marginTop: '20px' }}
             >
               Vedi tutti

--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -225,7 +225,7 @@ export function Home({
               Vedi tutti
             </button>
           </div>
-          <Card style={{ padding: '5px' }}>
+          <Card>
             {statsLoading ? (
               <div className="grid grid-cols-3 gap-3">
                 <Skeleton className="h-16 rounded-xl" />
@@ -244,7 +244,7 @@ export function Home({
 
         <section className="space-y-3">
           <h3 className="text-white text-lg font-semibold" style={{ margin: '20px 0 5px' }}>Attività simulate</h3>
-          <Card hoverable onClick={onViewActivities} style={{ marginBottom: '20px', padding: '5px' }}>
+          <Card hoverable onClick={onViewActivities} className="mb-5">
             <div className="flex items-center gap-4">
               <div className="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-xl flex items-center justify-center">
                 <Play className="text-[#f4bf4f]" size={24} />

--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -54,7 +54,7 @@ export function Home({
 
   return (
     <div
-      className="min-h-screen bg-[#0f0d0e] flex flex-col justify-center items-center"
+      className="min-h-screen app-gradient flex flex-col justify-center items-center"
       style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 96px)' }}
     >
       <div className="w-full max-w-md mx-auto px-6 pt-6 pb-8 space-y-6">

--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -161,9 +161,9 @@ export function Home({
             ) : (
               <div className="space-y-2">
                 <div className="flex items-start gap-3" style={{ marginBottom: '20px' }}>
-                  <div className="flex-shrink-0 bg-[#241f20] rounded-lg flex flex-col items-center justify-center" style={{ width: '70px', height: '70px' }}>
-                    <Calendar className="text-[#f4bf4f]" size={50} />
-                    <p className="text-xs text-[#f4bf4f] mt-1">{upcomingEvent?.date?.slice(0, 6)}</p>
+                  <div className="flex-shrink-0 bg-[#241f20] rounded-lg flex flex-col items-center justify-center w-[70px] h-[70px] gap-1">
+                    <Calendar className="text-[#f4bf4f] block" size={50} />
+                    <p className="text-xs leading-none text-[#f4bf4f] !m-0">{upcomingEvent?.date?.slice(0, 6)}</p>
                   </div>
                   <div className="flex-1 min-w-0">
                     <h4 className="text-white text-lg leading-tight line-clamp-2">{upcomingEvent?.name}</h4>

--- a/apps/mobile/src/components/screens/Login.tsx
+++ b/apps/mobile/src/components/screens/Login.tsx
@@ -38,7 +38,7 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword }: LoginProp
         <button
           type="button"
           onClick={onBack}
-          className="flex items-center justify-center size-[40px] text-[#f4bf4f]"
+          className="flex items-center justify-center size-[44px] text-[#f4bf4f]"
           aria-label="Indietro"
         >
           <ArrowLeft size={24} />
@@ -97,7 +97,7 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword }: LoginProp
             <button
               type="button"
               onClick={onForgotPassword}
-              className="text-[16px] leading-[25.6px] text-[#f4bf4f] self-start"
+              className="self-start rounded-md px-2 py-[10px] text-[16px] leading-[25.6px] text-[#f4bf4f]"
             >
               Password dimenticata?
             </button>
@@ -120,7 +120,7 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword }: LoginProp
           <button
             type="button"
             onClick={onSignup}
-            className="text-[16px] leading-[25.6px] text-[#f4bf4f]"
+            className="inline-flex items-center justify-center rounded-md px-2 py-[10px] text-[16px] leading-[25.6px] text-[#f4bf4f]"
           >
             Registrati
           </button>

--- a/apps/mobile/src/components/screens/Login.tsx
+++ b/apps/mobile/src/components/screens/Login.tsx
@@ -53,8 +53,8 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword }: LoginProp
           </p>
         </div>
 
-        <form onSubmit={handleSubmit} className="mt-8 flex w-full max-w-[300px] flex-col gap-5 self-center">
-          <div className="flex flex-col gap-2">
+        <form onSubmit={handleSubmit} className="mt-8 flex w-full max-w-[300px] flex-col gap-6 mx-auto">
+          <div className="flex flex-col gap-2 w-full">
             <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
               Email
             </label>
@@ -75,7 +75,7 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword }: LoginProp
             </div>
           </div>
 
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2 w-full">
             <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
               Password
             </label>
@@ -97,7 +97,7 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword }: LoginProp
             <button
               type="button"
               onClick={onForgotPassword}
-              className="self-start rounded-md px-2 py-[10px] text-[16px] leading-[25.6px] text-[#f4bf4f]"
+              className="self-start rounded-md px-2 py-[10px] mt-2 text-[16px] leading-[25.6px] text-[#f4bf4f]"
             >
               Password dimenticata?
             </button>

--- a/apps/mobile/src/components/screens/Login.tsx
+++ b/apps/mobile/src/components/screens/Login.tsx
@@ -32,19 +32,19 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword }: LoginProp
     <Screen
       withBottomNavPadding={false}
       className="relative items-start justify-start"
-      contentClassName="relative w-full max-w-[393px] h-[852px] px-0 pt-0 pb-0 space-y-0"
+      contentClassName="relative w-full max-w-[393px] flex-1 px-6 pt-8 pb-[calc(env(safe-area-inset-bottom,_0px)+32px)] space-y-0 box-border"
     >
-      <div className="relative w-full h-full">
+      <div className="flex h-full flex-col">
         <button
           type="button"
           onClick={onBack}
-          className="absolute content-stretch flex items-center left-[27px] p-0 size-[40px] top-[56px] text-[#f4bf4f] z-10"
+          className="flex items-center justify-center size-[40px] text-[#f4bf4f]"
           aria-label="Indietro"
         >
           <ArrowLeft size={24} />
         </button>
 
-        <div className="absolute flex flex-col h-[57px] items-start left-[calc(50%+0.5px)] top-[calc(50%-279.5px)] translate-x-[-50%] translate-y-[-50%] w-[222px]">
+        <div className="mt-4 flex flex-col items-start gap-1">
           <p className="text-[24px] leading-[31.2px] font-bold tracking-[-0.24px] text-[#f5f5f5]">
             Accedi
           </p>
@@ -53,15 +53,15 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword }: LoginProp
           </p>
         </div>
 
-        <form onSubmit={handleSubmit} className="absolute inset-0 z-0">
-          <div className="absolute flex flex-col h-[52px] items-start left-[calc(50%+0.5px)] top-[calc(50%-74px)] translate-x-[-50%] translate-y-[-50%] w-[300px]">
-            <label className="h-[24px] text-[16px] leading-[24px] text-[#b8b2b3] relative -top-[2px]">
+        <form onSubmit={handleSubmit} className="mt-8 flex w-full max-w-[300px] flex-col gap-5 self-center">
+          <div className="flex flex-col gap-2">
+            <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
               Email
             </label>
             <div
               className={`bg-[#241f20] border-2 ${
                 errors.email ? 'border-[#ff4d4f]' : 'border-[#2d2728]'
-              } rounded-[10px] flex h-[28px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
+              } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
             >
               <input
                 type="email"
@@ -75,14 +75,14 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword }: LoginProp
             </div>
           </div>
 
-          <div className="absolute flex flex-col h-[78px] items-start left-[calc(50%+0.5px)] top-[calc(50%+40px)] translate-x-[-50%] translate-y-[-50%] w-[300px]">
-            <label className="h-[24px] text-[16px] leading-[24px] text-[#b8b2b3] relative -top-[2px]">
+          <div className="flex flex-col gap-2">
+            <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
               Password
             </label>
             <div
               className={`bg-[#241f20] border-2 ${
                 errors.password ? 'border-[#ff4d4f]' : 'border-[#2d2728]'
-              } rounded-[10px] flex h-[28px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
+              } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
             >
               <input
                 type="password"
@@ -97,7 +97,7 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword }: LoginProp
             <button
               type="button"
               onClick={onForgotPassword}
-              className="pt-[10px] text-[16px] leading-[25.6px] text-[#f4bf4f]"
+              className="text-[16px] leading-[25.6px] text-[#f4bf4f] self-start"
             >
               Password dimenticata?
             </button>
@@ -105,7 +105,7 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword }: LoginProp
 
           <button
             type="submit"
-            className="absolute bg-gradient-to-b from-[#8c1c38] to-[#a82847] h-[28px] left-[calc(50%+0.5px)] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] top-[calc(50%+273px)] translate-x-[-50%] translate-y-[-50%] w-[300px]"
+            className="bg-gradient-to-b from-[#8c1c38] to-[#a82847] h-[44px] w-full rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)]"
           >
             <span className="block text-[18px] leading-[28px] text-center text-white">
               Accedi
@@ -113,7 +113,7 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword }: LoginProp
           </button>
         </form>
 
-        <div className="absolute bottom-[47px] h-[75px] left-1/2 translate-x-[-50%] w-[393px] text-center">
+        <div className="mt-auto pt-6 text-center">
           <p className="text-[16px] leading-[25.6px] text-[#b8b2b3]">
             Non hai un account?
           </p>

--- a/apps/mobile/src/components/screens/Profilo.tsx
+++ b/apps/mobile/src/components/screens/Profilo.tsx
@@ -150,9 +150,11 @@ export function Profilo({
               </div>
             </div>
             <div className="flex items-center gap-[8px]">
-              <span className="bg-gradient-to-b from-[#e6a23c] to-[#f4bf4f] rounded-full size-[20px] flex items-center justify-center text-[12px] leading-[16px] text-[#0f0d0e]">
-                {newAchievementsCount}
-              </span>
+              {newAchievementsCount > 0 ? (
+                <span className="bg-gradient-to-b from-[#e6a23c] to-[#f4bf4f] rounded-full size-[20px] flex items-center justify-center text-[12px] leading-[16px] text-[#0f0d0e]">
+                  {newAchievementsCount}
+                </span>
+              ) : null}
               <ChevronRight className="text-[#7a7577]" size={20} />
             </div>
           </button>

--- a/apps/mobile/src/components/screens/Profilo.tsx
+++ b/apps/mobile/src/components/screens/Profilo.tsx
@@ -1,5 +1,5 @@
 ﻿import React from 'react';
-import { Award, BarChart3, ChevronRight, LogOut, Settings, User } from 'lucide-react';
+import { Award, BarChart3, ChevronRight, LogOut, Settings, Theater, User } from 'lucide-react';
 import { ProgressBar } from '../ui/ProgressBar';
 import { achievements } from '../../data/achievements_data';
 

--- a/apps/mobile/src/components/screens/Profilo.tsx
+++ b/apps/mobile/src/components/screens/Profilo.tsx
@@ -140,10 +140,10 @@ export function Profilo({
                 <Award className="text-[#0f0d0e]" size={22} />
               </div>
               <div className="flex flex-col items-start">
-                <p className="text-[18px] leading-[25.2px] font-semibold text-white">
+                <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">
                   Titoli ottenuti
                 </p>
-                <p className="text-[14px] leading-[20px] text-[#b8b2b3]">
+                <p className="text-[14px] leading-[20px] text-[#b8b2b3] !m-0">
                   {achievements.length} badge sbloccati
                 </p>
               </div>
@@ -164,10 +164,10 @@ export function Profilo({
             <div className="flex items-center gap-[12px]">
               <Settings className="text-[#f4bf4f]" size={24} />
               <div>
-                <p className="text-[18px] leading-[25.2px] font-semibold text-white">
+                <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">
                   Gestisci account
                 </p>
-                <p className="text-[16px] leading-[25.6px] text-[#b8b2b3]">
+                <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">
                   Impostazioni e privacy
                 </p>
               </div>

--- a/apps/mobile/src/components/screens/Profilo.tsx
+++ b/apps/mobile/src/components/screens/Profilo.tsx
@@ -36,7 +36,7 @@ export function Profilo({
   onLogout
 }: ProfiloProps) {
   const safeXpTotal = Math.max(xpTotal, 1);
-  const roleLabel = userRole.replace(/\s*\/\s*/g, '/');
+  const roleLabel = (userRole ?? 'Ruolo').replace(/\s*\/\s*/g, '/');
 
   return (
     <div

--- a/apps/mobile/src/components/screens/Profilo.tsx
+++ b/apps/mobile/src/components/screens/Profilo.tsx
@@ -43,7 +43,7 @@ export function Profilo({
 
   return (
     <div
-      className="min-h-screen bg-[#0f0d0e]"
+      className="min-h-screen app-gradient"
       style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 100px)' }}
     >
       <div className="w-full max-w-[393px] mx-auto pt-[36px] pb-0 flex flex-col gap-[20px]">

--- a/apps/mobile/src/components/screens/Profilo.tsx
+++ b/apps/mobile/src/components/screens/Profilo.tsx
@@ -1,6 +1,7 @@
 ﻿import React from 'react';
-import { Award, BarChart3, ChevronRight, LogOut, MapPin, Settings, Theater, User } from 'lucide-react';
+import { Award, BarChart3, ChevronRight, LogOut, Settings, User } from 'lucide-react';
 import { ProgressBar } from '../ui/ProgressBar';
+import { achievements } from '../../data/achievements_data';
 
 interface ProfiloProps {
   userName: string;
@@ -11,6 +12,7 @@ interface ProfiloProps {
   xpSulCampo: number;
   reputationGlobal: number;
   onViewCarriera: () => void;
+  onViewTitoli: () => void;
   onSettings: () => void;
   onLogout: () => void;
 }
@@ -21,12 +23,6 @@ const theatreReputation = [
   { name: 'Teatro Quirino', reputation: 68 }
 ];
 
-const achievements = [
-  { id: '1', title: 'Ha lavorato in 3 teatri diversi', icon: MapPin },
-  { id: '2', title: 'Prima stagione completata', icon: Award },
-  { id: '3', title: '10 turni registrati', icon: Theater }
-];
-
 export function Profilo({
   userName,
   userRole,
@@ -35,6 +31,7 @@ export function Profilo({
   xpSulCampo,
   reputationGlobal,
   onViewCarriera,
+  onViewTitoli,
   onSettings,
   onLogout
 }: ProfiloProps) {
@@ -133,31 +130,31 @@ export function Profilo({
             </div>
           </div>
 
-          <div className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] px-[5px] py-[2px] flex flex-col gap-[12px]">
-            <div className="flex items-center justify-between">
-              <p className="text-[18px] leading-[25.2px] font-semibold text-white">
-                Titoli ottenuti
-              </p>
-              <span className="bg-gradient-to-b from-[#e6a23c] to-[#f4bf4f] rounded-full size-[16px] flex items-center justify-center text-[12px] leading-[16px] text-[#0f0d0e]">
+          <button
+            type="button"
+            onClick={onViewTitoli}
+            className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] px-[12px] py-[12px] flex items-center justify-between"
+          >
+            <div className="flex items-center gap-[12px]">
+              <div className="bg-gradient-to-b from-[#e6a23c] to-[#f4bf4f] rounded-[12px] size-[44px] flex items-center justify-center">
+                <Award className="text-[#0f0d0e]" size={22} />
+              </div>
+              <div className="flex flex-col items-start">
+                <p className="text-[18px] leading-[25.2px] font-semibold text-white">
+                  Titoli ottenuti
+                </p>
+                <p className="text-[14px] leading-[20px] text-[#b8b2b3]">
+                  {achievements.length} badge sbloccati
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center gap-[8px]">
+              <span className="bg-gradient-to-b from-[#e6a23c] to-[#f4bf4f] rounded-full size-[20px] flex items-center justify-center text-[12px] leading-[16px] text-[#0f0d0e]">
                 {achievements.length}
               </span>
+              <ChevronRight className="text-[#7a7577]" size={20} />
             </div>
-            <div className="flex flex-col gap-[12px]">
-              {achievements.map((achievement) => {
-                const Icon = achievement.icon;
-                return (
-                  <div key={achievement.id} className="bg-[#241f20] rounded-[10px] h-[40px] flex items-center gap-[12px] px-[8px]">
-                    <div className="bg-gradient-to-b from-[#e6a23c] to-[#f4bf4f] rounded-[10px] size-[40px] flex items-center justify-center">
-                      <Icon className="text-[#0f0d0e]" size={20} />
-                    </div>
-                    <span className="text-[16px] leading-[24px] text-[#b8b2b3]">
-                      {achievement.title}
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
+          </button>
 
           <button
             type="button"

--- a/apps/mobile/src/components/screens/Profilo.tsx
+++ b/apps/mobile/src/components/screens/Profilo.tsx
@@ -181,7 +181,7 @@ export function Profilo({
           <button
             type="button"
             onClick={onLogout}
-            className="flex items-center justify-center gap-[6px] h-[28px] text-[18px] leading-[28px] text-[#ff4d4f]"
+            className="flex items-center justify-center gap-[6px] h-[44px] rounded-md text-[18px] leading-[28px] text-[#ff4d4f]"
           >
             <LogOut size={20} />
             Esci

--- a/apps/mobile/src/components/screens/Profilo.tsx
+++ b/apps/mobile/src/components/screens/Profilo.tsx
@@ -37,6 +37,7 @@ export function Profilo({
 }: ProfiloProps) {
   const safeXpTotal = Math.max(xpTotal, 1);
   const roleLabel = (userRole ?? 'Ruolo').replace(/\s*\/\s*/g, '/');
+  const newAchievementsCount = achievements.filter((achievement) => achievement.isNew).length;
 
   return (
     <div
@@ -150,7 +151,7 @@ export function Profilo({
             </div>
             <div className="flex items-center gap-[8px]">
               <span className="bg-gradient-to-b from-[#e6a23c] to-[#f4bf4f] rounded-full size-[20px] flex items-center justify-center text-[12px] leading-[16px] text-[#0f0d0e]">
-                {achievements.length}
+                {newAchievementsCount}
               </span>
               <ChevronRight className="text-[#7a7577]" size={20} />
             </div>

--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -27,7 +27,7 @@ export function QRScanner({ onClose, onScanSuccess }: QRScannerProps) {
   };
   
   return (
-    <div className="fixed inset-0 bg-[#0f0d0e] z-50 flex flex-col">
+    <div className="fixed inset-0 app-gradient z-50 flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between p-4 bg-[#1a1617]">
         <h3 className="text-white">Scansiona QR</h3>

--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -59,7 +59,7 @@ export function QRScanner({ onClose, onScanSuccess }: QRScannerProps) {
                 </div>
                 
                 {/* QR Icon */}
-                <div className="absolute inset-0 flex items-center justify-center opacity-30">
+                <div className="absolute left-1/2 top-1/2 opacity-30 -translate-x-1/2 -translate-y-1/2">
                   <QrCode className="text-[#f4bf4f]" size={120} />
                 </div>
               </div>

--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -31,9 +31,9 @@ export function QRScanner({ onClose, onScanSuccess }: QRScannerProps) {
       {/* Header */}
       <div className="flex items-center justify-between p-4 bg-[#1a1617]">
         <h3 className="text-white">Scansiona QR</h3>
-        <button 
+        <button
           onClick={onClose}
-          className="p-2 hover:bg-[#241f20] rounded-lg transition-colors"
+          className="flex items-center justify-center size-[44px] hover:bg-[#241f20] rounded-lg transition-colors"
         >
           <X className="text-[#f4bf4f]" size={24} />
         </button>
@@ -85,9 +85,9 @@ export function QRScanner({ onClose, onScanSuccess }: QRScannerProps) {
                   Simula scansione (Demo)
                 </Button>
                 
-                <button 
+                <button
                   onClick={() => setIsScanning(false)}
-                  className="text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
+                  className="inline-flex items-center justify-center rounded-md px-2 py-[10px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
                 >
                   Inserisci codice manualmente
                 </button>
@@ -120,10 +120,10 @@ export function QRScanner({ onClose, onScanSuccess }: QRScannerProps) {
                 Conferma codice
               </Button>
               
-              <button 
+              <button
                 type="button"
                 onClick={() => setIsScanning(true)}
-                className="w-full text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
+                className="w-full rounded-md py-[10px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
               >
                 Torna alla scansione QR
               </button>

--- a/apps/mobile/src/components/screens/RoleSelection.tsx
+++ b/apps/mobile/src/components/screens/RoleSelection.tsx
@@ -44,7 +44,7 @@ export function RoleSelection({ roles, onComplete }: RoleSelectionProps) {
           {roles.map((role) => {
             const Icon = roleIcons[role.id] ?? Users;
             return (
-              <Card key={role.id} hoverable onClick={() => handleRoleSelect(role)} className="flex items-center gap-4 p-5">
+              <Card key={role.id} hoverable onClick={() => handleRoleSelect(role)} className="flex items-center gap-4">
                 <div className="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-xl flex items-center justify-center">
                   <Icon className="text-[#f4bf4f]" size={24} />
                 </div>

--- a/apps/mobile/src/components/screens/RoleSelection.tsx
+++ b/apps/mobile/src/components/screens/RoleSelection.tsx
@@ -72,6 +72,7 @@ export function RoleSelection({ roles, onComplete }: RoleSelectionProps) {
         header={
           <ScreenHeader>
             <button
+              type="button"
               onClick={() => setStep(1)}
               className="flex items-center justify-center size-[44px] text-[#f4bf4f]"
               aria-label="Indietro"

--- a/apps/mobile/src/components/screens/RoleSelection.tsx
+++ b/apps/mobile/src/components/screens/RoleSelection.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
-import { Users, Lightbulb, Volume2, Package, Clipboard, ChevronRight, Star } from 'lucide-react';
+import { Users, Lightbulb, Volume2, Package, Clipboard, ChevronRight, Star, ArrowLeft } from 'lucide-react';
 import { Role } from '../../state/store';
 import { Screen, ScreenHeader } from '../ui/Screen';
 
@@ -73,10 +73,10 @@ export function RoleSelection({ roles, onComplete }: RoleSelectionProps) {
           <ScreenHeader>
             <button
               onClick={() => setStep(1)}
-              className="flex items-center gap-2 rounded-md px-2 py-[10px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
+              className="flex items-center justify-center size-[44px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
+              aria-label="Cambia ruolo"
             >
-              <ChevronRight size={20} className="rotate-180" />
-              <span>Cambia ruolo</span>
+              <ArrowLeft size={24} />
             </button>
           </ScreenHeader>
         }

--- a/apps/mobile/src/components/screens/RoleSelection.tsx
+++ b/apps/mobile/src/components/screens/RoleSelection.tsx
@@ -73,8 +73,8 @@ export function RoleSelection({ roles, onComplete }: RoleSelectionProps) {
           <ScreenHeader>
             <button
               onClick={() => setStep(1)}
-              className="flex items-center justify-center size-[44px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
-              aria-label="Cambia ruolo"
+              className="flex items-center justify-center size-[44px] text-[#f4bf4f]"
+              aria-label="Indietro"
             >
               <ArrowLeft size={24} />
             </button>

--- a/apps/mobile/src/components/screens/RoleSelection.tsx
+++ b/apps/mobile/src/components/screens/RoleSelection.tsx
@@ -69,53 +69,54 @@ export function RoleSelection({ roles, onComplete }: RoleSelectionProps) {
     return (
       <Screen
         withBottomNavPadding={false}
-        header={
-          <ScreenHeader>
-            <button
-              type="button"
-              onClick={() => setStep(1)}
-              className="flex items-center justify-center size-[44px] text-[#f4bf4f]"
-              aria-label="Indietro"
-            >
-              <ArrowLeft size={24} />
-            </button>
-          </ScreenHeader>
-        }
+        className="relative items-start justify-start"
+        contentClassName="relative w-full max-w-[393px] flex-1 px-6 pt-8 pb-[calc(env(safe-area-inset-bottom,_0px)+32px)] space-y-0 box-border"
       >
-        <div className="text-center mb-4">
-          <div className="inline-flex items-center justify-center w-20 h-20 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-2xl mb-4 shadow-lg">
-            <Icon className="text-[#f4bf4f]" size={40} />
+        <div className="flex h-full flex-col">
+          <button
+            type="button"
+            onClick={() => setStep(1)}
+            className="flex items-center justify-center size-[44px] text-[#f4bf4f]"
+            aria-label="Indietro"
+          >
+            <ArrowLeft size={24} />
+          </button>
+
+          <div className="mt-4 text-center mb-4">
+            <div className="inline-flex items-center justify-center w-20 h-20 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-2xl mb-4 shadow-lg">
+              <Icon className="text-[#f4bf4f]" size={40} />
+            </div>
+            <h2 className="mb-3">{selectedRole.name}</h2>
+            <p className="text-[#b8b2b3] px-4">{selectedRole.focus}</p>
           </div>
-          <h2 className="mb-3">{selectedRole.name}</h2>
-          <p className="text-[#b8b2b3] px-4">{selectedRole.focus}</p>
+
+          <Card className="mb-4">
+            <h4 className="mb-4 text-[#f4bf4f]">Caratteristiche principali</h4>
+
+            <div className="space-y-4">
+              {Object.entries(selectedRole.stats).map(([key, value]) => (
+                <div key={key}>
+                  <div className="flex justify-between mb-2">
+                    <span className="text-[#b8b2b3] capitalize">
+                      {key === 'presence' ? 'Presenza scenica' : key === 'precision' ? 'Precisione' : key === 'leadership' ? 'Leadership' : 'Creatività'}
+                    </span>
+                    <span className="text-white">{value}/100</span>
+                  </div>
+                  <div className="h-2 bg-[#241f20] rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-gradient-to-r from-[#e6a23c] to-[#f4bf4f] rounded-full transition-all duration-500"
+                      style={{ width: `${value}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Card>
+
+          <Button variant="primary" size="lg" fullWidth onClick={() => onComplete(selectedRole)}>
+            Conferma ruolo e continua
+          </Button>
         </div>
-
-        <Card className="mb-4">
-          <h4 className="mb-4 text-[#f4bf4f]">Caratteristiche principali</h4>
-
-          <div className="space-y-4">
-            {Object.entries(selectedRole.stats).map(([key, value]) => (
-              <div key={key}>
-                <div className="flex justify-between mb-2">
-                  <span className="text-[#b8b2b3] capitalize">
-                    {key === 'presence' ? 'Presenza scenica' : key === 'precision' ? 'Precisione' : key === 'leadership' ? 'Leadership' : 'Creatività'}
-                  </span>
-                  <span className="text-white">{value}/100</span>
-                </div>
-                <div className="h-2 bg-[#241f20] rounded-full overflow-hidden">
-                  <div
-                    className="h-full bg-gradient-to-r from-[#e6a23c] to-[#f4bf4f] rounded-full transition-all duration-500"
-                    style={{ width: `${value}%` }}
-                  />
-                </div>
-              </div>
-            ))}
-          </div>
-        </Card>
-
-        <Button variant="primary" size="lg" fullWidth onClick={() => onComplete(selectedRole)}>
-          Conferma ruolo e continua
-        </Button>
       </Screen>
     );
   }

--- a/apps/mobile/src/components/screens/RoleSelection.tsx
+++ b/apps/mobile/src/components/screens/RoleSelection.tsx
@@ -73,7 +73,7 @@ export function RoleSelection({ roles, onComplete }: RoleSelectionProps) {
           <ScreenHeader>
             <button
               onClick={() => setStep(1)}
-              className="flex items-center gap-2 text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
+              className="flex items-center gap-2 rounded-md px-2 py-[10px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
             >
               <ChevronRight size={20} className="rotate-180" />
               <span>Cambia ruolo</span>

--- a/apps/mobile/src/components/screens/RoleSelection.tsx
+++ b/apps/mobile/src/components/screens/RoleSelection.tsx
@@ -30,7 +30,7 @@ export function RoleSelection({ roles, onComplete }: RoleSelectionProps) {
   if (step === 1) {
     return (
       <Screen withBottomNavPadding={false}>
-        <ScreenHeader>
+        <ScreenHeader gradient={false}>
           <div className="text-center">
             <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-full mb-4">
               <Star className="text-[#f4bf4f]" size={32} />

--- a/apps/mobile/src/components/screens/Signup.tsx
+++ b/apps/mobile/src/components/screens/Signup.tsx
@@ -58,8 +58,8 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
           </p>
         </div>
 
-        <form onSubmit={handleSubmit} className="mt-8 flex w-full max-w-[300px] flex-col gap-5 self-center">
-          <div className="flex flex-col gap-2">
+        <form onSubmit={handleSubmit} className="mt-8 flex w-full max-w-[300px] flex-col gap-6 mx-auto">
+          <div className="flex flex-col gap-2 w-full">
             <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
               Nome visualizzato
             </label>
@@ -80,7 +80,7 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
             </div>
           </div>
 
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2 w-full">
             <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
               Email
             </label>
@@ -101,7 +101,7 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
             </div>
           </div>
 
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2 w-full">
             <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
               Password
             </label>
@@ -120,10 +120,10 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
                 className="w-full h-full bg-transparent px-[10px] py-0 text-[16px] leading-[28px] text-[#f5f5f5] placeholder:text-[#7a7577] focus:outline-none"
               />
             </div>
-            <p className="text-[16px] leading-[25.6px] text-[#7a7577]">Almeno 8 caratteri</p>
+            <p className="mt-2 text-[16px] leading-[25.6px] text-[#7a7577]">Almeno 8 caratteri</p>
           </div>
 
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2 w-full">
             <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
               Conferma password
             </label>

--- a/apps/mobile/src/components/screens/Signup.tsx
+++ b/apps/mobile/src/components/screens/Signup.tsx
@@ -37,19 +37,19 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
     <Screen
       withBottomNavPadding={false}
       className="relative items-start justify-start"
-      contentClassName="relative w-full max-w-[393px] h-[852px] px-0 pt-0 pb-0 space-y-0"
+      contentClassName="relative w-full max-w-[393px] flex-1 px-6 pt-8 pb-[calc(env(safe-area-inset-bottom,_0px)+32px)] space-y-0 box-border"
     >
-      <div className="relative w-full h-full">
+      <div className="flex h-full flex-col">
         <button
           type="button"
           onClick={onBack}
-          className="absolute content-stretch flex items-center left-[27px] p-0 size-[40px] top-[56px] text-[#f4bf4f] z-10"
+          className="flex items-center justify-center size-[40px] text-[#f4bf4f]"
           aria-label="Indietro"
         >
           <ArrowLeft size={24} />
         </button>
 
-        <div className="absolute flex flex-col h-[57px] items-start left-[calc(50%+0.5px)] top-[calc(50%-279.5px)] translate-x-[-50%] translate-y-[-50%] w-[222px]">
+        <div className="mt-4 flex flex-col items-start gap-1">
           <p className="text-[24px] leading-[31.2px] font-bold tracking-[-0.24px] text-[#f5f5f5]">
             Crea il tuo account
           </p>
@@ -58,15 +58,15 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
           </p>
         </div>
 
-        <form onSubmit={handleSubmit} className="absolute inset-0 z-0">
-          <div className="absolute flex flex-col h-[52px] items-start left-[calc(50%+0.5px)] top-[calc(50%-203.5px)] translate-x-[-50%] translate-y-[-50%] w-[300px]">
-            <label className="h-[24px] text-[16px] leading-[24px] text-[#b8b2b3] relative -top-[2px]">
+        <form onSubmit={handleSubmit} className="mt-8 flex w-full max-w-[300px] flex-col gap-5 self-center">
+          <div className="flex flex-col gap-2">
+            <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
               Nome visualizzato
             </label>
             <div
               className={`bg-[#241f20] border-2 ${
                 errors.name ? 'border-[#ff4d4f]' : 'border-[#2d2728]'
-              } rounded-[10px] flex h-[28px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
+              } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
             >
               <input
                 type="text"
@@ -80,14 +80,14 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
             </div>
           </div>
 
-          <div className="absolute flex flex-col h-[52px] items-start left-[calc(50%+0.5px)] top-[calc(50%-113.5px)] translate-x-[-50%] translate-y-[-50%] w-[300px]">
-            <label className="h-[24px] text-[16px] leading-[24px] text-[#b8b2b3] relative -top-[2px]">
+          <div className="flex flex-col gap-2">
+            <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
               Email
             </label>
             <div
               className={`bg-[#241f20] border-2 ${
                 errors.email ? 'border-[#ff4d4f]' : 'border-[#2d2728]'
-              } rounded-[10px] flex h-[28px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
+              } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
             >
               <input
                 type="email"
@@ -101,14 +101,14 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
             </div>
           </div>
 
-          <div className="absolute flex flex-col h-[78px] items-start left-[calc(50%+0.5px)] top-[calc(50%-0.5px)] translate-x-[-50%] translate-y-[-50%] w-[300px]">
-            <label className="h-[24px] text-[16px] leading-[24px] text-[#b8b2b3] relative -top-[2px]">
+          <div className="flex flex-col gap-2">
+            <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
               Password
             </label>
             <div
               className={`bg-[#241f20] border-2 ${
                 errors.password ? 'border-[#ff4d4f]' : 'border-[#2d2728]'
-              } rounded-[10px] flex h-[28px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
+              } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
             >
               <input
                 type="password"
@@ -120,17 +120,17 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
                 className="w-full h-full bg-transparent px-[10px] py-0 text-[16px] leading-[28px] text-[#f5f5f5] placeholder:text-[#7a7577] focus:outline-none"
               />
             </div>
-            <p className="text-[16px] leading-[25.6px] text-[#7a7577] relative -top-[2px]">Almeno 8 caratteri</p>
+            <p className="text-[16px] leading-[25.6px] text-[#7a7577]">Almeno 8 caratteri</p>
           </div>
 
-          <div className="absolute flex flex-col h-[52px] items-start left-[calc(50%+0.5px)] top-[calc(50%+114.5px)] translate-x-[-50%] translate-y-[-50%] w-[300px]">
-            <label className="h-[24px] text-[16px] leading-[24px] text-[#b8b2b3] relative -top-[2px]">
+          <div className="flex flex-col gap-2">
+            <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
               Conferma password
             </label>
             <div
               className={`bg-[#241f20] border-2 ${
                 errors.confirmPassword ? 'border-[#ff4d4f]' : 'border-[#2d2728]'
-              } rounded-[10px] flex h-[28px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
+              } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
             >
               <input
                 type="password"
@@ -144,7 +144,7 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
             </div>
           </div>
 
-          <div className="absolute flex gap-[12px] h-[20px] items-start left-[calc(50%+0.5px)] top-[calc(50%+176.5px)] translate-x-[-50%] translate-y-[-50%] w-[300px]">
+          <div className="flex gap-[12px] items-start">
             <input
               id="terms"
               type="checkbox"
@@ -160,7 +160,7 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
 
           <button
             type="submit"
-            className="absolute bg-gradient-to-b from-[#8c1c38] to-[#a82847] h-[28px] left-[calc(50%+0.5px)] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] top-[calc(50%+233.5px)] translate-x-[-50%] translate-y-[-50%] w-[300px]"
+            className="bg-gradient-to-b from-[#8c1c38] to-[#a82847] h-[44px] w-full rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)]"
           >
             <span className="block text-[18px] leading-[28px] text-center text-white">
               Registrati
@@ -168,7 +168,7 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
           </button>
         </form>
 
-        <div className="absolute bottom-[47px] h-[75px] left-1/2 translate-x-[-50%] w-[393px] text-center">
+        <div className="mt-auto pt-6 text-center">
           <p className="text-[16px] leading-[25.6px] text-[#b8b2b3]">Hai già un account?</p>
           <button
             type="button"

--- a/apps/mobile/src/components/screens/Signup.tsx
+++ b/apps/mobile/src/components/screens/Signup.tsx
@@ -43,7 +43,7 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
         <button
           type="button"
           onClick={onBack}
-          className="flex items-center justify-center size-[40px] text-[#f4bf4f]"
+          className="flex items-center justify-center size-[44px] text-[#f4bf4f]"
           aria-label="Indietro"
         >
           <ArrowLeft size={24} />
@@ -144,19 +144,19 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
             </div>
           </div>
 
-          <div className="flex gap-[12px] items-start">
+          <label htmlFor="terms" className="flex gap-[12px] items-start rounded-md py-[6px] text-[14px] leading-[20px] text-[#b8b2b3]">
             <input
               id="terms"
               type="checkbox"
               checked={acceptTerms}
               onChange={(e) => setAcceptTerms(e.target.checked)}
-              className="bg-[#241f20] border border-[#2d2728] size-[20px] accent-[#a82847]"
+              className="bg-[#241f20] border border-[#2d2728] size-[24px] accent-[#a82847]"
             />
-            <label htmlFor="terms" className="text-[14px] leading-[20px] text-[#b8b2b3]">
+            <span>
               Accetto i <span className="text-[#f4bf4f]">Termini e Condizioni</span> e la{' '}
               <span className="text-[#f4bf4f]">Privacy Policy</span>
-            </label>
-          </div>
+            </span>
+          </label>
 
           <button
             type="submit"
@@ -173,7 +173,7 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
           <button
             type="button"
             onClick={onLogin}
-            className="text-[16px] leading-[25.6px] text-[#f4bf4f]"
+            className="inline-flex items-center justify-center rounded-md px-2 py-[10px] text-[16px] leading-[25.6px] text-[#f4bf4f]"
           >
             Accedi
           </button>

--- a/apps/mobile/src/components/screens/Signup.tsx
+++ b/apps/mobile/src/components/screens/Signup.tsx
@@ -121,7 +121,7 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
                   className="w-full h-full bg-transparent px-[10px] py-0 text-[16px] leading-[28px] text-[#f5f5f5] placeholder:text-[#7a7577] focus:outline-none"
                 />
               </div>
-              <p className="mt-2 text-[16px] leading-[25.6px] text-[#7a7577]">Almeno 8 caratteri</p>
+              <p className="mt-2 !mb-0 text-[16px] leading-[25.6px] text-[#7a7577]">Almeno 8 caratteri</p>
             </div>
 
             <div className="flex flex-col gap-2 w-full">

--- a/apps/mobile/src/components/screens/Signup.tsx
+++ b/apps/mobile/src/components/screens/Signup.tsx
@@ -101,46 +101,48 @@ export function Signup({ onBack, onSignup, onLogin }: SignupProps) {
             </div>
           </div>
 
-          <div className="flex flex-col gap-2 w-full">
-            <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
-              Password
-            </label>
-            <div
-              className={`bg-[#241f20] border-2 ${
-                errors.password ? 'border-[#ff4d4f]' : 'border-[#2d2728]'
-              } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
-            >
-              <input
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                autoComplete="new-password"
-                aria-invalid={Boolean(errors.password)}
-                placeholder="••••••••"
-                className="w-full h-full bg-transparent px-[10px] py-0 text-[16px] leading-[28px] text-[#f5f5f5] placeholder:text-[#7a7577] focus:outline-none"
-              />
+          <div className="flex flex-col gap-4 w-full">
+            <div className="flex flex-col gap-2 w-full">
+              <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
+                Password
+              </label>
+              <div
+                className={`bg-[#241f20] border-2 ${
+                  errors.password ? 'border-[#ff4d4f]' : 'border-[#2d2728]'
+                } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
+              >
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  autoComplete="new-password"
+                  aria-invalid={Boolean(errors.password)}
+                  placeholder="••••••••"
+                  className="w-full h-full bg-transparent px-[10px] py-0 text-[16px] leading-[28px] text-[#f5f5f5] placeholder:text-[#7a7577] focus:outline-none"
+                />
+              </div>
+              <p className="mt-2 text-[16px] leading-[25.6px] text-[#7a7577]">Almeno 8 caratteri</p>
             </div>
-            <p className="mt-2 text-[16px] leading-[25.6px] text-[#7a7577]">Almeno 8 caratteri</p>
-          </div>
 
-          <div className="flex flex-col gap-2 w-full">
-            <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
-              Conferma password
-            </label>
-            <div
-              className={`bg-[#241f20] border-2 ${
-                errors.confirmPassword ? 'border-[#ff4d4f]' : 'border-[#2d2728]'
-              } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
-            >
-              <input
-                type="password"
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-                autoComplete="new-password"
-                aria-invalid={Boolean(errors.confirmPassword)}
-                placeholder="••••••••"
-                className="w-full h-full bg-transparent px-[10px] py-0 text-[16px] leading-[28px] text-[#f5f5f5] placeholder:text-[#7a7577] focus:outline-none"
-              />
+            <div className="flex flex-col gap-2 w-full">
+              <label className="text-[16px] leading-[24px] text-[#b8b2b3]">
+                Conferma password
+              </label>
+              <div
+                className={`bg-[#241f20] border-2 ${
+                  errors.confirmPassword ? 'border-[#ff4d4f]' : 'border-[#2d2728]'
+                } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
+              >
+                <input
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  autoComplete="new-password"
+                  aria-invalid={Boolean(errors.confirmPassword)}
+                  placeholder="••••••••"
+                  className="w-full h-full bg-transparent px-[10px] py-0 text-[16px] leading-[28px] text-[#f5f5f5] placeholder:text-[#7a7577] focus:outline-none"
+                />
+              </div>
             </div>
           </div>
 

--- a/apps/mobile/src/components/screens/TitoliOttenuti.tsx
+++ b/apps/mobile/src/components/screens/TitoliOttenuti.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { Screen, ScreenHeader } from '../ui/Screen';
+import { Card } from '../ui/Card';
+import { achievements } from '../../data/achievements_data';
+
+interface TitoliOttenutiProps {
+  onBack: () => void;
+}
+
+export function TitoliOttenuti({ onBack }: TitoliOttenutiProps) {
+  return (
+    <Screen
+      header={(
+        <ScreenHeader>
+          <div className="max-w-md mx-auto">
+            <button
+              onClick={onBack}
+              className="flex items-center gap-2 rounded-md px-2 py-[10px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
+            >
+              <ArrowLeft size={20} />
+              <span>Indietro</span>
+            </button>
+          </div>
+          <div className="max-w-md mx-auto">
+            <h2 className="text-white mb-2">Titoli ottenuti</h2>
+            <p className="text-[#b8b2b3]">Tutti i badge sbloccati finora</p>
+          </div>
+        </ScreenHeader>
+      )}
+    >
+      <div className="grid grid-cols-2 gap-4">
+        {achievements.map((achievement) => {
+          const Icon = achievement.icon;
+          return (
+            <Card key={achievement.id} className="flex flex-col items-center text-center gap-3">
+              <div className="w-14 h-14 bg-gradient-to-br from-[#e6a23c] to-[#f4bf4f] rounded-2xl flex items-center justify-center">
+                <Icon className="text-[#0f0d0e]" size={24} />
+              </div>
+              <p className="text-xs leading-snug text-[#b8b2b3]">{achievement.title}</p>
+            </Card>
+          );
+        })}
+      </div>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/components/screens/TitoliOttenuti.tsx
+++ b/apps/mobile/src/components/screens/TitoliOttenuti.tsx
@@ -12,14 +12,15 @@ export function TitoliOttenuti({ onBack }: TitoliOttenutiProps) {
   return (
     <Screen
       header={(
-        <ScreenHeader>
+        <ScreenHeader gradient={false}>
           <div className="max-w-md mx-auto">
             <button
+              type="button"
               onClick={onBack}
-              className="flex items-center gap-2 rounded-md px-2 py-[10px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
+              className="flex items-center justify-center size-[44px] text-[#f4bf4f]"
+              aria-label="Indietro"
             >
-              <ArrowLeft size={20} />
-              <span>Indietro</span>
+              <ArrowLeft size={24} />
             </button>
           </div>
           <div className="max-w-md mx-auto">
@@ -34,7 +35,7 @@ export function TitoliOttenuti({ onBack }: TitoliOttenutiProps) {
           const Icon = achievement.icon;
           return (
             <Card key={achievement.id} className="flex flex-col items-center text-center gap-3">
-              <div className="w-14 h-14 bg-gradient-to-br from-[#e6a23c] to-[#f4bf4f] rounded-2xl flex items-center justify-center">
+              <div className="w-14 h-14 bg-[#f4bf4f] rounded-2xl flex items-center justify-center">
                 <Icon className="text-[#0f0d0e]" size={24} />
               </div>
               <p className="text-xs leading-snug text-[#b8b2b3]">{achievement.title}</p>

--- a/apps/mobile/src/components/screens/TurniATCL.tsx
+++ b/apps/mobile/src/components/screens/TurniATCL.tsx
@@ -24,7 +24,7 @@ export function TurniATCL({ turns, onScanQR }: TurniATCLProps) {
 
   return (
     <div
-      className="min-h-screen bg-[#0f0d0e]"
+      className="min-h-screen app-gradient"
       style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 96px)' }}
     >
       {/* Header */}

--- a/apps/mobile/src/components/screens/TurniATCL.tsx
+++ b/apps/mobile/src/components/screens/TurniATCL.tsx
@@ -41,10 +41,10 @@ export function TurniATCL({ turns, onScanQR }: TurniATCLProps) {
         {/* Scan Button */}
         <Button
           variant="primary"
-          size="lg"
+          size="md"
           fullWidth
           onClick={onScanQR}
-          style={{ padding: "0 5px" }}
+          className="min-h-[44px] px-4"
         >
           <QrCode size={20} />
           Registra nuovo turno (Scansiona QR)

--- a/apps/mobile/src/components/screens/TurniATCL.tsx
+++ b/apps/mobile/src/components/screens/TurniATCL.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { Card } from '../ui/Card';
 import { Button } from '../ui/Button';
 import { Badge } from '../ui/Badge';
+import { ScanQRCard } from '../ScanQRCard';
 import { QrCode, MapPin, Calendar, TrendingUp, Theater } from 'lucide-react';
 import { TurnRecord, RoleId, roles } from '../../state/store';
 
@@ -39,16 +40,7 @@ export function TurniATCL({ turns, onScanQR }: TurniATCLProps) {
       {/* Main Content */}
       <div className="w-full max-w-md mx-auto px-6 space-y-6 pt-6 pb-8">
         {/* Scan Button */}
-        <Button
-          variant="primary"
-          size="md"
-          fullWidth
-          onClick={onScanQR}
-          className="min-h-[44px] px-4"
-        >
-          <QrCode size={20} />
-          Registra nuovo turno (Scansiona QR)
-        </Button>
+        <ScanQRCard onScanQR={onScanQR} />
         
         {/* Stats Summary */}
         <Card>

--- a/apps/mobile/src/components/screens/Welcome.tsx
+++ b/apps/mobile/src/components/screens/Welcome.tsx
@@ -43,7 +43,7 @@ export function Welcome({ onStart, onLogin }: WelcomeProps) {
           </p>
         </div>
 
-        <div className="mt-[18px] mb-4 w-full max-w-[300px] bg-[#1a1617] border border-[#2d2728] rounded-[16px] px-4 py-3">
+        <div className="mt-[18px] mb-5 w-full max-w-[300px] bg-[#1a1617] border border-[#2d2728] rounded-[16px] px-4 py-3">
           <p className="!m-0 text-[16px] leading-[25.6px] text-center text-[#b8b2b3]">
             Simula la carriera di un professionista del teatro e registra la tua
             partecipazione agli eventi reali ATCL scansionando il QR sul biglietto.

--- a/apps/mobile/src/components/screens/Welcome.tsx
+++ b/apps/mobile/src/components/screens/Welcome.tsx
@@ -43,8 +43,8 @@ export function Welcome({ onStart, onLogin }: WelcomeProps) {
           </p>
         </div>
 
-        <div className="mt-[18px] w-full max-w-[300px] bg-[#1a1617] border border-[#2d2728] rounded-[16px] px-4 py-3">
-          <p className="text-[16px] leading-[25.6px] text-center text-[#b8b2b3]">
+        <div className="mt-[18px] mb-4 w-full max-w-[300px] bg-[#1a1617] border border-[#2d2728] rounded-[16px] px-4 py-3">
+          <p className="!m-0 text-[16px] leading-[25.6px] text-center text-[#b8b2b3]">
             Simula la carriera di un professionista del teatro e registra la tua
             partecipazione agli eventi reali ATCL scansionando il QR sul biglietto.
           </p>

--- a/apps/mobile/src/components/screens/Welcome.tsx
+++ b/apps/mobile/src/components/screens/Welcome.tsx
@@ -13,76 +13,62 @@ export function Welcome({ onStart, onLogin }: WelcomeProps) {
     <Screen
       withBottomNavPadding={false}
       className="relative items-start justify-start"
-      contentClassName="relative w-full max-w-[393px] h-[852px] px-0 pt-0 pb-0 space-y-0"
+      contentClassName="relative w-full max-w-[393px] flex-1 px-6 pt-8 pb-[calc(env(safe-area-inset-bottom,_0px)+32px)] space-y-0 box-border"
       style={{
         backgroundImage:
           'linear-gradient(180deg, rgba(15, 13, 14, 1) 0%, rgba(26, 22, 23, 1) 50%, rgba(45, 10, 15, 1) 100%), linear-gradient(90deg, rgba(15, 13, 14, 1) 0%, rgba(15, 13, 14, 1) 100%)'
       }}
     >
-      <div className="relative w-full h-full">
-        <div className="absolute z-10 h-[96px] left-1/2 top-[calc(50%+309px)] translate-x-[-50%] translate-y-[-50%] w-[448px]">
-          <div className="flex flex-col gap-[16px] items-center justify-center pb-[20px]">
-            <button
-              type="button"
-              onClick={onStart}
-              className="bg-gradient-to-b from-[#8c1c38] to-[#a82847] h-[28px] w-[300px] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)]"
-            >
-              <span className="block text-[18px] leading-[28px] text-center text-white">
-                Inizia
-              </span>
-            </button>
-            <button
-              type="button"
-              onClick={onLogin}
-              className="border-2 border-[#a82847] h-[32px] w-[300px] rounded-[16.4px]"
-            >
-              <span className="block text-[18px] leading-[28px] text-center text-[#f4bf4f]">
-                Accedi
-              </span>
-            </button>
+      <div className="relative flex h-full flex-col items-center text-center">
+        <div className="flex flex-col items-center gap-[20px] pt-[12px]">
+          <div className="bg-gradient-to-b from-[#a82847] to-[#6b1529] rounded-[24px] shadow-[0px_10px_15px_-3px_rgba(0,0,0,0.1),0px_4px_6px_-4px_rgba(0,0,0,0.1)] size-[128px]">
+            <div className="flex items-center justify-center w-full h-full">
+              <img alt="" className="size-[64px]" src={welcomeLogo} />
+            </div>
           </div>
+
+          <p
+            className="text-center text-[32px] leading-[38.4px] font-bold tracking-[-0.64px] text-transparent bg-clip-text"
+            style={{
+              WebkitTextFillColor: 'transparent',
+              backgroundImage:
+                'linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0) 100%), linear-gradient(180deg, rgba(244, 191, 79, 1) 0%, rgba(230, 162, 60, 1) 100%)'
+            }}
+          >
+            Turni di Palco
+          </p>
+
+          <p className="text-[16px] leading-[25.6px] text-center text-[#b8b2b3]">
+            Costruisci la tua carriera a teatro
+          </p>
         </div>
 
-        <div className="absolute z-0 pointer-events-none h-[852px] left-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] w-[393px]">
-          <div className="relative flex flex-col gap-[20px] items-center justify-center w-full h-full">
-            <div className="absolute bg-[#1a1617] border border-[#2d2728] h-[102px] left-[calc(50%+0.5px)] rounded-[16px] top-[calc(50%+115px)] translate-x-[-50%] translate-y-[-50%] w-[300px]">
-              <div className="flex items-center justify-center w-full h-full">
-                <p className="text-[16px] leading-[25.6px] text-center text-[#b8b2b3] w-[298px]">
-                  Simula la carriera di un professionista del teatro e registra la tua
-                  partecipazione agli eventi reali ATCL scansionando il QR sul biglietto.
-                </p>
-              </div>
-            </div>
+        <div className="mt-[18px] w-full max-w-[300px] bg-[#1a1617] border border-[#2d2728] rounded-[16px] px-4 py-3">
+          <p className="text-[16px] leading-[25.6px] text-center text-[#b8b2b3]">
+            Simula la carriera di un professionista del teatro e registra la tua
+            partecipazione agli eventi reali ATCL scansionando il QR sul biglietto.
+          </p>
+        </div>
 
-            <div className="absolute h-[211.984px] left-[calc(50%+0.31px)] top-[214px] translate-x-[-50%] w-[227.625px]">
-              <div className="flex flex-col gap-[20px] items-center relative w-full h-full">
-                <div className="bg-gradient-to-b from-[#a82847] to-[#6b1529] rounded-[24px] shadow-[0px_10px_15px_-3px_rgba(0,0,0,0.1),0px_4px_6px_-4px_rgba(0,0,0,0.1)] size-[128px]">
-                  <div className="flex items-center justify-center w-full h-full">
-                    <img alt="" className="size-[64px]" src={welcomeLogo} />
-                  </div>
-                </div>
-
-                <div className="h-[38.391px] relative w-fit">
-                  <p
-                    className="absolute left-1/2 top-[calc(50%-22.2px)] translate-x-[-50%] text-center whitespace-nowrap text-[32px] leading-[38.4px] font-bold tracking-[-0.64px] text-transparent bg-clip-text"
-                    style={{
-                      WebkitTextFillColor: 'transparent',
-                      backgroundImage:
-                        'linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0) 100%), linear-gradient(180deg, rgba(244, 191, 79, 1) 0%, rgba(230, 162, 60, 1) 100%)'
-                    }}
-                  >
-                    Turni di Palco
-                  </p>
-                </div>
-
-                <div className="absolute h-[25px] left-[calc(50%+0.19px)] top-[calc(50%+112.9px)] translate-x-[-50%] translate-y-[-50%] w-[228px]">
-                  <p className="text-[16px] leading-[25.6px] text-center text-[#b8b2b3]">
-                    Costruisci la tua carriera a teatro
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
+        <div className="mt-auto w-full flex flex-col items-center gap-[16px] pb-[12px]">
+          <button
+            type="button"
+            onClick={onStart}
+            className="bg-gradient-to-b from-[#8c1c38] to-[#a82847] h-[44px] w-full max-w-[300px] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)]"
+          >
+            <span className="block text-[18px] leading-[28px] text-center text-white">
+              Inizia
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={onLogin}
+            className="border-2 border-[#a82847] h-[44px] w-full max-w-[300px] rounded-[16.4px]"
+          >
+            <span className="block text-[18px] leading-[28px] text-center text-[#f4bf4f]">
+              Accedi
+            </span>
+          </button>
         </div>
       </div>
     </Screen>

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { cn } from './utils';
 
 interface CardProps {
   children: React.ReactNode;
@@ -13,7 +14,6 @@ export function Card({ children, className = '', onClick, hoverable = false, sty
   const defaultStyles: React.CSSProperties = {
     backgroundColor: 'rgb(26, 22, 23)',
     borderRadius: '16.4px',
-    padding: '16px',
     boxShadow: 'rgba(0, 0, 0, 0.1) 0px 4px 6px -1px, rgba(0, 0, 0, 0.1) 0px 2px 4px -2px',
     transitionDuration: '0.2s',
     transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)',
@@ -22,7 +22,7 @@ export function Card({ children, className = '', onClick, hoverable = false, sty
 
   return (
     <div
-      className={`transition-all duration-200 ${hoverClass} ${className}`}
+      className={cn('transition-all duration-200 p-4', hoverClass, className)}
       onClick={onClick}
       style={defaultStyles}
     >

--- a/apps/mobile/src/components/ui/MetricTile.tsx
+++ b/apps/mobile/src/components/ui/MetricTile.tsx
@@ -20,8 +20,8 @@ export function MetricTile({ label, value, helper, icon, onClick, progress }: Me
       )}
       onClick={onClick}
     >
-      <div className="flex items-start justify-between gap-2 mb-2">
-        <div className="text-xs text-[#b8b2b3]">{label}</div>
+      <div className="flex items-start justify-between gap-2 mb-2 min-h-[32px]">
+        <div className="text-xs leading-4 text-[#b8b2b3]">{label}</div>
         {icon ? <div className="text-[#f4bf4f]">{icon}</div> : null}
       </div>
       <div className="text-white leading-tight" style={{ fontSize: '55px', margin: '10px 0 20px' }}>{value}</div>

--- a/apps/mobile/src/components/ui/Screen.tsx
+++ b/apps/mobile/src/components/ui/Screen.tsx
@@ -23,7 +23,7 @@ export function Screen({
 }: ScreenProps) {
   return (
     <div
-      className={cn('min-h-screen min-h-[100dvh] bg-[#0f0d0e] flex flex-col items-center justify-center', className)}
+      className={cn('min-h-screen min-h-[100dvh] app-gradient flex flex-col items-center justify-center', className)}
       style={style}
     >
       {header}

--- a/apps/mobile/src/components/ui/Screen.tsx
+++ b/apps/mobile/src/components/ui/Screen.tsx
@@ -23,7 +23,7 @@ export function Screen({
 }: ScreenProps) {
   return (
     <div
-      className={cn('min-h-screen bg-[#0f0d0e] flex flex-col items-center justify-center', className)}
+      className={cn('min-h-screen min-h-[100dvh] bg-[#0f0d0e] flex flex-col items-center justify-center', className)}
       style={style}
     >
       {header}

--- a/apps/mobile/src/data/achievements_data.ts
+++ b/apps/mobile/src/data/achievements_data.ts
@@ -5,10 +5,11 @@ export type Achievement = {
   id: string;
   title: string;
   icon: LucideIcon;
+  isNew?: boolean;
 };
 
 export const achievements: Achievement[] = [
-  { id: '1', title: 'Ha lavorato in 3 teatri diversi', icon: MapPin },
-  { id: '2', title: 'Prima stagione completata', icon: Award },
-  { id: '3', title: '10 turni registrati', icon: Theater },
+  { id: '1', title: 'Ha lavorato in 3 teatri diversi', icon: MapPin, isNew: true },
+  { id: '2', title: 'Prima stagione completata', icon: Award, isNew: false },
+  { id: '3', title: '10 turni registrati', icon: Theater, isNew: false },
 ];

--- a/apps/mobile/src/data/achievements_data.ts
+++ b/apps/mobile/src/data/achievements_data.ts
@@ -1,0 +1,14 @@
+import { Award, MapPin, Theater } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+export type Achievement = {
+  id: string;
+  title: string;
+  icon: LucideIcon;
+};
+
+export const achievements: Achievement[] = [
+  { id: '1', title: 'Ha lavorato in 3 teatri diversi', icon: MapPin },
+  { id: '2', title: 'Prima stagione completata', icon: Award },
+  { id: '3', title: '10 turni registrati', icon: Theater },
+];

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -167,4 +167,16 @@
   .animate-slide-up {
     animation: slideUp 0.4s ease-out;
   }
+
+  .app-gradient {
+    background-color: var(--color-bg-primary);
+    background-image: linear-gradient(
+      180deg,
+      rgba(15, 13, 14, 1) 0%,
+      rgba(26, 22, 23, 1) 52%,
+      rgba(45, 10, 15, 1) 100%
+    );
+    background-repeat: no-repeat;
+    background-size: cover;
+  }
 }

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -40,6 +40,21 @@
   --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
   --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -1px rgba(0, 0, 0, 0.3);
   --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.5), 0 4px 6px -2px rgba(0, 0, 0, 0.4);
+
+  --heading-1-size: 2rem;
+  --heading-1-line: 1.2;
+  --heading-1-weight: 700;
+  --heading-1-track: -0.02em;
+
+  --heading-2-size: 1.5rem;
+  --heading-2-line: 1.3;
+  --heading-2-weight: 700;
+  --heading-2-track: -0.01em;
+
+  --heading-3-size: 1.25rem;
+  --heading-3-line: 1.4;
+  --heading-3-weight: 600;
+  --heading-3-track: -0.01em;
 }
 
 @layer base {
@@ -65,24 +80,28 @@
     -moz-osx-font-smoothing: grayscale;
   }
 
-  h1 {
-    font-size: 2rem;
-    line-height: 1.2;
-    font-weight: 700;
-    letter-spacing: -0.02em;
+  h1,
+  .heading-1 {
+    font-size: var(--heading-1-size);
+    line-height: var(--heading-1-line);
+    font-weight: var(--heading-1-weight);
+    letter-spacing: var(--heading-1-track);
   }
 
-  h2 {
-    font-size: 1.5rem;
-    line-height: 1.3;
-    font-weight: 700;
-    letter-spacing: -0.01em;
+  h2,
+  .heading-2 {
+    font-size: var(--heading-2-size);
+    line-height: var(--heading-2-line);
+    font-weight: var(--heading-2-weight);
+    letter-spacing: var(--heading-2-track);
   }
 
-  h3 {
-    font-size: 1.25rem;
-    line-height: 1.4;
-    font-weight: 600;
+  h3,
+  .heading-3 {
+    font-size: var(--heading-3-size);
+    line-height: var(--heading-3-line);
+    font-weight: var(--heading-3-weight);
+    letter-spacing: var(--heading-3-track);
   }
 
   h4 {


### PR DESCRIPTION
## Summary
- Align mobile UI with Figma across Home/Turni/Attivita screens and QR scan card
- Fix profile/role flows, add achievements screen, and clean up spacing/margins
- Standardize gradients/backgrounds and tap targets, plus heading scale tweaks

## Testing
- Not run (UI changes; verified via Puppeteer screenshots)