### PR TITLE
Add versioned state handling and sync badges

### DIFF
--- a/apps/pwa/src/avatar.ts
+++ b/apps/pwa/src/avatar.ts
@@ -1,6 +1,6 @@
 import "../../../shared/styles/main.css";
 import { registerServiceWorker } from "./pwa/register-sw";
-import { deriveRpmThumbnail, getAvatarVisual, loadState, saveState } from "./state";
+import { deriveRpmThumbnail, getAvatarVisual, loadState, saveState, SaveStateResult, STORAGE_KEY } from "./state";
 
 const RPM_ORIGIN = "https://readyplayer.me";
 const RPM_SRC = "https://readyplayer.me/avatar?frameApi";
@@ -22,6 +22,9 @@ root.innerHTML = `
         <a class="button ghost" href="/map.html">Mappa</a>
         <a class="button ghost" href="/profile.html">Profilo</a>
         <a class="button ghost" href="/game.html">Hub</a>
+      </div>
+      <div class="badges">
+        <span class="badge" data-sync-badge style="display:none">Stato aggiornato</span>
       </div>
     </header>
 
@@ -64,8 +67,32 @@ const avatarImg = root.querySelector<HTMLImageElement>('[data-avatar-img]');
 const avatarLabel = root.querySelector<HTMLElement>('[data-avatar-label]');
 const avatarMeta = root.querySelector<HTMLElement>('[data-avatar-meta]');
 const avatarUpdated = root.querySelector<HTMLElement>('[data-avatar-updated]');
+const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
 
 let state = loadState();
+let syncBadgeTimeout: number | undefined;
+
+function showSyncBadge(message = "Stato aggiornato") {
+  if (!syncBadge) return;
+  syncBadge.textContent = message;
+  syncBadge.style.display = "inline-flex";
+  if (syncBadgeTimeout) {
+    window.clearTimeout(syncBadgeTimeout);
+  }
+  syncBadgeTimeout = window.setTimeout(() => {
+    if (syncBadge) syncBadge.style.display = "none";
+  }, 2500);
+}
+
+function persistState(nextState: typeof state, feedback?: HTMLElement): SaveStateResult {
+  const result = saveState(nextState);
+  state = result.state;
+  if (!result.ok && feedback) {
+    feedback.dataset.state = "warn";
+    feedback.textContent = "Salvataggio locale non riuscito: manteniamo una copia in memoria.";
+  }
+  return result;
+}
 
 function renderPreview() {
   const avatarVisual = getAvatarVisual(state.profile.avatar);
@@ -130,11 +157,11 @@ function handleExported(url?: string, id?: string, thumb?: string) {
       avatar: { ...state.profile.avatar, rpmUrl: url, rpmThumbnail: derivedThumb, rpmId: id || "", updatedAt: Date.now() },
     },
   };
-  saveState(state);
+  const result = persistState(state, statusBox);
   renderPreview();
   if (statusBox) {
-    statusBox.dataset.state = "ok";
-    statusBox.textContent = "Avatar salvato nel profilo.";
+    statusBox.dataset.state = result.ok ? "ok" : "warn";
+    statusBox.textContent = result.ok ? "Avatar salvato nel profilo." : "Avatar salvato solo in memoria: riprova il salvataggio.";
   }
 }
 
@@ -159,15 +186,28 @@ root.querySelector<HTMLButtonElement>('[data-action="clear-avatar"]')?.addEventL
     ...state,
     profile: { ...state.profile, avatar: { ...state.profile.avatar, rpmUrl: "", rpmThumbnail: "", rpmId: "", updatedAt: undefined } },
   };
-  saveState(state);
+  const result = persistState(state, statusBox);
   renderPreview();
   if (statusBox) {
-    statusBox.dataset.state = "info";
-    statusBox.textContent = "Avatar RPM rimosso. Verrà usato il fallback locale.";
+    statusBox.dataset.state = result.ok ? "info" : "warn";
+    statusBox.textContent = result.ok
+      ? "Avatar RPM rimosso. Verrà usato il fallback locale."
+      : "Avatar rimosso solo in memoria: controlla i permessi di storage.";
   }
 });
 
 renderPreview();
+
+window.addEventListener("storage", (event) => {
+  if (event.key !== STORAGE_KEY) return;
+  state = loadState();
+  renderPreview();
+  showSyncBadge();
+  if (statusBox) {
+    statusBox.dataset.state = "info";
+    statusBox.textContent = "Stato aggiornato da un'altra scheda.";
+  }
+});
 
 registerServiceWorker({
   onReady: () => undefined,

--- a/apps/pwa/src/dev.ts
+++ b/apps/pwa/src/dev.ts
@@ -6,6 +6,8 @@ import {
   GameState,
   Rewards,
   RoleId,
+  SaveStateResult,
+  STORAGE_KEY,
   TurnRecord,
   avatarIcons,
   createDefaultState,
@@ -138,6 +140,9 @@ root.innerHTML = `
         <a class="button primary" href="/game.html">Vai all'hub</a>
         <a class="button ghost" href="/">Torna alla landing</a>
       </div>
+      <div class="badges">
+        <span class="badge" data-sync-badge style="display:none">Stato aggiornato</span>
+      </div>
     </section>
 
     <section class="grid layout-grid gameplay">
@@ -245,8 +250,34 @@ const eventSelect = root.querySelector<HTMLSelectElement>('[data-field="event-se
 const turnRoleSelect = root.querySelector<HTMLSelectElement>('[data-field="turn-role"]');
 const turnFeedbackBox = root.querySelector<HTMLElement>('[data-turn-feedback]');
 const turnLog = root.querySelector<HTMLElement>('[data-turn-log]');
+const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
 
 let gameState: GameState = loadState();
+let syncBadgeTimeout: number | undefined;
+
+function showSyncBadge(message = "Stato aggiornato") {
+  if (!syncBadge) return;
+  syncBadge.textContent = message;
+  syncBadge.style.display = "inline-flex";
+  if (syncBadgeTimeout) {
+    window.clearTimeout(syncBadgeTimeout);
+  }
+  syncBadgeTimeout = window.setTimeout(() => {
+    if (syncBadge) {
+      syncBadge.style.display = "none";
+    }
+  }, 2500);
+}
+
+function persistState(nextState: GameState, feedback?: HTMLElement): SaveStateResult {
+  const result = saveState(nextState);
+  gameState = result.state;
+  if (!result.ok && feedback) {
+    feedback.dataset.state = "warn";
+    feedback.textContent = "Salvataggio locale non riuscito: verrà usato un backup in memoria.";
+  }
+  return result;
+}
 
 function renderAvatarPreview() {
   if (!avatarPreview) return;
@@ -351,7 +382,7 @@ function handleSaveProfile() {
       avatar: { ...gameState.profile.avatar, hue: nextHue, icon: safeIcon },
     },
   };
-  saveState(gameState);
+  persistState(gameState, turnFeedbackBox);
   syncProfileForm();
   renderCareerCard();
   renderTurnHistory();
@@ -365,7 +396,7 @@ function handleResetState() {
   const confirmReset = window.confirm("Reset dello stato locale? Tutti i progressi mock verranno azzerati.");
   if (!confirmReset) return;
   gameState = createDefaultState();
-  saveState(gameState);
+  persistState(gameState, turnFeedbackBox);
   syncProfileForm();
   renderCareerCard();
   renderActivityUI();
@@ -419,7 +450,7 @@ function handleActivityChoice(choiceId: string) {
   const choice = activity.choices.find((item) => item.id === choiceId);
   if (!choice) return;
   applyRewards(choice.rewards);
-  saveState(gameState);
+  persistState(gameState, activityResultBox);
   renderCareerCard();
   if (activityResultBox) {
     activityResultBox.dataset.state = "ok";
@@ -476,13 +507,15 @@ function handleRegisterTurn() {
 
   applyRewards(rewards);
   gameState = { ...gameState, turns: [record, ...gameState.turns].slice(0, MAX_TURNS_STORED) };
-  saveState(gameState);
+  const result = persistState(gameState, turnFeedbackBox);
   renderCareerCard();
   renderTurnHistory();
   renderAvatarPreview();
   if (turnFeedbackBox) {
-    turnFeedbackBox.dataset.state = "ok";
-    turnFeedbackBox.textContent = `Turno registrato: ${selectedEvent.name} (${formatRewards(rewards)})`;
+    turnFeedbackBox.dataset.state = result.ok ? "ok" : "warn";
+    turnFeedbackBox.textContent = result.ok
+      ? `Turno registrato: ${selectedEvent.name} (${formatRewards(rewards)})`
+      : "Turno registrato ma salvataggio locale non riuscito: usa la stessa scheda.";
   }
 }
 
@@ -517,6 +550,17 @@ activityChoices?.addEventListener("click", (event) => {
 
 avatarHueInput?.addEventListener("input", () => {
   handleSaveProfile();
+});
+
+window.addEventListener("storage", (event) => {
+  if (event.key !== STORAGE_KEY) return;
+  gameState = loadState();
+  syncProfileForm();
+  renderCareerCard();
+  renderActivityUI();
+  renderTurnHistory();
+  renderAvatarPreview();
+  showSyncBadge();
 });
 
 avatarIconSelect?.addEventListener("change", () => {

--- a/apps/pwa/src/game.ts
+++ b/apps/pwa/src/game.ts
@@ -1,16 +1,12 @@
 import "../../../shared/styles/main.css";
 import { registerServiceWorker } from "./pwa/register-sw";
-import { formatRewards, getAvatarVisual, loadState, resolveRole } from "./state";
+import { formatRewards, getAvatarVisual, loadState, resolveRole, STORAGE_KEY } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");
 
 if (!root) {
   throw new Error("Root container missing");
 }
-
-const state = loadState();
-const role = resolveRole(state.profile.roleId);
-const avatarVisual = getAvatarVisual(state.profile.avatar);
 
 root.innerHTML = `
   <main class="page page-game layout-shell">
@@ -32,14 +28,14 @@ root.innerHTML = `
       <article class="card">
         <h2>Profilo</h2>
         <div class="profile-pane">
-          <div class="avatar-display large ${avatarVisual.image ? "has-image" : ""}" data-avatar="profile" style="--avatar-color:${avatarVisual.color};--avatar-hue:${state.profile.avatar.hue}deg;">
-            ${avatarVisual.image ? `<img src="${avatarVisual.image}" alt="Avatar ReadyPlayerMe" />` : ""}
-            <span class="avatar-icon">${avatarVisual.icon}</span>
+          <div class="avatar-display large" data-avatar="profile">
+            <img data-avatar-img alt="Avatar ReadyPlayerMe" />
+            <span class="avatar-icon" data-avatar-label></span>
           </div>
           <div>
-            <p class="eyebrow">${state.profile.name || "Profilo non configurato"}</p>
-            <p class="muted">${role.name} | Focus: ${role.focus}</p>
-            <div class="pill-row">${role.stats.map((stat) => `<span class="pill ghost">${stat}</span>`).join("")}</div>
+            <p class="eyebrow" data-player-name>Profilo non configurato</p>
+            <p class="muted" data-player-role>Ruolo non impostato</p>
+            <div class="pill-row" data-role-tags></div>
           </div>
         </div>
       </article>
@@ -47,9 +43,9 @@ root.innerHTML = `
       <article class="card">
         <h2>Statistiche</h2>
         <ul class="stat-list">
-          <li><span>XP</span><strong>${state.profile.xp}</strong></li>
-          <li><span>Cachet</span><strong>${state.profile.cachet}</strong></li>
-          <li><span>Reputazione ATCL</span><strong>${state.profile.repAtcl}</strong></li>
+          <li><span>XP</span><strong data-stat="xp">0</strong></li>
+          <li><span>Cachet</span><strong data-stat="cachet">0</strong></li>
+          <li><span>Reputazione ATCL</span><strong data-stat="rep">0</strong></li>
         </ul>
       </article>
 
@@ -58,11 +54,68 @@ root.innerHTML = `
         <ul class="log-list dense" data-turn-log></ul>
       </article>
     </section>
+    <div class="badges">
+      <span class="badge" data-sync-badge style="display:none">Stato aggiornato</span>
+    </div>
   </main>
 `;
 
+const avatarDisplay = root.querySelector<HTMLElement>('[data-avatar="profile"]');
+const avatarImg = root.querySelector<HTMLImageElement>('[data-avatar-img]');
+const avatarLabel = root.querySelector<HTMLElement>('[data-avatar-label]');
+const nameNode = root.querySelector<HTMLElement>('[data-player-name]');
+const roleNode = root.querySelector<HTMLElement>('[data-player-role]');
+const roleTags = root.querySelector<HTMLElement>('[data-role-tags]');
+const statXp = root.querySelector<HTMLElement>('[data-stat="xp"]');
+const statCachet = root.querySelector<HTMLElement>('[data-stat="cachet"]');
+const statRep = root.querySelector<HTMLElement>('[data-stat="rep"]');
 const turnLog = root.querySelector<HTMLElement>('[data-turn-log]');
-if (turnLog) {
+const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
+let state = loadState();
+let syncBadgeTimeout: number | undefined;
+
+function showSyncBadge(message = "Stato aggiornato") {
+  if (!syncBadge) return;
+  syncBadge.textContent = message;
+  syncBadge.style.display = "inline-flex";
+  if (syncBadgeTimeout) {
+    window.clearTimeout(syncBadgeTimeout);
+  }
+  syncBadgeTimeout = window.setTimeout(() => {
+    if (syncBadge) syncBadge.style.display = "none";
+  }, 2500);
+}
+
+function renderProfile() {
+  const avatarVisual = getAvatarVisual(state.profile.avatar);
+  if (avatarDisplay) {
+    avatarDisplay.style.setProperty("--avatar-color", avatarVisual.color);
+    avatarDisplay.style.setProperty("--avatar-hue", `${state.profile.avatar.hue}deg`);
+    avatarDisplay.classList.toggle("has-image", !!avatarVisual.image);
+  }
+  if (avatarImg) {
+    if (avatarVisual.image) {
+      avatarImg.src = avatarVisual.image;
+      avatarImg.style.display = "block";
+    } else {
+      avatarImg.removeAttribute("src");
+      avatarImg.style.display = "none";
+    }
+  }
+  if (avatarLabel) avatarLabel.textContent = avatarVisual.icon;
+  const role = resolveRole(state.profile.roleId);
+  if (nameNode) nameNode.textContent = state.profile.name || "Profilo non configurato";
+  if (roleNode) roleNode.textContent = `${role.name} | Focus: ${role.focus}`;
+  if (roleTags) {
+    roleTags.innerHTML = role.stats.map((stat) => `<span class="pill ghost">${stat}</span>`).join("");
+  }
+  if (statXp) statXp.textContent = state.profile.xp.toString();
+  if (statCachet) statCachet.textContent = state.profile.cachet.toString();
+  if (statRep) statRep.textContent = state.profile.repAtcl.toString();
+}
+
+function renderTurns() {
+  if (!turnLog) return;
   if (!state.turns.length) {
     turnLog.innerHTML = `<li class="muted">Nessun turno registrato.</li>`;
   } else {
@@ -75,6 +128,17 @@ if (turnLog) {
       .join("");
   }
 }
+
+renderProfile();
+renderTurns();
+
+window.addEventListener("storage", (event) => {
+  if (event.key !== STORAGE_KEY) return;
+  state = loadState();
+  renderProfile();
+  renderTurns();
+  showSyncBadge();
+});
 
 registerServiceWorker({
   onReady: () => undefined,

--- a/apps/pwa/src/map.ts
+++ b/apps/pwa/src/map.ts
@@ -6,7 +6,7 @@ import markerIconPng from "leaflet/dist/images/marker-icon.png";
 import markerShadowPng from "leaflet/dist/images/marker-shadow.png";
 import { renderChip } from "./components/chip";
 import { renderStatPill } from "./components/stat-pill";
-import { formatRewards, getAvatarVisual, loadState, mockEvents, resolveRole, Rewards, saveState } from "./state";
+import { formatRewards, GameState, getAvatarVisual, loadState, mockEvents, resolveRole, Rewards, saveState, SaveStateResult, STORAGE_KEY } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");
 
@@ -50,6 +50,7 @@ root.innerHTML = `
           </div>
         </div>
         <div class="top-stats">${topStatsMarkup}</div>
+        <span class="badge" data-sync-badge style="display:none">Stato aggiornato</span>
         <a class="button ghost" href="/avatar.html">Avatar</a>
         <a class="button ghost" href="/">Landing</a>
         <a class="button ghost" href="/profile.html">Profilo</a>
@@ -125,10 +126,12 @@ const topStatCachet = root.querySelector<HTMLElement>('[data-top-stat="cachet"]'
 const topStatRep = root.querySelector<HTMLElement>('[data-top-stat="rep"]');
 const drawerTabs = Array.from(root.querySelectorAll<HTMLButtonElement>("[data-drawer-tab]"));
 const drawerSections = Array.from(root.querySelectorAll<HTMLElement>("[data-section]"));
+const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
 
-let state = loadState();
+let state: GameState = loadState();
 let map: LeafletMap | null = null;
 let markerLayer: LayerGroup | null = null;
+let syncBadgeTimeout: number | undefined;
 const markerIcon = L.icon({
   iconUrl: markerIconPng,
   shadowUrl: markerShadowPng,
@@ -136,6 +139,30 @@ const markerIcon = L.icon({
   popupAnchor: [1, -28],
   tooltipAnchor: [12, -16],
 });
+
+function showSyncBadge(message = "Stato aggiornato") {
+  if (!syncBadge) return;
+  syncBadge.textContent = message;
+  syncBadge.style.display = "inline-flex";
+  if (syncBadgeTimeout) {
+    window.clearTimeout(syncBadgeTimeout);
+  }
+  syncBadgeTimeout = window.setTimeout(() => {
+    if (syncBadge) {
+      syncBadge.style.display = "none";
+    }
+  }, 2500);
+}
+
+function persistState(nextState: GameState, feedback?: HTMLElement): SaveStateResult {
+  const result = saveState(nextState);
+  state = result.state;
+  if (!result.ok && feedback) {
+    feedback.dataset.state = "warn";
+    feedback.textContent = "Salvataggio locale non riuscito, manteniamo una copia in memoria.";
+  }
+  return result;
+}
 
 function renderProfile() {
   const profile = state.profile;
@@ -265,11 +292,11 @@ function applyQuick(rewards: Rewards, label: string) {
       repAtcl: state.profile.repAtcl + rewards.reputation,
     },
   };
-  saveState(state);
+  const result = persistState(state, quickResult || profileState);
   renderProfile();
   if (quickResult) {
-    quickResult.dataset.state = "ok";
-    quickResult.textContent = `${label}: ${formatRewards(rewards)}`;
+    quickResult.dataset.state = result.ok ? "ok" : "warn";
+    quickResult.textContent = result.ok ? `${label}: ${formatRewards(rewards)}` : `${label}: salvato solo in memoria.`;
   }
 }
 
@@ -301,6 +328,7 @@ root.querySelector<HTMLButtonElement>('[data-action="sync-state"]')?.addEventLis
     quickResult.dataset.state = "info";
     quickResult.textContent = "Stato ricaricato dal profilo principale.";
   }
+  showSyncBadge("Stato aggiornato");
 });
 
 root.querySelector<HTMLButtonElement>('[data-action="quick-train"]')?.addEventListener("click", () => {
@@ -332,6 +360,19 @@ window.setTimeout(() => {
 }, 200);
 window.addEventListener("resize", () => {
   map?.invalidateSize();
+});
+
+window.addEventListener("storage", (event) => {
+  if (event.key !== STORAGE_KEY) return;
+  state = loadState();
+  renderProfile();
+  renderTurns();
+  renderMapMarkers();
+  showSyncBadge();
+  if (quickResult) {
+    quickResult.dataset.state = "info";
+    quickResult.textContent = "Sincronizzato da un'altra scheda.";
+  }
 });
 
 registerServiceWorker({

--- a/apps/pwa/src/map.ts
+++ b/apps/pwa/src/map.ts
@@ -243,6 +243,8 @@ function persistState(nextState: typeof state, feedback?: HTMLElement | null): S
     feedback.textContent = "Salvataggio locale non riuscito, manteniamo una copia in memoria.";
   }
   return result;
+}
+
 function toRadians(value: number) {
   return (value * Math.PI) / 180;
 }

--- a/apps/pwa/src/profile.ts
+++ b/apps/pwa/src/profile.ts
@@ -1,5 +1,5 @@
 import "../../../shared/styles/main.css";
-import { formatRewards, getAvatarVisual, loadState, resolveRole } from "./state";
+import { formatRewards, getAvatarVisual, loadState, resolveRole, STORAGE_KEY } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");
 
@@ -19,6 +19,9 @@ root.innerHTML = `
         <a class="button ghost" href="/map.html">Mappa</a>
         <a class="button ghost" href="/events.html">Eventi</a>
         <a class="button ghost" href="/turns.html">Turni</a>
+      </div>
+      <div class="badges">
+        <span class="badge" data-sync-badge style="display:none">Stato aggiornato</span>
       </div>
     </header>
 
@@ -62,51 +65,77 @@ const statXp = root.querySelector<HTMLElement>('[data-stat="xp"]');
 const statCachet = root.querySelector<HTMLElement>('[data-stat="cachet"]');
 const statRep = root.querySelector<HTMLElement>('[data-stat="rep"]');
 const turnLog = root.querySelector<HTMLElement>('[data-turn-log]');
+const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
 
-const state = loadState();
-const avatarVisual = getAvatarVisual(state.profile.avatar);
-if (avatarDisplay) {
-  avatarDisplay.style.setProperty("--avatar-color", avatarVisual.color);
-  avatarDisplay.style.setProperty("--avatar-hue", `${state.profile.avatar.hue}deg`);
-  avatarDisplay.classList.toggle("has-image", !!avatarVisual.image);
+let state = loadState();
+let syncBadgeTimeout: number | undefined;
+
+function showSyncBadge(message = "Stato aggiornato") {
+  if (!syncBadge) return;
+  syncBadge.textContent = message;
+  syncBadge.style.display = "inline-flex";
+  if (syncBadgeTimeout) {
+    window.clearTimeout(syncBadgeTimeout);
+  }
+  syncBadgeTimeout = window.setTimeout(() => {
+    if (syncBadge) syncBadge.style.display = "none";
+  }, 2500);
 }
-if (avatarImg) {
-  if (avatarVisual.image) {
-    avatarImg.src = avatarVisual.image;
-    avatarImg.style.display = "block";
-  } else {
-    avatarImg.removeAttribute("src");
-    avatarImg.style.display = "none";
+
+function renderProfile() {
+  const avatarVisual = getAvatarVisual(state.profile.avatar);
+  if (avatarDisplay) {
+    avatarDisplay.style.setProperty("--avatar-color", avatarVisual.color);
+    avatarDisplay.style.setProperty("--avatar-hue", `${state.profile.avatar.hue}deg`);
+    avatarDisplay.classList.toggle("has-image", !!avatarVisual.image);
+  }
+  if (avatarImg) {
+    if (avatarVisual.image) {
+      avatarImg.src = avatarVisual.image;
+      avatarImg.style.display = "block";
+    } else {
+      avatarImg.removeAttribute("src");
+      avatarImg.style.display = "none";
+    }
+  }
+  if (avatarLabel) {
+    avatarLabel.textContent = avatarVisual.icon;
+  }
+
+  if (nameNode) {
+    nameNode.textContent = state.profile.name || "Profilo non configurato";
+  }
+  const role = resolveRole(state.profile.roleId);
+  if (roleNode) {
+    roleNode.textContent = `${role.name} - Focus: ${role.focus}`;
+  }
+  if (roleTags) {
+    roleTags.innerHTML = role.stats.map((stat) => `<span class="pill ghost">${stat}</span>`).join("");
+  }
+  if (statXp) statXp.textContent = state.profile.xp.toString();
+  if (statCachet) statCachet.textContent = state.profile.cachet.toString();
+  if (statRep) statRep.textContent = state.profile.repAtcl.toString();
+
+  if (turnLog) {
+    if (!state.turns.length) {
+      turnLog.innerHTML = `<li class="muted">Nessun turno registrato.</li>`;
+    } else {
+      turnLog.innerHTML = state.turns
+        .slice(0, 8)
+        .map(
+          (turn) =>
+            `<li><div><strong>${turn.eventName}</strong> - ${turn.theatre} - ${turn.date}</div><div class="muted">${resolveRole(turn.roleId).name} | ${formatRewards(turn.rewards)}</div></li>`
+        )
+        .join("");
+    }
   }
 }
-if (avatarLabel) {
-  avatarLabel.textContent = avatarVisual.icon;
-}
 
-if (nameNode) {
-  nameNode.textContent = state.profile.name || "Profilo non configurato";
-}
-const role = resolveRole(state.profile.roleId);
-if (roleNode) {
-  roleNode.textContent = `${role.name} - Focus: ${role.focus}`;
-}
-if (roleTags) {
-  roleTags.innerHTML = role.stats.map((stat) => `<span class="pill ghost">${stat}</span>`).join("");
-}
-if (statXp) statXp.textContent = state.profile.xp.toString();
-if (statCachet) statCachet.textContent = state.profile.cachet.toString();
-if (statRep) statRep.textContent = state.profile.repAtcl.toString();
+renderProfile();
 
-if (turnLog) {
-  if (!state.turns.length) {
-    turnLog.innerHTML = `<li class="muted">Nessun turno registrato.</li>`;
-  } else {
-    turnLog.innerHTML = state.turns
-      .slice(0, 8)
-      .map(
-        (turn) =>
-          `<li><div><strong>${turn.eventName}</strong> - ${turn.theatre} - ${turn.date}</div><div class="muted">${resolveRole(turn.roleId).name} | ${formatRewards(turn.rewards)}</div></li>`
-      )
-      .join("");
-  }
-}
+window.addEventListener("storage", (event) => {
+  if (event.key !== STORAGE_KEY) return;
+  state = loadState();
+  renderProfile();
+  showSyncBadge();
+});

--- a/apps/pwa/src/state.ts
+++ b/apps/pwa/src/state.ts
@@ -29,7 +29,8 @@ export type TurnRecord = {
   rewards: Rewards;
 };
 export type PlayerProfile = { name: string; roleId: RoleId; xp: number; cachet: number; repAtcl: number; avatar: AvatarSettings };
-export type GameState = { profile: PlayerProfile; turns: TurnRecord[] };
+export type GameState = { version: number; profile: PlayerProfile; turns: TurnRecord[]; checksum: string };
+export type SaveStateResult = { ok: boolean; state: GameState; error?: string };
 
 export const roles: Role[] = [
   { id: "attore", name: "Attore / Attrice", focus: "Presenza scenica", stats: ["Presenza", "Memoria", "Versatilita"] },
@@ -77,19 +78,144 @@ export const mockEvents: GameEvent[] = [
 ];
 
 export const STORAGE_KEY = "tdp-game-state";
+export const CURRENT_STATE_VERSION = 1;
 
-export function createDefaultState(): GameState {
+const MAX_TURNS_PERSISTED = 50;
+
+let memoryFallback: GameState | null = null;
+
+function clampHue(value: number, fallback: number) {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.min(360, Math.round(value)));
+}
+
+function createDefaultProfile(): PlayerProfile {
   return {
-    profile: {
-      name: "",
-      roleId: "attore",
-      xp: 0,
-      cachet: 0,
-      repAtcl: 0,
-      avatar: { hue: 210, icon: "mask", rpmUrl: "", rpmThumbnail: "", rpmId: "", updatedAt: undefined },
-    },
+    name: "",
+    roleId: "attore",
+    xp: 0,
+    cachet: 0,
+    repAtcl: 0,
+    avatar: { hue: 210, icon: "mask", rpmUrl: "", rpmThumbnail: "", rpmId: "", updatedAt: undefined },
+  };
+}
+
+function baseState(): Omit<GameState, "checksum"> {
+  return {
+    version: CURRENT_STATE_VERSION,
+    profile: createDefaultProfile(),
     turns: [],
   };
+}
+
+function sanitizeNumber(value: unknown, fallback: number) {
+  if (typeof value !== "number" || Number.isNaN(value)) return fallback;
+  return Math.max(0, value);
+}
+
+function sanitizeAvatar(raw: Partial<AvatarSettings> | undefined, base: AvatarSettings): AvatarSettings {
+  const hue = clampHue(typeof raw?.hue === "number" ? raw.hue : base.hue, base.hue);
+  const icon = avatarIcons.some((item) => item.id === raw?.icon) ? (raw?.icon as AvatarIcon) : base.icon;
+  const rpmUrl = typeof raw?.rpmUrl === "string" ? raw.rpmUrl : "";
+  const rpmThumbnailCandidate = typeof raw?.rpmThumbnail === "string" ? raw.rpmThumbnail : "";
+  const rpmThumbnail = rpmThumbnailCandidate || deriveRpmThumbnail(rpmUrl) || base.rpmThumbnail;
+  const rpmId = typeof raw?.rpmId === "string" ? raw.rpmId : "";
+  const updatedAt = typeof raw?.updatedAt === "number" ? raw.updatedAt : undefined;
+  return { ...base, hue, icon, rpmUrl, rpmThumbnail, rpmId, updatedAt };
+}
+
+function sanitizeRewards(raw: Partial<Rewards> | undefined): Rewards {
+  return {
+    xp: sanitizeNumber(raw?.xp, 0),
+    cachet: sanitizeNumber(raw?.cachet, 0),
+    reputation: sanitizeNumber(raw?.reputation, 0),
+  };
+}
+
+function sanitizeTurn(raw: unknown, fallbackRole: RoleId): TurnRecord | null {
+  if (!raw || typeof raw !== "object") return null;
+  const turn = raw as Partial<TurnRecord>;
+  const id = typeof turn.id === "string" ? turn.id : "";
+  const eventId = typeof turn.eventId === "string" ? turn.eventId : "";
+  const eventName = typeof turn.eventName === "string" ? turn.eventName : "";
+  const theatre = typeof turn.theatre === "string" ? turn.theatre : "";
+  const date = typeof turn.date === "string" ? turn.date : "";
+  if (!id || !eventId || !eventName || !theatre || !date) return null;
+  const roleId = typeof turn.roleId === "string" && turn.roleId in roleMap ? (turn.roleId as RoleId) : fallbackRole;
+  const rewards = sanitizeRewards(turn.rewards);
+  return { id, eventId, eventName, theatre, date, roleId, rewards };
+}
+
+function sanitizeTurns(rawTurns: unknown[], fallbackRole: RoleId): TurnRecord[] {
+  const clean = rawTurns
+    .map((turn) => sanitizeTurn(turn, fallbackRole))
+    .filter(Boolean) as TurnRecord[];
+  return clean.slice(0, MAX_TURNS_PERSISTED);
+}
+
+function normalizeProfile(rawProfile: Partial<PlayerProfile> | undefined, base: PlayerProfile): PlayerProfile {
+  const safeRole = rawProfile?.roleId && rawProfile.roleId in roleMap ? rawProfile.roleId : base.roleId;
+  return {
+    ...base,
+    ...rawProfile,
+    name: typeof rawProfile?.name === "string" ? rawProfile.name : base.name,
+    roleId: safeRole as RoleId,
+    xp: sanitizeNumber(rawProfile?.xp, base.xp),
+    cachet: sanitizeNumber(rawProfile?.cachet, base.cachet),
+    repAtcl: sanitizeNumber(rawProfile?.repAtcl, base.repAtcl),
+    avatar: sanitizeAvatar(rawProfile?.avatar, base.avatar),
+  };
+}
+
+function computeChecksum(input: string) {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+  }
+  return (hash >>> 0).toString(16);
+}
+
+function calculateStateChecksum(avatar: AvatarSettings, turns: TurnRecord[]) {
+  const payload = JSON.stringify({ avatar, turns });
+  return computeChecksum(payload);
+}
+
+function attachChecksum(state: Omit<GameState, "checksum"> & Partial<Pick<GameState, "checksum">>): GameState {
+  const checksum = calculateStateChecksum(state.profile.avatar, state.turns);
+  return { ...state, checksum };
+}
+
+function normalizeState(raw: Partial<GameState> | null | undefined): GameState {
+  const base = baseState();
+  const profile = normalizeProfile(raw?.profile, base.profile);
+  const turns = Array.isArray(raw?.turns) ? sanitizeTurns(raw.turns, profile.roleId) : [];
+  const version = typeof raw?.version === "number" ? raw.version : 0;
+  const nextVersion = version < CURRENT_STATE_VERSION ? CURRENT_STATE_VERSION : version;
+  const candidate: Omit<GameState, "checksum"> = { version: nextVersion, profile, turns };
+  const normalized = attachChecksum(candidate);
+  if (raw?.checksum && raw.checksum !== normalized.checksum) {
+    console.warn("Game state checksum mismatch. A sanitized copy will be used instead.");
+  }
+  return normalized;
+}
+
+export function createDefaultState(): GameState {
+  return normalizeState(baseState());
+}
+
+const migrations: ((state: GameState) => GameState)[] = [
+  (state) => (state.version < CURRENT_STATE_VERSION ? { ...state, version: CURRENT_STATE_VERSION } : state),
+  (state) => attachChecksum(state),
+];
+
+function migrateState(raw: Partial<GameState> | null): GameState {
+  const normalized = normalizeState(raw);
+  const migrated = migrations.reduce((acc, step) => step(acc), normalized);
+  if ((raw?.version ?? 0) < CURRENT_STATE_VERSION) {
+    console.info(`Game state migrated to version ${CURRENT_STATE_VERSION}`);
+  }
+  return migrated;
 }
 
 export const roleMap = roles.reduce<Record<RoleId, Role>>((acc, role) => {
@@ -132,32 +258,28 @@ export function getAvatarVisual(avatar: AvatarSettings) {
 export function loadState(): GameState {
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return createDefaultState();
-    const parsed = JSON.parse(raw) as GameState;
-    if (!parsed.profile || !parsed.profile.roleId) return createDefaultState();
-    const base = createDefaultState();
-    const safeRole = parsed.profile.roleId in roleMap ? parsed.profile.roleId : base.profile.roleId;
-    const safeAvatar: AvatarSettings = {
-      hue: typeof parsed.profile.avatar?.hue === "number" ? Math.max(0, Math.min(360, parsed.profile.avatar.hue)) : base.profile.avatar.hue,
-      icon: avatarIcons.some((item) => item.id === parsed.profile.avatar?.icon) ? (parsed.profile.avatar?.icon as AvatarIcon) : base.profile.avatar.icon,
-      rpmUrl: typeof parsed.profile.avatar?.rpmUrl === "string" ? parsed.profile.avatar.rpmUrl : "",
-      rpmThumbnail: typeof parsed.profile.avatar?.rpmThumbnail === "string" ? parsed.profile.avatar.rpmThumbnail : "",
-      rpmId: typeof parsed.profile.avatar?.rpmId === "string" ? parsed.profile.avatar.rpmId : "",
-      updatedAt: typeof parsed.profile.avatar?.updatedAt === "number" ? parsed.profile.avatar.updatedAt : undefined,
-    };
-    return {
-      profile: { ...base.profile, ...parsed.profile, roleId: safeRole, avatar: safeAvatar },
-      turns: Array.isArray(parsed.turns) ? parsed.turns : [],
-    };
+    const parsed = raw ? (JSON.parse(raw) as Partial<GameState>) : null;
+    const migrated = migrateState(parsed);
+    memoryFallback = migrated;
+    return migrated;
   } catch {
-    return createDefaultState();
+    console.error("Failed to load game state from storage, using fallback.");
+    if (memoryFallback) return memoryFallback;
+    const fallback = createDefaultState();
+    memoryFallback = fallback;
+    return fallback;
   }
 }
 
-export function saveState(state: GameState) {
+export function saveState(state: GameState): SaveStateResult {
+  const prepared = attachChecksum({ ...state, version: CURRENT_STATE_VERSION });
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-  } catch {
-    // ignore storage errors
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(prepared));
+    memoryFallback = prepared;
+    return { ok: true, state: prepared };
+  } catch (error) {
+    console.error("Failed to persist game state, using in-memory fallback.", error);
+    memoryFallback = prepared;
+    return { ok: false, state: prepared, error: error instanceof Error ? error.message : "Unknown storage error" };
   }
 }

--- a/apps/pwa/src/turns.ts
+++ b/apps/pwa/src/turns.ts
@@ -1,5 +1,5 @@
 import "../../../shared/styles/main.css";
-import { formatRewards, loadState, resolveRole } from "./state";
+import { formatRewards, loadState, resolveRole, STORAGE_KEY } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");
 
@@ -20,6 +20,9 @@ root.innerHTML = `
         <a class="button ghost" href="/profile.html">Profilo</a>
         <a class="button ghost" href="/events.html">Eventi</a>
       </div>
+      <div class="badges">
+        <span class="badge" data-sync-badge style="display:none">Stato aggiornato</span>
+      </div>
     </header>
 
     <section class="grid layout-grid">
@@ -32,9 +35,25 @@ root.innerHTML = `
 `;
 
 const turnList = root.querySelector<HTMLElement>('[data-turn-list]');
-const state = loadState();
+const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
 
-if (turnList) {
+let state = loadState();
+let syncBadgeTimeout: number | undefined;
+
+function showSyncBadge(message = "Stato aggiornato") {
+  if (!syncBadge) return;
+  syncBadge.textContent = message;
+  syncBadge.style.display = "inline-flex";
+  if (syncBadgeTimeout) {
+    window.clearTimeout(syncBadgeTimeout);
+  }
+  syncBadgeTimeout = window.setTimeout(() => {
+    if (syncBadge) syncBadge.style.display = "none";
+  }, 2500);
+}
+
+function renderTurns() {
+  if (!turnList) return;
   if (!state.turns.length) {
     turnList.innerHTML = `<li class="muted">Nessun turno registrato.</li>`;
   } else {
@@ -46,3 +65,12 @@ if (turnList) {
       .join("");
   }
 }
+
+renderTurns();
+
+window.addEventListener("storage", (event) => {
+  if (event.key !== STORAGE_KEY) return;
+  state = loadState();
+  renderTurns();
+  showSyncBadge();
+});


### PR DESCRIPTION
## Summary
- version the game state payload, add checksum validation, and migrate legacy storage safely with in-memory fallbacks
- surface storage sync badges across app pages and refresh UIs when localStorage changes in another tab
- harden saves with defensive write paths, user-facing warnings, and validation for avatar and turn payloads

## Testing
- npm run test:pwa


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957cb6de9a88326b79b2c97d96c579a)