### PR TITLE
Add progression milestones and turn log analytics

### DIFF
--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "turni-di-palco-v440d67b1";
+const CACHE_NAME = "turni-di-palco-vc7b1f2d4";
 const OFFLINE_URL = "/index.html";
 const CORE_ASSETS = [
   "/",

--- a/apps/pwa/src/dev.ts
+++ b/apps/pwa/src/dev.ts
@@ -17,6 +17,7 @@ import {
   roles,
   saveState,
 } from "./state";
+import { buildProgressCopy, getEarnedMilestones, getProgressState, repMilestones, xpMilestones } from "./progression";
 
 type ActivityChoice = { id: string; label: string; summary: string; rewards: Rewards };
 type Activity = { id: string; title: string; description: string; choices: ActivityChoice[] };
@@ -58,6 +59,8 @@ const devNav = [
 
 const devAppBar = renderAppBar({ eyebrow: "Turni di Palco", subtitle: "Dev playground", actions: devNav });
 
+const ACTIVITY_COOLDOWN_MS = 20000;
+const MAX_ACTIVITY_RUNS = 3;
 const activities: Activity[] = [
   {
     id: "ritardo",
@@ -184,8 +187,37 @@ root.innerHTML = `
           <li><span>Cachet</span><strong data-stat="cachet">0</strong></li>
           <li><span>Reputazione ATCL</span><strong data-stat="rep">0</strong></li>
         </ul>
+        <div class="progress-grid">
+          <div class="progress-track" data-track="xp">
+            <div class="progress-head">
+              <div>
+                <p class="eyebrow">Crescita XP</p>
+                <p class="muted" data-progress-copy="xp">Registrando turni e attivita sblocchi milestone XP.</p>
+              </div>
+              <strong data-progress-value="xp">0 XP</strong>
+            </div>
+            <div class="progress-bar" role="progressbar" aria-label="Progresso XP" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+              <span class="progress-fill" data-progress-bar="xp" style="width: 0%"></span>
+            </div>
+          </div>
+          <div class="progress-track" data-track="rep">
+            <div class="progress-head">
+              <div>
+                <p class="eyebrow">Reputazione</p>
+                <p class="muted" data-progress-copy="rep">Cura i turni per ottenere badge di reputazione.</p>
+              </div>
+              <strong data-progress-value="rep">0 rep</strong>
+            </div>
+            <div class="progress-bar" role="progressbar" aria-label="Progresso reputazione" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+              <span class="progress-fill accent" data-progress-bar="rep" style="width: 0%"></span>
+            </div>
+          </div>
+        </div>
         <div class="pill-row" data-role-stats></div>
-        <p class="muted" data-career-note>Seleziona un ruolo per vedere le competenze chiave.</p>
+        <div class="badge-panel">
+          <div class="badge-grid" data-badge-list></div>
+          <p class="muted" data-career-note>Seleziona un ruolo per vedere le competenze chiave.</p>
+        </div>
       </article>
 
       <article class="card">
@@ -196,6 +228,17 @@ root.innerHTML = `
             <select data-field="activity-select"></select>
           </label>
           <p class="muted" data-activity-description>Seleziona uno scenario per avviare una micro-attivita narrativa.</p>
+          <div class="inline-alert" data-activity-tutorial>
+            <div>
+              <p class="eyebrow">Tutorial</p>
+              <p class="muted">Scegli una opzione per sbloccare le attivita e registrare la prima scelta guidata.</p>
+            </div>
+            <button class="button ghost small" type="button" data-action="dismiss-tutorial">Segna come letto</button>
+          </div>
+          <div class="meta-row">
+            <span class="meta-chip" data-activity-guard>Cooldown attivita pronto.</span>
+            <span class="meta-chip ghost" data-activity-limit>Limite sessione: 0 / ${MAX_ACTIVITY_RUNS}</span>
+          </div>
           <div class="cta-row" data-activity-choices></div>
           <div class="result-box" data-activity-result>Ancora nessuna attivita eseguita.</div>
         </div>
@@ -235,12 +278,22 @@ const avatarIconSelect = root.querySelector<HTMLSelectElement>('[data-avatar-ico
 const statXp = root.querySelector<HTMLElement>('[data-stat="xp"]');
 const statCachet = root.querySelector<HTMLElement>('[data-stat="cachet"]');
 const statRep = root.querySelector<HTMLElement>('[data-stat="rep"]');
+const progressCopyXp = root.querySelector<HTMLElement>('[data-progress-copy="xp"]');
+const progressCopyRep = root.querySelector<HTMLElement>('[data-progress-copy="rep"]');
+const progressValueXp = root.querySelector<HTMLElement>('[data-progress-value="xp"]');
+const progressValueRep = root.querySelector<HTMLElement>('[data-progress-value="rep"]');
+const progressBarXp = root.querySelector<HTMLElement>('[data-progress-bar="xp"]');
+const progressBarRep = root.querySelector<HTMLElement>('[data-progress-bar="rep"]');
+const badgeList = root.querySelector<HTMLElement>('[data-badge-list]');
 const roleStatsContainer = root.querySelector<HTMLElement>('[data-role-stats]');
 const careerNote = root.querySelector<HTMLElement>('[data-career-note]');
 const activitySelect = root.querySelector<HTMLSelectElement>('[data-field="activity-select"]');
 const activityDescription = root.querySelector<HTMLElement>('[data-activity-description]');
 const activityChoices = root.querySelector<HTMLElement>('[data-activity-choices]');
 const activityResultBox = root.querySelector<HTMLElement>('[data-activity-result]');
+const activityGuardChip = root.querySelector<HTMLElement>('[data-activity-guard]');
+const activityLimitChip = root.querySelector<HTMLElement>('[data-activity-limit]');
+const tutorialBox = root.querySelector<HTMLElement>('[data-activity-tutorial]');
 const eventSelect = root.querySelector<HTMLSelectElement>('[data-field="event-select"]');
 const turnRoleSelect = root.querySelector<HTMLSelectElement>('[data-field="turn-role"]');
 const turnFeedbackBox = root.querySelector<HTMLElement>('[data-turn-feedback]');
@@ -300,6 +353,30 @@ function renderAvatarOptions() {
   avatarIconSelect.innerHTML = avatarIcons.map((item) => `<option value="${item.id}">${item.label}</option>`).join("");
 }
 
+function getActivityStats(activityId: string) {
+  return gameState.activityStats[activityId] ?? { runs: 0, lastPlayedAt: undefined };
+}
+
+function renderActivityGuard(activityId: string) {
+  if (!activityGuardChip || !activityLimitChip) return;
+  const stats = getActivityStats(activityId);
+  const now = Date.now();
+  const remainingSeconds = stats.lastPlayedAt ? Math.max(0, Math.ceil((ACTIVITY_COOLDOWN_MS - (now - stats.lastPlayedAt)) / 1000)) : 0;
+  if (remainingSeconds > 0) {
+    activityGuardChip.textContent = `Cooldown: attendi ${remainingSeconds}s prima di ripetere.`;
+    activityGuardChip.dataset.state = "warn";
+  } else {
+    activityGuardChip.textContent = "Cooldown attivita pronto.";
+    activityGuardChip.dataset.state = "ok";
+  }
+  activityLimitChip.textContent = `Limite sessione: ${Math.min(stats.runs, MAX_ACTIVITY_RUNS)} / ${MAX_ACTIVITY_RUNS}`;
+  activityLimitChip.dataset.state = stats.runs >= MAX_ACTIVITY_RUNS ? "warn" : "info";
+}
+
+function renderTutorialBox() {
+  if (!tutorialBox) return;
+  tutorialBox.style.display = gameState.tutorial.firstChoiceComplete ? "none" : "grid";
+}
 function renderEvents() {
   if (!eventSelect) return;
   if (!devEvents.length) {
@@ -318,6 +395,41 @@ function renderCareerCard() {
   if (statXp) statXp.textContent = gameState.profile.xp.toString();
   if (statCachet) statCachet.textContent = gameState.profile.cachet.toString();
   if (statRep) statRep.textContent = gameState.profile.repAtcl.toString();
+
+  const xpProgress = getProgressState(gameState.profile.xp, xpMilestones);
+  const repProgress = getProgressState(gameState.profile.repAtcl, repMilestones);
+  if (progressValueXp) progressValueXp.textContent = `${gameState.profile.xp} XP`;
+  if (progressValueRep) progressValueRep.textContent = `${gameState.profile.repAtcl} rep`;
+  if (progressCopyXp) progressCopyXp.textContent = buildProgressCopy(xpProgress, "XP");
+  if (progressCopyRep) progressCopyRep.textContent = buildProgressCopy(repProgress, "punti rep");
+  if (progressBarXp) {
+    progressBarXp.style.width = `${xpProgress.percent}%`;
+    progressBarXp.parentElement?.setAttribute("aria-valuenow", xpProgress.percent.toString());
+  }
+  if (progressBarRep) {
+    progressBarRep.style.width = `${repProgress.percent}%`;
+    progressBarRep.parentElement?.setAttribute("aria-valuenow", repProgress.percent.toString());
+  }
+
+  const earnedXp = getEarnedMilestones(gameState.profile.xp, xpMilestones);
+  const earnedRep = getEarnedMilestones(gameState.profile.repAtcl, repMilestones);
+  const seen = new Set<string>();
+  const repIds = new Set(repMilestones.map((item) => item.id));
+  const badges = [...earnedXp, ...earnedRep].filter((item) => {
+    if (seen.has(item.id)) return false;
+    seen.add(item.id);
+    return true;
+  });
+  if (badgeList) {
+    badgeList.innerHTML = badges.length
+      ? badges
+          .map(
+            (badge) =>
+              `<span class="badge-chip">${badge.label}<small>${badge.target}${repIds.has(badge.id) ? " rep" : " XP"}</small></span>`
+          )
+          .join("")
+      : '<span class="badge-chip ghost">Completa una milestone XP/rep per sbloccare un badge.</span>';
+  }
 
   if (roleStatsContainer) {
     const role = resolveRole(gameState.profile.roleId);
@@ -369,8 +481,12 @@ function handleResetState() {
   syncProfileForm();
   renderCareerCard();
   renderActivityUI();
+  if (activities.length) {
+    renderActivityGuard(activities[0].id);
+  }
   renderTurnHistory();
   renderAvatarPreview();
+  renderTutorialBox();
   if (turnFeedbackBox) {
     turnFeedbackBox.textContent = "Stato locale resettato.";
   }
@@ -394,6 +510,7 @@ function renderActivityUI(activityId?: string) {
     if (activityChoices) {
       activityChoices.innerHTML = "";
     }
+    renderTutorialBox();
     return;
   }
 
@@ -408,6 +525,8 @@ function renderActivityUI(activityId?: string) {
     activityResultBox.textContent = "Scegli una delle opzioni per applicare ricompense.";
   }
   renderActivityOptions(activity);
+  renderActivityGuard(activity.id);
+  renderTutorialBox();
 }
 
 function handleActivityChoice(choiceId: string) {
@@ -418,9 +537,36 @@ function handleActivityChoice(choiceId: string) {
   if (!activity) return;
   const choice = activity.choices.find((item) => item.id === choiceId);
   if (!choice) return;
+  const stats = getActivityStats(activity.id);
+  const now = Date.now();
+  const remainingMs = stats.lastPlayedAt ? ACTIVITY_COOLDOWN_MS - (now - stats.lastPlayedAt) : 0;
+  if (remainingMs > 0) {
+    const remainingSeconds = Math.max(0, Math.ceil(remainingMs / 1000));
+    if (activityResultBox) {
+      activityResultBox.dataset.state = "warn";
+      activityResultBox.textContent = `Attendi ${remainingSeconds}s prima di ripetere l'attivita.`;
+    }
+    renderActivityGuard(activity.id);
+    return;
+  }
+  if (stats.runs >= MAX_ACTIVITY_RUNS) {
+    if (activityResultBox) {
+      activityResultBox.dataset.state = "warn";
+      activityResultBox.textContent = "Limite sessione raggiunto per questo scenario demo.";
+    }
+    renderActivityGuard(activity.id);
+    return;
+  }
   applyRewards(choice.rewards);
+  gameState = {
+    ...gameState,
+    activityStats: { ...gameState.activityStats, [activity.id]: { runs: stats.runs + 1, lastPlayedAt: now } },
+    tutorial: { ...gameState.tutorial, firstChoiceComplete: true },
+  };
   saveState(gameState);
   renderCareerCard();
+  renderActivityGuard(activity.id);
+  renderTutorialBox();
   if (activityResultBox) {
     activityResultBox.dataset.state = "ok";
     activityResultBox.textContent = `${choice.summary} (${formatRewards(choice.rewards)})`;
@@ -495,6 +641,7 @@ syncProfileForm();
 renderCareerCard();
 renderTurnHistory();
 renderAvatarPreview();
+renderTutorialBox();
 
 root.querySelector<HTMLButtonElement>('[data-action="save-profile"]')?.addEventListener("click", handleSaveProfile);
 root.querySelector<HTMLButtonElement>('[data-action="reset-state"]')?.addEventListener("click", handleResetState);
@@ -521,6 +668,12 @@ avatarHueInput?.addEventListener("input", () => {
 
 avatarIconSelect?.addEventListener("change", () => {
   handleSaveProfile();
+});
+
+root.querySelector<HTMLButtonElement>('[data-action="dismiss-tutorial"]')?.addEventListener("click", () => {
+  gameState = { ...gameState, tutorial: { ...gameState.tutorial, firstChoiceComplete: true } };
+  saveState(gameState);
+  renderTutorialBox();
 });
 
 registerServiceWorker({

--- a/apps/pwa/src/features/permissions-card.ts
+++ b/apps/pwa/src/features/permissions-card.ts
@@ -168,7 +168,7 @@ export function attachPermissionsListeners(root: HTMLElement) {
                 icon: "/icons/pwa-192.png"
             });
             renderResult("Notifica di prova inviata.", "ok");
-        } catch (e) {
+        } catch {
             renderResult("Invio notifica fallito.", "error");
         }
     });

--- a/apps/pwa/src/game.ts
+++ b/apps/pwa/src/game.ts
@@ -1,5 +1,6 @@
 import "../../../shared/styles/main.css";
 import { registerServiceWorker } from "./pwa/register-sw";
+import { buildProgressCopy, getProgressState, repMilestones, xpMilestones } from "./progression";
 import { formatRewards, getAvatarVisual, loadState, resolveRole } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");
@@ -51,6 +52,26 @@ root.innerHTML = `
           <li><span>Cachet</span><strong>${state.profile.cachet}</strong></li>
           <li><span>Reputazione ATCL</span><strong>${state.profile.repAtcl}</strong></li>
         </ul>
+        <div class="progress-grid compact">
+          <div class="progress-track slim" data-track="xp">
+            <div class="progress-head">
+              <p class="muted" data-progress-copy="xp">Traguardi XP</p>
+              <strong data-progress-value="xp">${state.profile.xp} XP</strong>
+            </div>
+            <div class="progress-bar" role="progressbar" aria-label="Progresso XP" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+              <span class="progress-fill" data-progress-bar="xp" style="width: 0%"></span>
+            </div>
+          </div>
+          <div class="progress-track slim" data-track="rep">
+            <div class="progress-head">
+              <p class="muted" data-progress-copy="rep">Traguardi reputazione</p>
+              <strong data-progress-value="rep">${state.profile.repAtcl} rep</strong>
+            </div>
+            <div class="progress-bar" role="progressbar" aria-label="Progresso reputazione" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+              <span class="progress-fill accent" data-progress-bar="rep" style="width: 0%"></span>
+            </div>
+          </div>
+        </div>
       </article>
 
       <article class="card layout-span-2">
@@ -60,6 +81,28 @@ root.innerHTML = `
     </section>
   </main>
 `;
+
+const progressCopyXp = root.querySelector<HTMLElement>('[data-progress-copy="xp"]');
+const progressCopyRep = root.querySelector<HTMLElement>('[data-progress-copy="rep"]');
+const progressValueXp = root.querySelector<HTMLElement>('[data-progress-value="xp"]');
+const progressValueRep = root.querySelector<HTMLElement>('[data-progress-value="rep"]');
+const progressBarXp = root.querySelector<HTMLElement>('[data-progress-bar="xp"]');
+const progressBarRep = root.querySelector<HTMLElement>('[data-progress-bar="rep"]');
+
+const xpProgress = getProgressState(state.profile.xp, xpMilestones);
+const repProgress = getProgressState(state.profile.repAtcl, repMilestones);
+if (progressCopyXp) progressCopyXp.textContent = buildProgressCopy(xpProgress, "XP");
+if (progressCopyRep) progressCopyRep.textContent = buildProgressCopy(repProgress, "punti rep");
+if (progressValueXp) progressValueXp.textContent = `${state.profile.xp} XP`;
+if (progressValueRep) progressValueRep.textContent = `${state.profile.repAtcl} rep`;
+if (progressBarXp) {
+  progressBarXp.style.width = `${xpProgress.percent}%`;
+  progressBarXp.parentElement?.setAttribute("aria-valuenow", xpProgress.percent.toString());
+}
+if (progressBarRep) {
+  progressBarRep.style.width = `${repProgress.percent}%`;
+  progressBarRep.parentElement?.setAttribute("aria-valuenow", repProgress.percent.toString());
+}
 
 const turnLog = root.querySelector<HTMLElement>('[data-turn-log]');
 if (turnLog) {

--- a/apps/pwa/src/profile.ts
+++ b/apps/pwa/src/profile.ts
@@ -1,4 +1,5 @@
 import "../../../shared/styles/main.css";
+import { buildProgressCopy, getEarnedMilestones, getProgressState, repMilestones, xpMilestones } from "./progression";
 import { formatRewards, getAvatarVisual, loadState, resolveRole } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");
@@ -42,6 +43,37 @@ root.innerHTML = `
           <div class="stat-chip"><span>Cachet</span><strong data-stat="cachet">0</strong></div>
           <div class="stat-chip"><span>Rep</span><strong data-stat="rep">0</strong></div>
         </div>
+        <div class="progress-grid">
+          <div class="progress-track" data-track="xp">
+            <div class="progress-head">
+              <div>
+                <p class="eyebrow">Percorso XP</p>
+                <p class="muted" data-progress-copy="xp">Accumula esperienza nei turni registrati.</p>
+              </div>
+              <strong data-progress-value="xp">0 XP</strong>
+            </div>
+            <div class="progress-bar" role="progressbar" aria-label="Progresso XP" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+              <span class="progress-fill" data-progress-bar="xp" style="width: 0%"></span>
+            </div>
+          </div>
+          <div class="progress-track" data-track="rep">
+            <div class="progress-head">
+              <div>
+                <p class="eyebrow">Reputazione</p>
+                <p class="muted" data-progress-copy="rep">Fa crescere la reputazione ATCL per sbloccare badge.</p>
+              </div>
+              <strong data-progress-value="rep">0 rep</strong>
+            </div>
+            <div class="progress-bar" role="progressbar" aria-label="Progresso reputazione" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+              <span class="progress-fill accent" data-progress-bar="rep" style="width: 0%"></span>
+            </div>
+          </div>
+        </div>
+        <div class="badge-panel">
+          <p class="eyebrow">Badge sbloccati</p>
+          <div class="badge-grid" data-badge-list></div>
+          <p class="muted" data-badge-note>Completa milestone XP o reputazione per guadagnare badge.</p>
+        </div>
       </article>
 
       <article class="card">
@@ -61,6 +93,14 @@ const roleTags = root.querySelector<HTMLElement>("[data-role-tags]");
 const statXp = root.querySelector<HTMLElement>('[data-stat="xp"]');
 const statCachet = root.querySelector<HTMLElement>('[data-stat="cachet"]');
 const statRep = root.querySelector<HTMLElement>('[data-stat="rep"]');
+const progressCopyXp = root.querySelector<HTMLElement>('[data-progress-copy="xp"]');
+const progressCopyRep = root.querySelector<HTMLElement>('[data-progress-copy="rep"]');
+const progressValueXp = root.querySelector<HTMLElement>('[data-progress-value="xp"]');
+const progressValueRep = root.querySelector<HTMLElement>('[data-progress-value="rep"]');
+const progressBarXp = root.querySelector<HTMLElement>('[data-progress-bar="xp"]');
+const progressBarRep = root.querySelector<HTMLElement>('[data-progress-bar="rep"]');
+const badgeList = root.querySelector<HTMLElement>('[data-badge-list]');
+const badgeNote = root.querySelector<HTMLElement>('[data-badge-note]');
 const turnLog = root.querySelector<HTMLElement>('[data-turn-log]');
 
 const state = loadState();
@@ -96,6 +136,49 @@ if (roleTags) {
 if (statXp) statXp.textContent = state.profile.xp.toString();
 if (statCachet) statCachet.textContent = state.profile.cachet.toString();
 if (statRep) statRep.textContent = state.profile.repAtcl.toString();
+
+const xpProgress = getProgressState(state.profile.xp, xpMilestones);
+const repProgress = getProgressState(state.profile.repAtcl, repMilestones);
+if (progressValueXp) progressValueXp.textContent = `${state.profile.xp} XP`;
+if (progressValueRep) progressValueRep.textContent = `${state.profile.repAtcl} rep`;
+if (progressCopyXp) progressCopyXp.textContent = buildProgressCopy(xpProgress, "XP");
+if (progressCopyRep) progressCopyRep.textContent = buildProgressCopy(repProgress, "punti rep");
+if (progressBarXp) {
+  progressBarXp.style.width = `${xpProgress.percent}%`;
+  progressBarXp.parentElement?.setAttribute("aria-valuenow", xpProgress.percent.toString());
+}
+if (progressBarRep) {
+  progressBarRep.style.width = `${repProgress.percent}%`;
+  progressBarRep.parentElement?.setAttribute("aria-valuenow", repProgress.percent.toString());
+}
+
+const earnedXp = getEarnedMilestones(state.profile.xp, xpMilestones);
+const earnedRep = getEarnedMilestones(state.profile.repAtcl, repMilestones);
+const seen = new Set<string>();
+const repIds = new Set(repMilestones.map((item) => item.id));
+const badges = [...earnedXp, ...earnedRep].filter((badge) => {
+  if (seen.has(badge.id)) return false;
+  seen.add(badge.id);
+  return true;
+});
+if (badgeList) {
+  badgeList.innerHTML = badges.length
+    ? badges
+        .map(
+          (badge) =>
+            `<span class="badge-chip">${badge.label}<small>${badge.target}${repIds.has(badge.id) ? " rep" : " XP"}</small></span>`
+        )
+        .join("")
+    : '<span class="badge-chip ghost">Ancora nessun badge: completa milestone XP/rep.</span>';
+}
+if (badgeNote) {
+  const nextTarget = xpProgress.remaining > 0 ? { progress: xpProgress, unit: "XP" } : { progress: repProgress, unit: "punti" };
+  const nextCopy =
+    xpProgress.remaining <= 0 && repProgress.remaining <= 0
+      ? "Tieni traccia dei nuovi turni per ampliare il medagliere."
+      : buildProgressCopy(nextTarget.progress, nextTarget.unit);
+  badgeNote.textContent = nextCopy;
+}
 
 if (turnLog) {
   if (!state.turns.length) {

--- a/apps/pwa/src/progression.ts
+++ b/apps/pwa/src/progression.ts
@@ -1,0 +1,62 @@
+export type ProgressMilestone = { id: string; label: string; target: number; flavor?: string };
+
+export type ProgressState = {
+  current: number;
+  previousTarget: number;
+  nextTarget: number;
+  nextLabel: string;
+  percent: number;
+  remaining: number;
+};
+
+export const xpMilestones: ProgressMilestone[] = [
+  { id: "debutto", label: "Debutto ATCL", target: 50, flavor: "Primi passi nel circuito" },
+  { id: "tecnico-fidato", label: "Tecnico fidato", target: 150, flavor: "Reperibilita sul territorio" },
+  { id: "caposquadra", label: "Caposquadra", target: 320, flavor: "Coordinamento troupe" },
+  { id: "mentore", label: "Mentore", target: 520, flavor: "Supporto ai nuovi ingressi" },
+];
+
+export const repMilestones: ProgressMilestone[] = [
+  { id: "voce-locale", label: "Voce locale", target: 8, flavor: "Riconoscimento dai teatri partner" },
+  { id: "volto-circuito", label: "Volto del circuito", target: 18, flavor: "Referenze consolidate" },
+  { id: "talent-scout", label: "Talent scout", target: 30, flavor: "Mentorship e passaparola" },
+];
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getOrderedMilestones(milestones: ProgressMilestone[]) {
+  return [...milestones].sort((a, b) => a.target - b.target);
+}
+
+export function getProgressState(current: number, milestones: ProgressMilestone[]): ProgressState {
+  const ordered = getOrderedMilestones(milestones);
+  const previous = ordered.filter((item) => current >= item.target).pop();
+  const next = ordered.find((item) => current < item.target);
+  const previousTarget = previous?.target ?? 0;
+  const nextTarget = next?.target ?? previousTarget;
+  const span = next ? nextTarget - previousTarget || 1 : current || 1;
+  const progress = next ? current - previousTarget : span;
+  const percent = next ? clamp(Math.round((progress / span) * 100), 0, 100) : 100;
+  const remaining = next ? Math.max(0, nextTarget - current) : 0;
+  return {
+    current,
+    previousTarget,
+    nextTarget,
+    nextLabel: next?.label ?? previous?.label ?? "Completato",
+    percent,
+    remaining,
+  };
+}
+
+export function getEarnedMilestones(current: number, milestones: ProgressMilestone[]): ProgressMilestone[] {
+  return getOrderedMilestones(milestones).filter((item) => current >= item.target);
+}
+
+export function buildProgressCopy(progress: ProgressState, unitLabel: string) {
+  if (progress.remaining <= 0) {
+    return `Hai sbloccato ${progress.nextLabel}.`;
+  }
+  return `Mancano ${progress.remaining} ${unitLabel} per ${progress.nextLabel}.`;
+}

--- a/apps/pwa/src/state.ts
+++ b/apps/pwa/src/state.ts
@@ -29,7 +29,14 @@ export type TurnRecord = {
   rewards: Rewards;
 };
 export type PlayerProfile = { name: string; roleId: RoleId; xp: number; cachet: number; repAtcl: number; avatar: AvatarSettings };
-export type GameState = { profile: PlayerProfile; turns: TurnRecord[] };
+export type ActivityStats = { runs: number; lastPlayedAt?: number };
+export type TutorialState = { firstChoiceComplete: boolean };
+export type GameState = {
+  profile: PlayerProfile;
+  turns: TurnRecord[];
+  activityStats: Record<string, ActivityStats>;
+  tutorial: TutorialState;
+};
 
 export const roles: Role[] = [
   { id: "attore", name: "Attore / Attrice", focus: "Presenza scenica", stats: ["Presenza", "Memoria", "Versatilita"] },
@@ -89,6 +96,8 @@ export function createDefaultState(): GameState {
       avatar: { hue: 210, icon: "mask", rpmUrl: "", rpmThumbnail: "", rpmId: "", updatedAt: undefined },
     },
     turns: [],
+    activityStats: {},
+    tutorial: { firstChoiceComplete: false },
   };
 }
 
@@ -148,6 +157,10 @@ export function loadState(): GameState {
     return {
       profile: { ...base.profile, ...parsed.profile, roleId: safeRole, avatar: safeAvatar },
       turns: Array.isArray(parsed.turns) ? parsed.turns : [],
+      activityStats: typeof parsed.activityStats === "object" && parsed.activityStats ? parsed.activityStats : base.activityStats,
+      tutorial: {
+        firstChoiceComplete: !!parsed.tutorial?.firstChoiceComplete,
+      },
     };
   } catch {
     return createDefaultState();

--- a/apps/pwa/src/style.css
+++ b/apps/pwa/src/style.css
@@ -747,6 +747,59 @@ code {
   border-color: var(--focus-ring);
 }
 
+.field.inline {
+  min-width: 200px;
+}
+
+.toolbar {
+  margin: 0.35rem 0 0.75rem;
+}
+
+.filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.inline-alert {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem 0.9rem;
+  border-radius: 12px;
+  background: var(--surface-veil-soft);
+  border: 1px dashed var(--border-subtle);
+}
+
+.meta-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 10px;
+  background: var(--surface-veil-soft);
+  border: 1px solid var(--border-subtle);
+  font-size: 0.95rem;
+}
+
+.meta-chip.ghost {
+  background: transparent;
+  border-style: dashed;
+}
+
+.meta-chip[data-state="warn"] {
+  border-color: var(--color-warning-300);
+  color: var(--color-warning-300);
+}
+
 .stat-list {
   list-style: none;
   padding: 0;
@@ -769,6 +822,94 @@ code {
   color: var(--color-info-100);
 }
 
+.progress-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.progress-grid.compact {
+  gap: 0.5rem;
+}
+
+.progress-track {
+  display: grid;
+  gap: 0.4rem;
+  padding: 0.7rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-veil-soft);
+}
+
+.progress-track.slim {
+  padding: 0.5rem 0.65rem;
+}
+
+.progress-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.65rem;
+}
+
+.progress-head strong {
+  white-space: nowrap;
+}
+
+.progress-bar {
+  height: 10px;
+  border-radius: 999px;
+  background: var(--surface-veil);
+  border: 1px solid var(--border-regular);
+  overflow: hidden;
+}
+
+.progress-fill {
+  display: block;
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, var(--color-sky-300), rgba(244, 191, 79, 0.55));
+  border-radius: inherit;
+  transition: width 160ms ease;
+}
+
+.progress-fill.accent {
+  background: linear-gradient(90deg, var(--color-warning-300), var(--color-gold-500));
+}
+
+.badge-panel {
+  display: grid;
+  gap: 0.4rem;
+  margin-top: 0.35rem;
+}
+
+.badge-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.badge-chip {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-veil);
+  box-shadow: var(--shadow-soft-elevated);
+}
+
+.badge-chip small {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.badge-chip.ghost {
+  border-style: dashed;
+  opacity: 0.8;
+  box-shadow: none;
+}
+
 .log-list {
   list-style: none;
   padding: 0;
@@ -780,6 +921,44 @@ code {
 .log-list li {
   padding-bottom: 0.25rem;
   border-bottom: 1px dashed var(--surface-veil-strong);
+}
+
+.chart-grid {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  margin: 0.5rem 0 0.25rem;
+}
+
+.chart-card {
+  border: 1px solid var(--border-regular);
+  border-radius: 14px;
+  padding: 0.85rem;
+  background: var(--surface-veil);
+  box-shadow: var(--shadow-soft-elevated);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.chart-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.chart-head strong {
+  white-space: nowrap;
+}
+
+.sparkline {
+  width: 100%;
+  min-height: 86px;
+}
+
+.sparkline svg {
+  width: 100%;
+  height: 100%;
 }
 
 .avatar-display {

--- a/apps/pwa/src/test/permissions.spec.ts
+++ b/apps/pwa/src/test/permissions.spec.ts
@@ -9,14 +9,14 @@ describe('PermissionsService', () => {
     it('should report notifications supported if Notification exists', () => {
         // Mock window.Notification
         const original = window.Notification;
-        Object.defineProperty(window, 'Notification', { value: {} as any, writable: true });
+        Object.defineProperty(window, 'Notification', { value: {} as unknown as typeof Notification, writable: true });
         expect(PermissionsService.supportsNotifications()).toBe(true);
         Object.defineProperty(window, 'Notification', { value: original, writable: true });
     });
 
     it('should check notification permission properly', () => {
         const original = window.Notification;
-        Object.defineProperty(window, 'Notification', { value: { permission: 'granted' } as any, writable: true });
+        Object.defineProperty(window, 'Notification', { value: { permission: 'granted' } as unknown as typeof Notification, writable: true });
         expect(PermissionsService.getNotificationPermission()).toBe('granted');
         Object.defineProperty(window, 'Notification', { value: original, writable: true });
     });

--- a/apps/pwa/src/turns.ts
+++ b/apps/pwa/src/turns.ts
@@ -1,5 +1,5 @@
 import "../../../shared/styles/main.css";
-import { formatRewards, loadState, resolveRole } from "./state";
+import { formatRewards, loadState, resolveRole, roles } from "./state";
 
 const root = document.querySelector<HTMLDivElement>("#app");
 
@@ -25,6 +25,52 @@ root.innerHTML = `
     <section class="grid layout-grid">
       <article class="card layout-span-2">
         <h2>Turni</h2>
+        <div class="toolbar">
+          <div class="filter-row">
+            <label class="field inline">
+              <span>Ruolo</span>
+              <select data-filter-role></select>
+            </label>
+            <label class="field inline">
+              <span>Teatro</span>
+              <select data-filter-venue></select>
+            </label>
+            <label class="field inline">
+              <span>Ordina</span>
+              <select data-filter-sort>
+                <option value="desc">Dal piu recente</option>
+                <option value="asc">Dal piu vecchio</option>
+              </select>
+            </label>
+          </div>
+        </div>
+        <div class="stat-board">
+          <div class="stat-chip"><span>Turni filtrati</span><strong data-total-count>0</strong></div>
+          <div class="stat-chip"><span>XP filtrati</span><strong data-total-xp>0</strong></div>
+          <div class="stat-chip"><span>Cachet filtrato</span><strong data-total-cachet>0</strong></div>
+        </div>
+        <div class="chart-grid">
+          <div class="chart-card">
+            <div class="chart-head">
+              <div>
+                <p class="eyebrow">XP</p>
+                <p class="muted">Andamento cumulativo XP guadagnati</p>
+              </div>
+              <strong data-chart-total="xp">0 XP</strong>
+            </div>
+            <div class="sparkline" data-sparkline="xp"></div>
+          </div>
+          <div class="chart-card">
+            <div class="chart-head">
+              <div>
+                <p class="eyebrow">Cachet</p>
+                <p class="muted">Crescita cachet nel tempo</p>
+              </div>
+              <strong data-chart-total="cachet">0</strong>
+            </div>
+            <div class="sparkline" data-sparkline="cachet"></div>
+          </div>
+        </div>
         <ul class="log-list dense" data-turn-list></ul>
       </article>
     </section>
@@ -32,17 +78,134 @@ root.innerHTML = `
 `;
 
 const turnList = root.querySelector<HTMLElement>('[data-turn-list]');
+const roleFilter = root.querySelector<HTMLSelectElement>('[data-filter-role]');
+const venueFilter = root.querySelector<HTMLSelectElement>('[data-filter-venue]');
+const sortFilter = root.querySelector<HTMLSelectElement>('[data-filter-sort]');
+const totalCount = root.querySelector<HTMLElement>('[data-total-count]');
+const totalXp = root.querySelector<HTMLElement>('[data-total-xp]');
+const totalCachet = root.querySelector<HTMLElement>('[data-total-cachet]');
+const sparklineXp = root.querySelector<HTMLElement>('[data-sparkline="xp"]');
+const sparklineCachet = root.querySelector<HTMLElement>('[data-sparkline="cachet"]');
+const chartTotalXp = root.querySelector<HTMLElement>('[data-chart-total="xp"]');
+const chartTotalCachet = root.querySelector<HTMLElement>('[data-chart-total="cachet"]');
 const state = loadState();
 
-if (turnList) {
-  if (!state.turns.length) {
-    turnList.innerHTML = `<li class="muted">Nessun turno registrato.</li>`;
-  } else {
-    turnList.innerHTML = state.turns
-      .map(
-        (turn) =>
-          `<li><div><strong>${turn.eventName}</strong> - ${turn.theatre} - ${turn.date}</div><div class="muted">${resolveRole(turn.roleId).name} | ${formatRewards(turn.rewards)}</div></li>`
-      )
-      .join("");
+function safeDateValue(dateStr: string) {
+  const parsed = Date.parse(dateStr);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function populateFilters() {
+  if (roleFilter) {
+    roleFilter.innerHTML = `<option value="all">Tutti i ruoli</option>${roles
+      .map((role) => `<option value="${role.id}">${role.name}</option>`)
+      .join("")}`;
+    roleFilter.value = "all";
+  }
+  if (venueFilter) {
+    const venues = Array.from(new Set(state.turns.map((turn) => turn.theatre)));
+    venueFilter.innerHTML = `<option value="all">Tutti i teatri</option>${
+      venues.length ? venues.map((venue) => `<option value="${venue}">${venue}</option>`).join("") : ""
+    }`;
+    venueFilter.value = "all";
+  }
+  if (sortFilter) {
+    sortFilter.value = "desc";
   }
 }
+
+function getFilteredTurns() {
+  const roleValue = roleFilter?.value || "all";
+  const venueValue = venueFilter?.value || "all";
+  const sortOrder = sortFilter?.value || "desc";
+  const turns = state.turns
+    .filter((turn) => (roleValue === "all" ? true : turn.roleId === roleValue))
+    .filter((turn) => (venueValue === "all" ? true : turn.theatre === venueValue))
+    .sort((a, b) => (sortOrder === "asc" ? safeDateValue(a.date) - safeDateValue(b.date) : safeDateValue(b.date) - safeDateValue(a.date)));
+  return turns;
+}
+
+function renderTotals(turns: typeof state.turns) {
+  const count = turns.length;
+  const totalXpValue = turns.reduce((acc, turn) => acc + turn.rewards.xp, 0);
+  const totalCachetValue = turns.reduce((acc, turn) => acc + turn.rewards.cachet, 0);
+  if (totalCount) totalCount.textContent = count.toString();
+  if (totalXp) totalXp.textContent = `${totalXpValue}`;
+  if (totalCachet) totalCachet.textContent = `${totalCachetValue}`;
+  if (chartTotalXp) chartTotalXp.textContent = `${totalXpValue} XP`;
+  if (chartTotalCachet) chartTotalCachet.textContent = `${totalCachetValue}`;
+}
+
+function buildSparkline(values: number[], accent = false) {
+  if (!values.length) {
+    return `<div class="muted">Nessun dato da visualizzare.</div>`;
+  }
+  const width = 280;
+  const height = 80;
+  const maxValue = Math.max(...values);
+  const step = values.length > 1 ? width / (values.length - 1) : width;
+  const stroke = accent ? "var(--color-warning)" : "var(--color-sky-300)";
+  const points = values
+    .map((value, index) => {
+      const x = Math.round(index * step);
+      const normalized = maxValue === 0 ? 0 : value / maxValue;
+      const y = Math.round(height - normalized * (height - 14) - 6);
+      return `${x},${y}`;
+    })
+    .join(" ");
+  const lastValue = values[values.length - 1];
+  const lastX = (values.length - 1) * step;
+  const lastY = height - (maxValue === 0 ? 0 : (lastValue / maxValue) * (height - 14)) - 6;
+  return `<svg viewBox="0 0 ${width} ${height}" role="img" aria-label="Andamento nel tempo">
+    <polyline fill="none" stroke="${stroke}" stroke-width="3" stroke-linecap="round" points="${points}" />
+    <circle cx="${lastX}" cy="${lastY}" r="5" fill="${stroke}" />
+  </svg>`;
+}
+
+function renderCharts(turns: typeof state.turns) {
+  const sorted = [...turns].sort((a, b) => safeDateValue(a.date) - safeDateValue(b.date));
+  let xpAccumulator = 0;
+  let cachetAccumulator = 0;
+  const xpSeries = sorted.map((turn) => {
+    xpAccumulator += turn.rewards.xp;
+    return xpAccumulator;
+  });
+  const cachetSeries = sorted.map((turn) => {
+    cachetAccumulator += turn.rewards.cachet;
+    return cachetAccumulator;
+  });
+  if (sparklineXp) {
+    sparklineXp.innerHTML = buildSparkline(xpSeries);
+  }
+  if (sparklineCachet) {
+    sparklineCachet.innerHTML = buildSparkline(cachetSeries, true);
+  }
+}
+
+function renderTurnList(turns: typeof state.turns) {
+  if (!turnList) return;
+  if (!turns.length) {
+    turnList.innerHTML = `<li class="muted">Nessun turno registrato.</li>`;
+    return;
+  }
+  turnList.innerHTML = turns
+    .map(
+      (turn) =>
+        `<li><div><strong>${turn.eventName}</strong> - ${turn.theatre} - ${turn.date}</div><div class="muted">${resolveRole(turn.roleId).name} | ${formatRewards(turn.rewards)}</div></li>`
+    )
+    .join("");
+}
+
+function renderView() {
+  const filtered = getFilteredTurns();
+  renderTotals(filtered);
+  renderCharts(filtered);
+  renderTurnList(filtered);
+}
+
+populateFilters();
+renderView();
+
+roleFilter?.addEventListener("change", renderView);
+venueFilter?.addEventListener("change", renderView);
+sortFilter?.addEventListener("change", renderView);


### PR DESCRIPTION
## Summary
- add shared progression helpers with XP/rep milestones and expose progress bars plus badge lists on the hub and profile
- introduce cooldowns, session limits, and a first-choice tutorial hint for simulated activities in the dev playground
- extend the turn register with role/venue filters, cumulative XP/cachet sparklines, and bump the service worker cache version

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957cb6ebc4883268c34a1bb39ca096a)