### PR TITLE
Improve service worker update flow

### DIFF
--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "turni-di-palco-v440d67b1";
+const CACHE_NAME = "turni-di-palco-v440d67b2";
 const OFFLINE_URL = "/index.html";
 const CORE_ASSETS = [
   "/",
@@ -29,6 +29,12 @@ self.addEventListener("activate", (event) => {
       .then((keys) => Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))))
       .then(() => self.clients.claim())
   );
+});
+
+self.addEventListener("message", (event) => {
+  if (event.data === "skipWaiting" || event.data?.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
 });
 
 self.addEventListener("fetch", (event) => {

--- a/apps/pwa/src/avatar.ts
+++ b/apps/pwa/src/avatar.ts
@@ -1,5 +1,6 @@
 import "../../../shared/styles/main.css";
 import { registerServiceWorker } from "./pwa/register-sw";
+import { promptServiceWorkerUpdate } from "./pwa/sw-update";
 import { deriveRpmThumbnail, getAvatarVisual, loadState, saveState } from "./state";
 
 const RPM_ORIGIN = "https://readyplayer.me";
@@ -171,6 +172,10 @@ renderPreview();
 
 registerServiceWorker({
   onReady: () => undefined,
-  onUpdate: () => undefined,
-  onError: () => undefined,
+  onUpdate: (registration) => {
+    promptServiceWorkerUpdate(registration);
+  },
+  onError: (error) => {
+    console.error("Service worker registration failed", error);
+  },
 });

--- a/apps/pwa/src/dev.ts
+++ b/apps/pwa/src/dev.ts
@@ -1,5 +1,6 @@
 import "../../../shared/styles/main.css";
 import { registerServiceWorker } from "./pwa/register-sw";
+import { promptServiceWorkerUpdate } from "./pwa/sw-update";
 import { renderAppBar } from "./components/app-bar";
 import {
   AvatarIcon,
@@ -525,7 +526,9 @@ avatarIconSelect?.addEventListener("change", () => {
 
 registerServiceWorker({
   onReady: () => undefined,
-  onUpdate: () => undefined,
+  onUpdate: (registration) => {
+    promptServiceWorkerUpdate(registration);
+  },
   onError: (error) => {
     console.error("Service worker registration failed", error);
   },

--- a/apps/pwa/src/features/status-card.ts
+++ b/apps/pwa/src/features/status-card.ts
@@ -1,64 +1,90 @@
 import { registerServiceWorker } from "../pwa/register-sw";
+import { applyServiceWorkerUpdate, promptServiceWorkerUpdate } from "../pwa/sw-update";
 
 export function renderStatusCard() {
-    return `
-      <article class="card status">
-        <h2>Status</h2>
-        <dl>
-          <div class="status-line">
-            <dt>Connection</dt>
-            <dd data-connection>Detecting...</dd>
-          </div>
-          <div class="status-line">
-            <dt>Service worker</dt>
-            <dd data-sw-status>Waiting for registration...</dd>
-          </div>
-        </dl>
-        <p class="muted">Toggle rete per test offline. Se c'e un update SW usa il pulsante reload.</p>
-      </article>
-    `;
+  return `
+    <article class="card status">
+      <h2>Status</h2>
+      <dl>
+        <div class="status-line">
+          <dt>Connection</dt>
+          <dd data-connection>Detecting...</dd>
+        </div>
+        <div class="status-line">
+          <dt>Service worker</dt>
+          <dd data-sw-status>Waiting for registration...</dd>
+        </div>
+      </dl>
+      <p class="muted">Toggle rete per test offline. Se c'e un update SW usa il pulsante reload.</p>
+      <div class="status-log" data-sw-error-box hidden>
+        <p class="eyebrow">Log SW</p>
+        <ul class="status-log-list" data-sw-errors></ul>
+      </div>
+    </article>
+  `;
 }
 
 export function attachStatusListeners(root: HTMLElement, reloadButtonSelector: string) {
-    const connectionNode = root.querySelector<HTMLElement>("[data-connection]");
-    const swStatusNode = root.querySelector<HTMLElement>("[data-sw-status]");
-    const reloadButton = root.querySelector<HTMLButtonElement>(reloadButtonSelector);
+  const connectionNode = root.querySelector<HTMLElement>("[data-connection]");
+  const swStatusNode = root.querySelector<HTMLElement>("[data-sw-status]");
+  const swErrorBox = root.querySelector<HTMLElement>("[data-sw-error-box]");
+  const swErrorList = root.querySelector<HTMLUListElement>("[data-sw-errors]");
+  const reloadButton = root.querySelector<HTMLButtonElement>(reloadButtonSelector);
+  let pendingUpdate: ServiceWorkerRegistration | null = null;
 
-    function setConnectionStatus() {
-        if (!connectionNode) return;
-        const online = navigator.onLine;
-        connectionNode.textContent = online ? "Online" : "Offline";
-        connectionNode.dataset.state = online ? "online" : "offline";
+  function setConnectionStatus() {
+    if (!connectionNode) return;
+    const online = navigator.onLine;
+    connectionNode.textContent = online ? "Online" : "Offline";
+    connectionNode.dataset.state = online ? "online" : "offline";
+  }
+
+  function pushServiceWorkerError(message: string) {
+    if (!swErrorList || !swErrorBox) return;
+    const item = document.createElement("li");
+    item.textContent = message;
+    swErrorList.appendChild(item);
+    swErrorBox.hidden = false;
+  }
+
+  window.addEventListener("online", setConnectionStatus);
+  window.addEventListener("offline", setConnectionStatus);
+  setConnectionStatus();
+
+  registerServiceWorker({
+    onReady: () => {
+      pendingUpdate = null;
+      reloadButton?.classList.add("ghost");
+      if (swStatusNode) {
+        swStatusNode.textContent = "Ready for offline use";
+        swStatusNode.dataset.state = "ready";
+      }
+    },
+    onUpdate: (registration) => {
+      pendingUpdate = registration;
+      if (swStatusNode) {
+        swStatusNode.textContent = "Update available - reload to apply";
+        swStatusNode.dataset.state = "update";
+      }
+      reloadButton?.classList.remove("ghost");
+      promptServiceWorkerUpdate(registration);
+    },
+    onError: (error) => {
+      if (swStatusNode) {
+        swStatusNode.textContent = "Service worker failed";
+        swStatusNode.dataset.state = "error";
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      pushServiceWorkerError(message);
+      console.error("Service worker registration failed", error);
+    },
+  });
+
+  reloadButton?.addEventListener("click", () => {
+    if (pendingUpdate) {
+      applyServiceWorkerUpdate(pendingUpdate);
+    } else {
+      window.location.reload();
     }
-
-    window.addEventListener("online", setConnectionStatus);
-    window.addEventListener("offline", setConnectionStatus);
-    setConnectionStatus();
-
-    registerServiceWorker({
-        onReady: () => {
-            if (swStatusNode) {
-                swStatusNode.textContent = "Ready for offline use";
-                swStatusNode.dataset.state = "ready";
-            }
-        },
-        onUpdate: () => {
-            if (swStatusNode) {
-                swStatusNode.textContent = "Update available - reload to apply";
-                swStatusNode.dataset.state = "update";
-            }
-            reloadButton?.classList.remove("ghost");
-        },
-        onError: (error) => {
-            if (swStatusNode) {
-                swStatusNode.textContent = "Service worker failed";
-                swStatusNode.dataset.state = "error";
-            }
-            console.error("Service worker registration failed", error);
-        },
-    });
-
-    reloadButton?.addEventListener("click", () => {
-        window.location.reload();
-    });
+  });
 }

--- a/apps/pwa/src/game.ts
+++ b/apps/pwa/src/game.ts
@@ -1,5 +1,6 @@
 import "../../../shared/styles/main.css";
 import { registerServiceWorker } from "./pwa/register-sw";
+import { promptServiceWorkerUpdate } from "./pwa/sw-update";
 import { formatRewards, getAvatarVisual, loadState, resolveRole } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");
@@ -78,6 +79,10 @@ if (turnLog) {
 
 registerServiceWorker({
   onReady: () => undefined,
-  onUpdate: () => undefined,
-  onError: () => undefined,
+  onUpdate: (registration) => {
+    promptServiceWorkerUpdate(registration);
+  },
+  onError: (error) => {
+    console.error("Service worker registration failed", error);
+  },
 });

--- a/apps/pwa/src/map.ts
+++ b/apps/pwa/src/map.ts
@@ -1,5 +1,6 @@
 import "../../../shared/styles/main.css";
 import { registerServiceWorker } from "./pwa/register-sw";
+import { promptServiceWorkerUpdate } from "./pwa/sw-update";
 import L, { Map as LeafletMap, LayerGroup } from "leaflet";
 import "leaflet/dist/leaflet.css";
 import markerIconPng from "leaflet/dist/images/marker-icon.png";
@@ -336,6 +337,10 @@ window.addEventListener("resize", () => {
 
 registerServiceWorker({
   onReady: () => undefined,
-  onUpdate: () => undefined,
-  onError: () => undefined,
+  onUpdate: (registration) => {
+    promptServiceWorkerUpdate(registration);
+  },
+  onError: (error) => {
+    console.error("Service worker registration failed", error);
+  },
 });

--- a/apps/pwa/src/pwa/register-sw.ts
+++ b/apps/pwa/src/pwa/register-sw.ts
@@ -1,21 +1,35 @@
 type ServiceWorkerCallbacks = {
   onReady?: () => void;
   onRegistered?: (registration: ServiceWorkerRegistration) => void;
-  onUpdate?: () => void;
+  onUpdate?: (registration: ServiceWorkerRegistration, worker?: ServiceWorker | null) => void;
   onError?: (error: unknown) => void;
 };
 
-export function registerServiceWorker(callbacks: ServiceWorkerCallbacks = {}) {
+type ServiceWorkerOptions = {
+  devMode?: "cleanup" | "register";
+  devCleanupRegistrations?: boolean;
+};
+
+export function registerServiceWorker(callbacks: ServiceWorkerCallbacks = {}, options: ServiceWorkerOptions = {}) {
   if (!("serviceWorker" in navigator)) {
     return;
   }
 
-  // In sviluppo: assicurati che eventuali SW vecchi vengano rimossi per evitare cache errate.
+  const devMode: ServiceWorkerOptions["devMode"] =
+    options.devMode ?? (import.meta.env.VITE_SW_DEV === "true" ? "register" : "cleanup");
+  const devCleanupRegistrations = options.devCleanupRegistrations ?? true;
+
+  // In sviluppo: consenti SW controllati solo quando esplicitamente richiesto.
   if (!import.meta.env.PROD) {
-    navigator.serviceWorker.getRegistrations().then((registrations) => {
-      registrations.forEach((registration) => registration.unregister().catch(() => undefined));
-    });
-    return;
+    if (devCleanupRegistrations) {
+      navigator.serviceWorker.getRegistrations().then((registrations) => {
+        registrations.forEach((registration) => registration.unregister().catch(() => undefined));
+      });
+    }
+
+    if (devMode === "cleanup") {
+      return;
+    }
   }
 
   navigator.serviceWorker
@@ -23,7 +37,9 @@ export function registerServiceWorker(callbacks: ServiceWorkerCallbacks = {}) {
     .then((registration) => {
       callbacks.onRegistered?.(registration);
 
-      if (registration.active) {
+      if (registration.waiting && navigator.serviceWorker.controller) {
+        callbacks.onUpdate?.(registration, registration.waiting);
+      } else if (registration.active) {
         callbacks.onReady?.();
       }
 
@@ -36,7 +52,7 @@ export function registerServiceWorker(callbacks: ServiceWorkerCallbacks = {}) {
           const hasController = Boolean(navigator.serviceWorker.controller);
 
           if (isInstalled && hasController) {
-            callbacks.onUpdate?.();
+            callbacks.onUpdate?.(registration, registration.waiting ?? newWorker);
           } else if (isInstalled) {
             callbacks.onReady?.();
           }

--- a/apps/pwa/src/pwa/sw-update.ts
+++ b/apps/pwa/src/pwa/sw-update.ts
@@ -1,0 +1,72 @@
+let activeToast: HTMLDivElement | null = null;
+let pendingRegistration: ServiceWorkerRegistration | null = null;
+
+function dismissToast() {
+  if (activeToast) {
+    activeToast.remove();
+    activeToast = null;
+  }
+}
+
+function reloadWhenReady(registration: ServiceWorkerRegistration) {
+  const reload = () => window.location.reload();
+
+  const onControllerChange = () => {
+    navigator.serviceWorker.removeEventListener("controllerchange", onControllerChange);
+    reload();
+  };
+
+  navigator.serviceWorker.addEventListener("controllerchange", onControllerChange);
+
+  const waitingWorker = registration.waiting ?? registration.installing;
+  if (waitingWorker) {
+    waitingWorker.addEventListener("statechange", () => {
+      if (waitingWorker.state === "activated") {
+        reload();
+      }
+    });
+    waitingWorker.postMessage({ type: "SKIP_WAITING" });
+    waitingWorker.postMessage("skipWaiting");
+  } else {
+    reload();
+  }
+}
+
+export function applyServiceWorkerUpdate(registration: ServiceWorkerRegistration) {
+  dismissToast();
+  reloadWhenReady(registration);
+}
+
+export function promptServiceWorkerUpdate(registration: ServiceWorkerRegistration) {
+  pendingRegistration = registration;
+
+  if (activeToast) {
+    return;
+  }
+
+  const toast = document.createElement("div");
+  toast.className = "toast update-toast";
+  toast.innerHTML = `
+    <div>
+      <p class="eyebrow">Aggiornamento disponibile</p>
+      <p>È pronta una nuova versione offline. Ricarica per applicarla.</p>
+    </div>
+    <div class="toast-actions">
+      <button type="button" class="button ghost" data-action="dismiss-update">Più tardi</button>
+      <button type="button" class="button primary" data-action="apply-update">Ricarica ora</button>
+    </div>
+  `;
+
+  toast.querySelector<HTMLButtonElement>('[data-action="dismiss-update"]')?.addEventListener("click", () => {
+    dismissToast();
+  });
+
+  toast.querySelector<HTMLButtonElement>('[data-action="apply-update"]')?.addEventListener("click", () => {
+    if (pendingRegistration) {
+      applyServiceWorkerUpdate(pendingRegistration);
+    }
+  });
+
+  document.body.appendChild(toast);
+  activeToast = toast;
+}

--- a/apps/pwa/src/style.css
+++ b/apps/pwa/src/style.css
@@ -691,6 +691,26 @@ code {
   font-weight: 600;
 }
 
+.status-log {
+  border-top: 1px solid var(--surface-veil-strong);
+  padding-top: 0.75rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.status-log .eyebrow {
+  color: var(--color-brand-200);
+}
+
+.status-log-list {
+  list-style: disc;
+  padding-left: 1.1rem;
+  margin: 0;
+  color: var(--color-neutral-300);
+  display: grid;
+  gap: 0.25rem;
+}
+
 [data-state="info"] {
   color: var(--color-neutral-200);
 }
@@ -719,6 +739,55 @@ code {
 .muted {
   color: var(--text-muted);
   font-size: 0.95rem;
+}
+
+.toast {
+  position: fixed;
+  bottom: 1.25rem;
+  right: 1.25rem;
+  max-width: 420px;
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 1rem 1.1rem;
+  border-radius: 14px;
+  border: 1px solid var(--border-regular);
+  background: var(--bg-panel);
+  box-shadow:
+    var(--shadow-elevated),
+    inset 0 1px 0 var(--surface-veil-bright);
+  z-index: 40;
+  backdrop-filter: blur(16px);
+}
+
+.toast p {
+  margin: 0;
+}
+
+.toast .eyebrow {
+  color: var(--color-brand-200);
+  font-weight: 700;
+}
+
+.toast-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+@media (max-width: 640px) {
+  .toast {
+    left: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+    width: calc(100% - 2rem);
+    flex-wrap: wrap;
+  }
+
+  .toast-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
 }
 
 .form-grid {


### PR DESCRIPTION
## Summary
- add configurable service worker registration in development plus richer update callbacks
- surface user-facing update prompts and status card logging for service worker errors
- enable skipWaiting message handling in the worker and refresh cache version for the new flow

## Testing
- npm run test:pwa


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957cb6b88688326bb5859d71774144f)