### PR TITLE
Add shared header shell for PWA pages

### DIFF
--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "turni-di-palco-v440d67b1";
+const CACHE_NAME = "turni-di-palco-v440d67b2";
 const OFFLINE_URL = "/index.html";
 const CORE_ASSETS = [
   "/",

--- a/apps/pwa/src/avatar.ts
+++ b/apps/pwa/src/avatar.ts
@@ -1,4 +1,5 @@
 import "../../../shared/styles/main.css";
+import { renderPageHero } from "./components/page-hero";
 import { registerServiceWorker } from "./pwa/register-sw";
 import { deriveRpmThumbnail, getAvatarVisual, loadState, saveState } from "./state";
 
@@ -11,19 +12,21 @@ if (!root) {
   throw new Error("Root container missing");
 }
 
+const pageHero = renderPageHero({
+  title: "Avatar ReadyPlayer.Me",
+  description: "Crea o aggiorna il tuo avatar 3D. Il risultato verrà salvato nel profilo e usato nelle altre pagine.",
+  currentPage: "avatar",
+  breadcrumbs: [
+    { label: "Hub", href: "/game.html" },
+    { label: "Avatar" },
+  ],
+  backHref: "/game.html",
+  backLabel: "Torna all'hub",
+});
+
 root.innerHTML = `
   <main class="page page-game layout-shell">
-    <header class="hero layout-stack">
-      <p class="eyebrow">Turni di Palco</p>
-      <h1>Avatar ReadyPlayer.Me</h1>
-      <p class="lede">Crea o aggiorna il tuo avatar 3D. Il risultato verrà salvato nel profilo e usato nelle altre pagine.</p>
-      <div class="cta-row">
-        <a class="button ghost" href="/">Landing</a>
-        <a class="button ghost" href="/map.html">Mappa</a>
-        <a class="button ghost" href="/profile.html">Profilo</a>
-        <a class="button ghost" href="/game.html">Hub</a>
-      </div>
-    </header>
+    ${pageHero}
 
     <section class="grid layout-grid">
       <article class="card layout-span-2">

--- a/apps/pwa/src/components/page-hero.ts
+++ b/apps/pwa/src/components/page-hero.ts
@@ -1,0 +1,145 @@
+export type PageShortcut = {
+  id: string;
+  label: string;
+  href?: string;
+  icon?: string;
+  variant?: "primary" | "ghost";
+  kind?: "link" | "button";
+  dataAction?: string;
+};
+
+export type Breadcrumb = {
+  label: string;
+  href?: string;
+};
+
+export type PageHeroProps = {
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  currentPage: PageShortcut["id"];
+  breadcrumbs?: Breadcrumb[];
+  quickActions?: PageShortcut[];
+  ctaRow?: PageShortcut[];
+  backHref?: string;
+  backLabel?: string;
+};
+
+export const sharedShortcuts: PageShortcut[] = [
+  { id: "home", label: "Home", href: "/", icon: "🏠" },
+  { id: "game", label: "Hub", href: "/game.html", icon: "🎮" },
+  { id: "map", label: "Mappa", href: "/map.html", icon: "🗺️" },
+  { id: "turns", label: "Turni", href: "/turns.html", icon: "📒" },
+  { id: "events", label: "Eventi", href: "/events.html", icon: "🎟️" },
+  { id: "profile", label: "Profilo", href: "/profile.html", icon: "👤" },
+  { id: "avatar", label: "Avatar", href: "/avatar.html", icon: "🧩" },
+];
+
+function renderBreadcrumbs(items: Breadcrumb[] = []) {
+  if (!items.length) return "";
+  const lastIndex = items.length - 1;
+  return `
+    <nav aria-label="Percorso" class="breadcrumbs">
+      <ol>
+        ${items
+          .map((crumb, index) => {
+            const isCurrent = index === lastIndex;
+            if (crumb.href && !isCurrent) {
+              return `<li><a href="${crumb.href}">${crumb.label}</a></li>`;
+            }
+            return `<li aria-current="page">${crumb.label}</li>`;
+          })
+          .join('<li class="breadcrumb-separator">/</li>')}
+      </ol>
+    </nav>
+  `;
+}
+
+function renderShortcut(shortcut: PageShortcut, currentPage: string) {
+  const isActive = shortcut.id === currentPage;
+  const stateAttr = isActive ? "active" : "default";
+  return `
+    <a class="quick-link" href="${shortcut.href ?? "#"}" data-state="${stateAttr}">
+      ${shortcut.icon ? `<span class="quick-icon" aria-hidden="true">${shortcut.icon}</span>` : ""}
+      <span class="quick-label">${shortcut.label}</span>
+    </a>
+  `;
+}
+
+function renderQuickbar(currentPage: string, quickActions: PageShortcut[]) {
+  if (!quickActions.length) return "";
+  const uniqueActions = quickActions.filter(
+    (action, index, list) => list.findIndex((item) => item.id === action.id) === index
+  );
+  const shortcuts = uniqueActions.map((action) => renderShortcut(action, currentPage)).join("");
+  return `
+    <div class="quickbar" role="navigation" aria-label="Scorciatoie">
+      <span class="quickbar-label">Navigazione rapida</span>
+      <div class="quickbar-actions">
+        ${shortcuts}
+      </div>
+    </div>
+  `;
+}
+
+function renderCtaRow(ctaRow: PageShortcut[] = []) {
+  if (!ctaRow.length) return "";
+  const buttons = ctaRow
+    .map((cta) => {
+      const variant = cta.variant ?? "ghost";
+      if (cta.kind === "button") {
+        return `<button class="button ${variant}" type="button"${cta.dataAction ? ` data-action="${cta.dataAction}"` : ""}>
+          ${cta.icon ? `<span aria-hidden="true">${cta.icon}</span>` : ""}${cta.label}
+        </button>`;
+      }
+      return `<a class="button ${variant}" href="${cta.href ?? "#"}">
+        ${cta.icon ? `<span aria-hidden="true">${cta.icon}</span>` : ""}${cta.label}
+      </a>`;
+    })
+    .join("");
+  return `<div class="cta-row">${buttons}</div>`;
+}
+
+export function renderPageHero({
+  eyebrow = "Turni di Palco",
+  title,
+  description,
+  currentPage,
+  breadcrumbs = [],
+  quickActions = [],
+  ctaRow = [],
+  backHref,
+  backLabel = "Indietro",
+}: PageHeroProps) {
+  const quickbar = renderQuickbar(currentPage, [...sharedShortcuts, ...quickActions]);
+  const ctas = renderCtaRow(ctaRow);
+  const backLink = backHref
+    ? `<a class="back-link" href="${backHref}" data-back>
+        <span aria-hidden="true">←</span>
+        <span>${backLabel}</span>
+      </a>`
+    : "";
+
+  return `
+    <header class="hero layout-stack page-hero">
+      <div class="page-hero-header">
+        <div class="page-hero-brand">
+          <span class="brand-mark">TdP</span>
+          <div class="page-hero-meta">
+            <div class="page-hero-topline">
+              ${backLink}
+              <p class="eyebrow">${eyebrow}</p>
+            </div>
+            <div class="page-hero-title-row">
+              <h1>${title}</h1>
+              ${renderBreadcrumbs(breadcrumbs)}
+            </div>
+            ${description ? `<p class="lede">${description}</p>` : ""}
+          </div>
+        </div>
+      </div>
+      ${ctas}
+      ${quickbar}
+    </header>
+  `;
+}

--- a/apps/pwa/src/events.ts
+++ b/apps/pwa/src/events.ts
@@ -1,4 +1,5 @@
 import "../../../shared/styles/main.css";
+import { renderPageHero } from "./components/page-hero";
 import { mockEvents, resolveRole } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");
@@ -7,20 +8,21 @@ if (!root) {
   throw new Error("Root container missing");
 }
 
+const pageHero = renderPageHero({
+  title: "Eventi mock",
+  description: "Usati per testare la registrazione turni e la mappa.",
+  currentPage: "events",
+  breadcrumbs: [
+    { label: "Hub", href: "/game.html" },
+    { label: "Eventi" },
+  ],
+  backHref: "/game.html",
+  backLabel: "Torna all'hub",
+});
+
 root.innerHTML = `
   <main class="page page-game layout-shell">
-    <header class="hero layout-stack">
-      <p class="eyebrow">Turni di Palco</p>
-      <h1>Eventi mock</h1>
-      <p class="lede">Usati per testare la registrazione turni e la mappa.</p>
-      <div class="cta-row">
-        <a class="button ghost" href="/">Landing</a>
-        <a class="button ghost" href="/avatar.html">Avatar</a>
-        <a class="button ghost" href="/map.html">Mappa</a>
-        <a class="button ghost" href="/profile.html">Profilo</a>
-        <a class="button ghost" href="/turns.html">Turni</a>
-      </div>
-    </header>
+    ${pageHero}
 
     <section class="grid layout-grid">
       <article class="card layout-span-2">

--- a/apps/pwa/src/game.ts
+++ b/apps/pwa/src/game.ts
@@ -1,5 +1,6 @@
 import "../../../shared/styles/main.css";
 import { registerServiceWorker } from "./pwa/register-sw";
+import { renderPageHero } from "./components/page-hero";
 import { formatRewards, getAvatarVisual, loadState, resolveRole } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");
@@ -11,22 +12,22 @@ if (!root) {
 const state = loadState();
 const role = resolveRole(state.profile.roleId);
 const avatarVisual = getAvatarVisual(state.profile.avatar);
+const pageHero = renderPageHero({
+  title: "Hub di navigazione",
+  description: "Accedi a mappa, profilo, eventi e registro turni.",
+  currentPage: "game",
+  breadcrumbs: [
+    { label: "Home", href: "/" },
+    { label: "Hub" },
+  ],
+  backHref: "/",
+  backLabel: "Torna alla landing",
+  quickActions: [{ id: "dev", label: "Dev playground", href: "/dev.html", icon: "🛠️" }],
+});
 
 root.innerHTML = `
   <main class="page page-game layout-shell">
-    <header class="hero layout-stack">
-      <p class="eyebrow">Turni di Palco</p>
-      <h1>Hub di navigazione</h1>
-      <p class="lede">Accedi a mappa, profilo, eventi e registro turni.</p>
-      <div class="cta-row">
-        <a class="button primary" href="/map.html">Apri mappa</a>
-        <a class="button ghost" href="/avatar.html">Avatar</a>
-        <a class="button ghost" href="/profile.html">Profilo</a>
-        <a class="button ghost" href="/events.html">Eventi</a>
-        <a class="button ghost" href="/turns.html">Turni</a>
-        <a class="button ghost" href="/">Landing</a>
-      </div>
-    </header>
+    ${pageHero}
 
     <section class="grid layout-grid">
       <article class="card">

--- a/apps/pwa/src/main.ts
+++ b/apps/pwa/src/main.ts
@@ -1,16 +1,7 @@
 import "../../../shared/styles/main.css";
-import { renderAppBar } from "./components/app-bar";
+import { renderPageHero } from "./components/page-hero";
 import { renderPermissionsCard, attachPermissionsListeners } from "./features/permissions-card";
 import { renderStatusCard, attachStatusListeners } from "./features/status-card";
-
-const mainNav = [
-  { label: "Home", href: "#hero", state: "active" as const },
-  { label: "Permessi", href: "#permissions" },
-  { label: "Dev playground", href: "/dev.html", icon: "🛠️" },
-  { label: "Pagina gioco", href: "/game.html", icon: "🎮" },
-];
-
-const appBar = renderAppBar({ eyebrow: "Turni di Palco", subtitle: "PWA shell", actions: mainNav });
 
 const root = document.querySelector<HTMLDivElement>("#app");
 
@@ -18,27 +9,29 @@ if (!root) {
   throw new Error("Root container missing");
 }
 
+const hero = renderPageHero({
+  title: "Progressive Web App base",
+  description:
+    "Shell installabile e offline-ready per costruire il loop di gioco. I moduli demo (profilo, attivita simulate e turni) ora vivono nel playground dev.",
+  currentPage: "home",
+  breadcrumbs: [{ label: "Home" }],
+  quickActions: [
+    { id: "hero", label: "Hero", href: "#hero", icon: "⬆️" },
+    { id: "permissions", label: "Permessi", href: "#permissions", icon: "✅" },
+    { id: "dev", label: "Dev playground", href: "/dev.html", icon: "🛠️" },
+    { id: "game", label: "Hub", href: "/game.html", icon: "🎮" },
+  ],
+  ctaRow: [
+    { id: "open-dev", label: "Apri dev playground", href: "/dev.html", variant: "primary", icon: "🛠️" },
+    { id: "refresh", label: "Reload per update", kind: "button", dataAction: "refresh", variant: "ghost" },
+    { id: "open-game", label: "Apri interfaccia base", href: "/game.html", variant: "ghost", icon: "🎮" },
+  ],
+});
+
 root.innerHTML = `
   <main class="page">
-    ${appBar}
-
-    <section class="hero layout-stack" id="hero">
-      <p class="eyebrow">Turni di Palco</p>
-      <h1>Progressive Web App base</h1>
-      <p class="lede">
-        Shell installabile e offline-ready per costruire il loop di gioco. I moduli demo (profilo, attivita simulate e turni) ora vivono nel playground dev.
-      </p>
-      <div class="cta-row">
-        <a class="button primary" href="/dev.html">
-          Apri dev playground
-        </a>
-        <button class="button ghost" type="button" data-action="refresh">
-          Reload per update
-        </button>
-        <a class="button ghost" href="/game.html">
-          Apri interfaccia base
-        </a>
-      </div>
+    <section class="layout-stack" id="hero">
+      ${hero}
       <div class="badges">
         <span class="badge">Installable</span>
         <span class="badge">Offline friendly</span>

--- a/apps/pwa/src/profile.ts
+++ b/apps/pwa/src/profile.ts
@@ -1,4 +1,5 @@
 import "../../../shared/styles/main.css";
+import { renderPageHero } from "./components/page-hero";
 import { formatRewards, getAvatarVisual, loadState, resolveRole } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");
@@ -7,20 +8,21 @@ if (!root) {
   throw new Error("Root container missing");
 }
 
+const pageHero = renderPageHero({
+  title: "Profilo",
+  description: "Stato giocatore, avatar e riepilogo recente.",
+  currentPage: "profile",
+  breadcrumbs: [
+    { label: "Hub", href: "/game.html" },
+    { label: "Profilo" },
+  ],
+  backHref: "/game.html",
+  backLabel: "Torna all'hub",
+});
+
 root.innerHTML = `
   <main class="page page-game layout-shell">
-    <header class="hero layout-stack">
-      <p class="eyebrow">Turni di Palco</p>
-      <h1>Profilo</h1>
-      <p class="lede">Stato giocatore, avatar e riepilogo recente.</p>
-      <div class="cta-row">
-        <a class="button ghost" href="/">Landing</a>
-        <a class="button ghost" href="/avatar.html">Avatar</a>
-        <a class="button ghost" href="/map.html">Mappa</a>
-        <a class="button ghost" href="/events.html">Eventi</a>
-        <a class="button ghost" href="/turns.html">Turni</a>
-      </div>
-    </header>
+    ${pageHero}
 
     <section class="grid layout-grid">
       <article class="card layout-span-2">

--- a/apps/pwa/src/style.css
+++ b/apps/pwa/src/style.css
@@ -223,6 +223,140 @@ code {
     var(--inset-bright);
 }
 
+.page-hero {
+  gap: 1.1rem;
+}
+
+.page-hero-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.page-hero-brand {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.page-hero-meta {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.page-hero-topline {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.page-hero-title-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.back-link {
+  display: none;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.55rem;
+  border-radius: 10px;
+  background: var(--surface-veil-soft);
+  border: 1px solid var(--border-regular);
+  color: var(--color-info-50);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.back-link:hover {
+  border-color: var(--surface-veil-highlight);
+}
+
+.breadcrumbs ol {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.breadcrumbs a {
+  color: var(--color-info-50);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.breadcrumbs a:hover {
+  text-decoration: underline;
+}
+
+.breadcrumb-separator {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.quickbar {
+  display: grid;
+  gap: 0.35rem;
+  border-radius: 14px;
+  border: 1px solid var(--border-regular);
+  padding: 0.65rem 0.75rem;
+  background: var(--surface-veil-strong);
+}
+
+.quickbar-label {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.quickbar-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.quick-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.55rem 0.8rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-regular);
+  background: var(--surface-veil);
+  text-decoration: none;
+  color: var(--text-primary);
+  font-weight: 600;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    transform 120ms ease;
+}
+
+.quick-link:hover {
+  border-color: var(--surface-veil-highlight);
+}
+
+.quick-link:active {
+  transform: translateY(1px);
+}
+
+.quick-link[data-state="active"] {
+  border-color: var(--border-strong);
+  background: var(--surface-veil-soft);
+  box-shadow: 0 0 0 1px var(--surface-veil-highlight) inset;
+}
+
+.quick-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
 .eyebrow {
   text-transform: uppercase;
   font-size: 0.8rem;
@@ -339,6 +473,20 @@ code {
   .app-stage,
   .app-layout {
   grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 780px) {
+  .page-hero-header {
+    align-items: flex-start;
+  }
+
+  .back-link {
+    display: inline-flex;
+  }
+
+  .quickbar {
+    padding: 0.75rem;
   }
 }
 

--- a/apps/pwa/src/turns.ts
+++ b/apps/pwa/src/turns.ts
@@ -1,4 +1,5 @@
 import "../../../shared/styles/main.css";
+import { renderPageHero } from "./components/page-hero";
 import { formatRewards, loadState, resolveRole } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");
@@ -7,20 +8,21 @@ if (!root) {
   throw new Error("Root container missing");
 }
 
+const pageHero = renderPageHero({
+  title: "Registro turni",
+  description: "Ultimi turni registrati dal prototipo.",
+  currentPage: "turns",
+  breadcrumbs: [
+    { label: "Hub", href: "/game.html" },
+    { label: "Turni" },
+  ],
+  backHref: "/game.html",
+  backLabel: "Torna all'hub",
+});
+
 root.innerHTML = `
   <main class="page page-game layout-shell">
-    <header class="hero layout-stack">
-      <p class="eyebrow">Turni di Palco</p>
-      <h1>Registro turni</h1>
-      <p class="lede">Ultimi turni registrati dal prototipo.</p>
-      <div class="cta-row">
-        <a class="button ghost" href="/">Landing</a>
-        <a class="button ghost" href="/avatar.html">Avatar</a>
-        <a class="button ghost" href="/map.html">Mappa</a>
-        <a class="button ghost" href="/profile.html">Profilo</a>
-        <a class="button ghost" href="/events.html">Eventi</a>
-      </div>
-    </header>
+    ${pageHero}
 
     <section class="grid layout-grid">
       <article class="card layout-span-2">


### PR DESCRIPTION
## Summary
- add a reusable page hero shell with breadcrumbs, back links, and configurable call-to-action rows
- refactor landing, hub, profile, events, turns, and avatar pages to consume the shared navigation shortcuts bar
- style the new navigation elements for mobile/desktop and bump the service worker cache version for updated assets

## Testing
- npm run test:pwa


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957cb69f3508326a43b380464677d89)