### PR TITLE
Improve map event interactions and accessibility

### DIFF
--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "turni-di-palco-v440d67b1";
+const CACHE_NAME = "turni-di-palco-vbe4c9add";
 const OFFLINE_URL = "/index.html";
 const CORE_ASSETS = [
   "/",

--- a/apps/pwa/src/map.ts
+++ b/apps/pwa/src/map.ts
@@ -6,7 +6,25 @@ import markerIconPng from "leaflet/dist/images/marker-icon.png";
 import markerShadowPng from "leaflet/dist/images/marker-shadow.png";
 import { renderChip } from "./components/chip";
 import { renderStatPill } from "./components/stat-pill";
-import { formatRewards, getAvatarVisual, loadState, mockEvents, resolveRole, Rewards, saveState } from "./state";
+import {
+  formatRewards,
+  getAvatarVisual,
+  loadState,
+  mockEvents,
+  resolveRole,
+  Rewards,
+  RoleId,
+  roles,
+  TurnRecord,
+  saveState,
+} from "./state";
+
+type DecoratedEvent = (typeof mockEvents)[number] & { distanceKm: number };
+type DrawerSection = "events" | "turns" | "profile";
+
+const defaultCenter = [41.9028, 12.4964] as const; // Roma
+const DEFAULT_DISTANCE_KM = 220;
+const MAX_STORED_TURNS = 10;
 
 const root = document.querySelector<HTMLDivElement>("#app");
 
@@ -21,9 +39,20 @@ const topStatsMarkup = [
 ].join("");
 
 const drawerTabsMarkup = [
-  renderChip({ label: "Eventi", size: "sm", variant: "ghost", state: "active", dataAttributes: { "drawer-tab": "events" } }),
-  renderChip({ label: "Turni", size: "sm", variant: "ghost", dataAttributes: { "drawer-tab": "turns" } }),
-  renderChip({ label: "Profilo", size: "sm", variant: "ghost", dataAttributes: { "drawer-tab": "profile" } }),
+  renderChip({
+    label: "Eventi",
+    size: "sm",
+    variant: "ghost",
+    state: "active",
+    dataAttributes: { "drawer-tab": "events", "tab-id": "tab-events" },
+  }),
+  renderChip({ label: "Turni", size: "sm", variant: "ghost", dataAttributes: { "drawer-tab": "turns", "tab-id": "tab-turns" } }),
+  renderChip({
+    label: "Profilo",
+    size: "sm",
+    variant: "ghost",
+    dataAttributes: { "drawer-tab": "profile", "tab-id": "tab-profile" },
+  }),
 ].join("");
 
 root.innerHTML = `
@@ -71,7 +100,7 @@ root.innerHTML = `
 
     <section class="map-drawer">
       <div class="drawer-header">
-        <div class="drawer-tabs">${drawerTabsMarkup}</div>
+        <div class="drawer-tabs" role="tablist" aria-label="Sezioni mappa" data-tablist="drawer">${drawerTabsMarkup}</div>
         <div class="stat-board compact">
           <div class="stat-chip">
             <span>XP</span>
@@ -88,15 +117,44 @@ root.innerHTML = `
         </div>
       </div>
       <div class="drawer-body">
-        <div class="drawer-section" data-section="profile">
+        <div class="drawer-section" data-section="profile" id="panel-profile" role="tabpanel" aria-labelledby="tab-profile">
           <div class="pill-row" data-role-tags></div>
           <div class="result-box slim" data-quick-result>Mappa pronta.</div>
         </div>
-        <div class="drawer-section" data-section="events">
-          <p class="muted tiny">Prossimi eventi mock</p>
+        <div class="drawer-section" data-section="events" id="panel-events" role="tabpanel" aria-labelledby="tab-events">
+          <div class="drawer-filters" role="group" aria-label="Filtri eventi">
+            <label class="field inline">
+              <span>Ruolo focus</span>
+              <select data-filter-role aria-label="Filtra eventi per ruolo">
+                <option value="all">Tutti i ruoli</option>
+                ${roles.map((role) => `<option value="${role.id}">${role.name}</option>`).join("")}
+              </select>
+            </label>
+            <label class="field inline">
+              <span>Data massima</span>
+              <input type="date" data-filter-date aria-label="Filtra per data" />
+            </label>
+            <label class="field inline">
+              <span>Distanza max: <strong data-distance-value>${DEFAULT_DISTANCE_KM}</strong> km</span>
+              <input type="range" min="30" max="420" step="10" value="${DEFAULT_DISTANCE_KM}" data-filter-distance aria-label="Filtra per distanza" />
+            </label>
+          </div>
+          <div class="pill-row focus-row" data-focus-hints></div>
+          <div class="inline-feedback" data-loading-indicator hidden aria-live="polite">Caricamento eventi...</div>
+          <div class="compact-note" data-compact-note role="status" aria-live="polite" hidden>Layout compatto: usa i tab o apri la mappa a tutto schermo per leggere i dettagli.</div>
+          <div class="event-detail" data-event-detail>
+            <div data-event-content>
+              <p class="muted">Seleziona un evento per vedere i dettagli.</p>
+            </div>
+            <div class="detail-actions">
+              <button class="button primary" type="button" data-action="register-turn" disabled>Registra turno</button>
+              <div class="result-box slim" data-event-feedback>In attesa di selezione.</div>
+            </div>
+          </div>
+          <p class="muted tiny" data-filter-summary>Prossimi eventi mock</p>
           <ul class="log-list dense" data-event-list></ul>
         </div>
-        <div class="drawer-section" data-section="turns">
+        <div class="drawer-section" data-section="turns" id="panel-turns" role="tabpanel" aria-labelledby="tab-turns">
           <p class="muted tiny">Registro recente</p>
           <ul class="log-list dense" data-turn-log></ul>
         </div>
@@ -125,10 +183,30 @@ const topStatCachet = root.querySelector<HTMLElement>('[data-top-stat="cachet"]'
 const topStatRep = root.querySelector<HTMLElement>('[data-top-stat="rep"]');
 const drawerTabs = Array.from(root.querySelectorAll<HTMLButtonElement>("[data-drawer-tab]"));
 const drawerSections = Array.from(root.querySelectorAll<HTMLElement>("[data-section]"));
+const drawerTablist = root.querySelector<HTMLElement>('[data-tablist="drawer"]');
+const filterRoleSelect = root.querySelector<HTMLSelectElement>('[data-filter-role]');
+const filterDateInput = root.querySelector<HTMLInputElement>('[data-filter-date]');
+const filterDistanceInput = root.querySelector<HTMLInputElement>('[data-filter-distance]');
+const distanceValue = root.querySelector<HTMLElement>('[data-distance-value]');
+const filterSummary = root.querySelector<HTMLElement>('[data-filter-summary]');
+const focusHints = root.querySelector<HTMLElement>('[data-focus-hints]');
+const eventContent = root.querySelector<HTMLElement>('[data-event-content]');
+const eventFeedback = root.querySelector<HTMLElement>('[data-event-feedback]');
+const loadingIndicator = root.querySelector<HTMLElement>('[data-loading-indicator]');
+const compactNote = root.querySelector<HTMLElement>('[data-compact-note]');
+const registerTurnButton = root.querySelector<HTMLButtonElement>('[data-action="register-turn"]');
 
 let state = loadState();
 let map: LeafletMap | null = null;
 let markerLayer: LayerGroup | null = null;
+const markerMap = new Map<string, L.Marker>();
+let filteredEvents: DecoratedEvent[] = [];
+let selectedEventId: string | null = null;
+const eventFilters: { role: RoleId | "all"; date: string; distance: number } = {
+  role: "all",
+  date: "",
+  distance: DEFAULT_DISTANCE_KM,
+};
 const markerIcon = L.icon({
   iconUrl: markerIconPng,
   shadowUrl: markerShadowPng,
@@ -136,6 +214,37 @@ const markerIcon = L.icon({
   popupAnchor: [1, -28],
   tooltipAnchor: [12, -16],
 });
+
+function toRadians(value: number) {
+  return (value * Math.PI) / 180;
+}
+
+function computeDistanceKm(lat: number, lng: number) {
+  const [centerLat, centerLng] = defaultCenter;
+  const earthRadiusKm = 6371;
+  const dLat = toRadians(lat - centerLat);
+  const dLng = toRadians(lng - centerLng);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRadians(centerLat)) * Math.cos(toRadians(lat)) * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return Math.max(0, Math.round(earthRadiusKm * c));
+}
+
+function setEventLoading(isLoading: boolean) {
+  if (eventList) eventList.setAttribute("aria-busy", String(isLoading));
+  if (loadingIndicator) loadingIndicator.hidden = !isLoading;
+}
+
+function updateDistanceLabel(value: number) {
+  if (distanceValue) distanceValue.textContent = value.toString();
+}
+
+function updateViewportNote() {
+  if (compactNote) {
+    compactNote.hidden = window.innerWidth >= 720;
+  }
+}
 
 function renderProfile() {
   const profile = state.profile;
@@ -182,19 +291,208 @@ function renderProfile() {
   }
 }
 
-function renderEvents() {
-  if (!eventList) return;
-  if (!mockEvents.length) {
-    eventList.innerHTML = `<li class="muted">Nessun evento mock.</li>`;
+function computeTurnRewards(event: DecoratedEvent, roleId: RoleId): Rewards {
+  const bonus = event.focusRole && event.focusRole === roleId ? 8 : 0;
+  return {
+    xp: event.baseRewards.xp + bonus,
+    cachet: event.baseRewards.cachet + Math.round(bonus / 2),
+    reputation: event.baseRewards.reputation + Math.round(bonus / 4),
+  };
+}
+
+function renderFocusIndicators(targetEvent?: DecoratedEvent) {
+  if (!focusHints) return;
+  const activeRole = resolveRole(state.profile.roleId);
+  const focusRole = targetEvent?.focusRole ? resolveRole(targetEvent.focusRole) : null;
+  const match = focusRole?.id === activeRole.id;
+  const focusLabel = focusRole ? focusRole.name : "Multi-ruolo";
+  focusHints.innerHTML = `
+    <span class="focus-pill active">Ruolo attivo: ${activeRole.name}</span>
+    <span class="focus-pill ${match ? "match" : "ghost"}">Focus evento: ${focusLabel}${match ? " (match)" : ""}</span>
+  `;
+}
+
+function renderEventDetail(event?: DecoratedEvent) {
+  if (!eventContent || !eventFeedback || !registerTurnButton) return;
+  if (!event) {
+    eventContent.innerHTML = `<p class="muted">Seleziona un evento per vedere i dettagli.</p>`;
+    registerTurnButton.disabled = true;
+    registerTurnButton.removeAttribute("data-event-id");
+    eventFeedback.dataset.state = "info";
+    eventFeedback.textContent = "In attesa di selezione.";
+    renderFocusIndicators();
     return;
   }
-  eventList.innerHTML = mockEvents
-    .map(
-      (item) =>
-        `<li><div><strong>${item.name}</strong> - ${item.theatre}</div><div class="muted">${item.date} | Focus: ${item.focusRole ? resolveRole(item.focusRole).name : "Any"
-        }</div></li>`
-    )
+  const focusRole = event.focusRole ? resolveRole(event.focusRole) : null;
+  const match = focusRole?.id === state.profile.roleId;
+  const rewards = computeTurnRewards(event, state.profile.roleId);
+  eventContent.innerHTML = `
+    <div class="detail-head">
+      <div>
+        <p class="eyebrow">${event.id}</p>
+        <h3>${event.name}</h3>
+        <p class="muted tiny">${event.theatre} • ${event.date}</p>
+      </div>
+      <span class="focus-pill ${match ? "match" : "ghost"}">${focusRole ? focusRole.name : "Multi-ruolo"}</span>
+    </div>
+    <div class="detail-meta">
+      <span class="pill ghost">~${event.distanceKm} km</span>
+      <span class="pill ghost">${formatRewards(rewards)}</span>
+    </div>
+  `;
+  registerTurnButton.disabled = false;
+  registerTurnButton.dataset.eventId = event.id;
+  registerTurnButton.textContent = "Registra turno";
+  eventFeedback.dataset.state = "info";
+  eventFeedback.textContent = "Pronto a registrare questo evento.";
+  renderFocusIndicators(event);
+}
+
+function setEventFeedback(state: "info" | "ok" | "warn" | "error", message: string) {
+  if (!eventFeedback) return;
+  eventFeedback.dataset.state = state;
+  eventFeedback.textContent = message;
+}
+
+function updateFilterSummary(list: DecoratedEvent[]) {
+  if (!filterSummary) return;
+  const count = list.length;
+  const label = count === 1 ? "evento" : "eventi";
+  filterSummary.textContent = `${count} ${label} filtrati • scorciatoie: Alt+1 Eventi, Alt+2 Turni, Alt+3 Profilo`;
+}
+
+function getFilteredEvents(): DecoratedEvent[] {
+  const decorated = mockEvents.map((event) => ({
+    ...event,
+    distanceKm: computeDistanceKm(event.lat, event.lng),
+  })) as DecoratedEvent[];
+  return decorated
+    .filter((event) => (eventFilters.role === "all" ? true : event.focusRole === eventFilters.role))
+    .filter((event) => {
+      if (!eventFilters.date) return true;
+      const eventDate = new Date(event.date).getTime();
+      const filterDate = new Date(eventFilters.date).getTime();
+      return Number.isFinite(eventDate) && Number.isFinite(filterDate) ? eventDate <= filterDate : true;
+    })
+    .filter((event) => event.distanceKm <= eventFilters.distance)
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+function renderEventList(events: DecoratedEvent[]) {
+  if (!eventList) return;
+  if (!events.length) {
+    eventList.innerHTML = `<li class="muted">Nessun evento trovato con questi filtri.</li>`;
+    return;
+  }
+  eventList.innerHTML = events
+    .map((item) => {
+      const isSelected = item.id === selectedEventId;
+      const focusRole = item.focusRole ? resolveRole(item.focusRole) : null;
+      const isMatch = focusRole?.id === state.profile.roleId;
+      const rewards = computeTurnRewards(item, state.profile.roleId);
+      return `<li>
+        <button class="event-card${isSelected ? " active" : ""}" type="button" data-event-id="${item.id}" aria-pressed="${isSelected}">
+          <div class="event-card__header">
+            <div>
+              <strong>${item.name}</strong>
+              <p class="muted tiny">${item.theatre} • ${item.date}</p>
+            </div>
+            <span class="focus-pill ${isMatch ? "match" : "ghost"}">${focusRole ? focusRole.name : "Multi-ruolo"}</span>
+          </div>
+          <div class="event-card__meta">
+            <span class="pill ghost">~${item.distanceKm} km</span>
+            <span class="pill ghost">${formatRewards(rewards)}</span>
+          </div>
+        </button>
+      </li>`;
+    })
     .join("");
+}
+
+function updateSelectedListItem() {
+  if (!eventList) return;
+  const items = Array.from(eventList.querySelectorAll<HTMLElement>("[data-event-id]"));
+  items.forEach((item) => {
+    const isActive = item.dataset.eventId === selectedEventId;
+    item.classList.toggle("active", isActive);
+    item.setAttribute("aria-pressed", String(isActive));
+  });
+}
+
+function focusEventOnMap(event: DecoratedEvent, openPopup = true) {
+  const marker = markerMap.get(event.id);
+  if (map && marker) {
+    map.flyTo([event.lat, event.lng], Math.max(map.getZoom(), 10));
+    if (openPopup) {
+      marker.openPopup();
+    }
+  }
+}
+
+function selectEvent(eventId: string, focusMap = true) {
+  const target = filteredEvents.find((event) => event.id === eventId);
+  if (!target) return;
+  selectedEventId = target.id;
+  updateSelectedListItem();
+  renderEventDetail(target);
+  if (focusMap) {
+    focusEventOnMap(target);
+  }
+}
+
+function renderMapMarkers(events: DecoratedEvent[]) {
+  if (!map || !markerLayer) return;
+  markerLayer.clearLayers();
+  markerMap.clear();
+  if (!events.length) return;
+  const bounds: L.LatLngExpression[] = [];
+  events.forEach((event) => {
+    const marker = L.marker([event.lat, event.lng], { icon: markerIcon }).bindPopup(
+      `<strong>${event.name}</strong><br/>${event.theatre}<br/>${event.date}<br/>Focus: ${event.focusRole ? resolveRole(event.focusRole).name : "Any"
+      }`
+    );
+    marker.on("click", () => selectEvent(event.id, false));
+    markerLayer.addLayer(marker);
+    markerMap.set(event.id, marker);
+    bounds.push([event.lat, event.lng]);
+  });
+  if (bounds.length > 1) {
+    map.fitBounds(bounds, { padding: [30, 30] });
+  } else {
+    map.setView(bounds[0] as L.LatLngExpression, 11);
+  }
+  if (selectedEventId && markerMap.has(selectedEventId)) {
+    markerMap.get(selectedEventId)?.openPopup();
+  }
+}
+
+function applyFilters(options?: { forceSelection?: boolean }) {
+  setEventLoading(true);
+  window.setTimeout(() => {
+    filteredEvents = getFilteredEvents();
+    if (!filteredEvents.length) {
+      renderEventList(filteredEvents);
+      renderEventDetail(undefined);
+      renderFocusIndicators();
+      renderMapMarkers(filteredEvents);
+      updateFilterSummary(filteredEvents);
+      setEventLoading(false);
+      return;
+    }
+    if (options?.forceSelection || !selectedEventId || !filteredEvents.some((event) => event.id === selectedEventId)) {
+      selectedEventId = filteredEvents[0].id;
+    }
+    renderEventList(filteredEvents);
+    updateSelectedListItem();
+    renderMapMarkers(filteredEvents);
+    const target = filteredEvents.find((event) => event.id === selectedEventId);
+    renderEventDetail(target);
+    if (target) {
+      focusEventOnMap(target, false);
+    }
+    updateFilterSummary(filteredEvents);
+    setEventLoading(false);
+  }, 120);
 }
 
 function renderTurns() {
@@ -212,47 +510,133 @@ function renderTurns() {
     .join("");
 }
 
+function handleRegisterTurn() {
+  const target = filteredEvents.find((event) => event.id === selectedEventId);
+  if (!target) {
+    setEventFeedback("warn", "Seleziona un evento prima di registrare.");
+    return;
+  }
+  const rewards = computeTurnRewards(target, state.profile.roleId);
+  const record: TurnRecord = {
+    id: `turn-${Date.now()}`,
+    eventId: target.id,
+    eventName: target.name,
+    theatre: target.theatre,
+    date: target.date,
+    roleId: state.profile.roleId,
+    rewards,
+  };
+  state = {
+    ...state,
+    profile: {
+      ...state.profile,
+      xp: state.profile.xp + rewards.xp,
+      cachet: state.profile.cachet + rewards.cachet,
+      repAtcl: state.profile.repAtcl + rewards.reputation,
+    },
+    turns: [record, ...state.turns].slice(0, MAX_STORED_TURNS),
+  };
+  saveState(state);
+  renderProfile();
+  renderTurns();
+  renderEventDetail(target);
+  setEventFeedback("ok", `Turno registrato: ${target.name} (${formatRewards(rewards)})`);
+}
+
 function initMap() {
   if (!mapContainer || map) return;
-  const defaultCenter = [41.9028, 12.4964] as const; // Roma
   map = L.map(mapContainer, { zoomControl: true }).setView(defaultCenter, 7);
   L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
     maxZoom: 19,
     attribution: "OpenStreetMap contributors",
   }).addTo(map);
   markerLayer = L.layerGroup().addTo(map);
-  renderMapMarkers();
 }
 
-function renderMapMarkers() {
-  if (!map || !markerLayer) return;
-  markerLayer.clearLayers();
-  if (!mockEvents.length) return;
-  const bounds: L.LatLngExpression[] = [];
-  mockEvents.forEach((event) => {
-    const marker = L.marker([event.lat, event.lng], { icon: markerIcon }).bindPopup(
-      `<strong>${event.name}</strong><br/>${event.theatre}<br/>${event.date}<br/>Focus: ${event.focusRole ? resolveRole(event.focusRole).name : "Any"
-      }`
-    );
-    markerLayer.addLayer(marker);
-    bounds.push([event.lat, event.lng]);
-  });
-  if (bounds.length > 1) {
-    map.fitBounds(bounds, { padding: [30, 30] });
-  } else {
-    map.setView(bounds[0] as L.LatLngExpression, 11);
-  }
-}
-
-function setDrawer(sectionId: "events" | "turns" | "profile") {
+function setDrawer(sectionId: DrawerSection) {
   drawerTabs.forEach((tab) => {
     const isActive = tab.dataset.drawerTab === sectionId;
     tab.classList.toggle("active", isActive);
     tab.dataset.state = isActive ? "active" : "default";
+    tab.setAttribute("aria-selected", String(isActive));
+    tab.tabIndex = isActive ? 0 : -1;
   });
   drawerSections.forEach((section) => {
-    section.classList.toggle("active", section.dataset.section === sectionId);
+    const isActive = section.dataset.section === sectionId;
+    section.classList.toggle("active", isActive);
+    section.toggleAttribute("hidden", !isActive);
+    section.setAttribute("aria-hidden", String(!isActive));
   });
+}
+
+function setupTabsAccessibility() {
+  drawerTabs.forEach((tab) => {
+    tab.setAttribute("role", "tab");
+    const tabId = tab.dataset.tabId;
+    if (tabId) {
+      tab.id = tabId;
+    }
+    const section = drawerSections.find((panel) => panel.dataset.section === tab.dataset.drawerTab);
+    if (section) {
+      const sectionId = section.id || `panel-${tab.dataset.drawerTab}`;
+      section.id = sectionId;
+      tab.setAttribute("aria-controls", sectionId);
+      section.setAttribute("aria-labelledby", tab.id);
+    }
+  });
+  drawerSections.forEach((section) => {
+    section.setAttribute("role", "tabpanel");
+  });
+  if (drawerTablist) {
+    drawerTablist.setAttribute("role", "tablist");
+    drawerTablist.setAttribute("aria-orientation", "horizontal");
+  }
+}
+
+function focusTab(direction: 1 | -1) {
+  const currentIndex = drawerTabs.findIndex((tab) => tab.dataset.state === "active");
+  const nextIndex = (currentIndex + direction + drawerTabs.length) % drawerTabs.length;
+  const nextTab = drawerTabs[nextIndex];
+  const target = nextTab?.dataset.drawerTab as DrawerSection | undefined;
+  if (target) {
+    setDrawer(target);
+    nextTab.focus();
+  }
+}
+
+function handleTabKeydown(event: KeyboardEvent) {
+  if (event.key === "ArrowRight") {
+    event.preventDefault();
+    focusTab(1);
+  }
+  if (event.key === "ArrowLeft") {
+    event.preventDefault();
+    focusTab(-1);
+  }
+  if (event.key === "Home") {
+    event.preventDefault();
+    const first = drawerTabs[0];
+    const target = first?.dataset.drawerTab as DrawerSection | undefined;
+    if (target) {
+      setDrawer(target);
+      first.focus();
+    }
+  }
+  if (event.key === "End") {
+    event.preventDefault();
+    const last = drawerTabs[drawerTabs.length - 1];
+    const target = last?.dataset.drawerTab as DrawerSection | undefined;
+    if (target) {
+      setDrawer(target);
+      last.focus();
+    }
+  }
+}
+
+function handleTabShortcut(section: DrawerSection) {
+  setDrawer(section);
+  const targetTab = drawerTabs.find((tab) => tab.dataset.drawerTab === section);
+  targetTab?.focus();
 }
 
 function applyQuick(rewards: Rewards, label: string) {
@@ -287,16 +671,20 @@ function handleQuick(action: "train" | "scene" | "audio") {
 }
 
 renderProfile();
-renderEvents();
 renderTurns();
 initMap();
+setupTabsAccessibility();
+updateDistanceLabel(eventFilters.distance);
+applyFilters({ forceSelection: true });
 setDrawer("events");
+updateViewportNote();
 
 root.querySelector<HTMLButtonElement>('[data-action="sync-state"]')?.addEventListener("click", () => {
   state = loadState();
   renderProfile();
   renderTurns();
-  renderMapMarkers();
+  applyFilters({ forceSelection: true });
+  setEventFeedback("info", "Stato ricaricato dal profilo principale.");
   if (quickResult) {
     quickResult.dataset.state = "info";
     quickResult.textContent = "Stato ricaricato dal profilo principale.";
@@ -305,26 +693,74 @@ root.querySelector<HTMLButtonElement>('[data-action="sync-state"]')?.addEventLis
 
 root.querySelector<HTMLButtonElement>('[data-action="quick-train"]')?.addEventListener("click", () => {
   handleQuick("train");
-  renderMapMarkers();
+  renderMapMarkers(filteredEvents);
 });
 
 root.querySelector<HTMLButtonElement>('[data-action="quick-scene"]')?.addEventListener("click", () => {
   handleQuick("scene");
-  renderMapMarkers();
+  renderMapMarkers(filteredEvents);
 });
 
 root.querySelector<HTMLButtonElement>('[data-action="quick-audio"]')?.addEventListener("click", () => {
   handleQuick("audio");
-  renderMapMarkers();
+  renderMapMarkers(filteredEvents);
 });
 
 drawerTabs.forEach((tab) => {
   tab.addEventListener("click", () => {
-    const target = tab.dataset.drawerTab as "events" | "turns" | "profile" | undefined;
-    if (target) {
-      setDrawer(target);
-    }
+    const target = tab.dataset.drawerTab as DrawerSection | undefined;
+    if (target) handleTabShortcut(target);
   });
+});
+
+drawerTablist?.addEventListener("keydown", handleTabKeydown);
+
+filterRoleSelect?.addEventListener("change", () => {
+  const value = filterRoleSelect.value as RoleId | "all";
+  eventFilters.role = value;
+  applyFilters({ forceSelection: true });
+});
+
+filterDateInput?.addEventListener("change", () => {
+  eventFilters.date = filterDateInput.value;
+  applyFilters();
+});
+
+filterDistanceInput?.addEventListener("input", () => {
+  const nextValue = Number(filterDistanceInput.value) || DEFAULT_DISTANCE_KM;
+  eventFilters.distance = nextValue;
+  updateDistanceLabel(nextValue);
+  applyFilters();
+});
+
+eventList?.addEventListener("click", (event) => {
+  const target = (event.target as HTMLElement | null)?.closest<HTMLButtonElement>("[data-event-id]");
+  if (!target) return;
+  const eventId = target.dataset.eventId;
+  if (eventId) {
+    selectEvent(eventId);
+  }
+});
+
+registerTurnButton?.addEventListener("click", handleRegisterTurn);
+
+window.addEventListener("keydown", (event) => {
+  const targetTag = (event.target as HTMLElement | null)?.tagName;
+  if (targetTag && ["INPUT", "TEXTAREA", "SELECT"].includes(targetTag)) return;
+  if (event.altKey && !event.ctrlKey && !event.metaKey) {
+    if (event.key === "1") {
+      event.preventDefault();
+      handleTabShortcut("events");
+    }
+    if (event.key === "2") {
+      event.preventDefault();
+      handleTabShortcut("turns");
+    }
+    if (event.key === "3") {
+      event.preventDefault();
+      handleTabShortcut("profile");
+    }
+  }
 });
 
 window.setTimeout(() => {
@@ -332,6 +768,7 @@ window.setTimeout(() => {
 }, 200);
 window.addEventListener("resize", () => {
   map?.invalidateSize();
+  updateViewportNote();
 });
 
 registerServiceWorker({

--- a/apps/pwa/src/state.ts
+++ b/apps/pwa/src/state.ts
@@ -17,6 +17,7 @@ export type GameEvent = {
   date: string;
   lat: number;
   lng: number;
+  baseRewards: Rewards;
   focusRole?: RoleId;
 };
 export type TurnRecord = {
@@ -54,6 +55,7 @@ export const mockEvents: GameEvent[] = [
     date: "2025-12-15",
     lat: 41.4676,
     lng: 12.9037,
+    baseRewards: { xp: 35, cachet: 25, reputation: 8 },
     focusRole: "attrezzista",
   },
   {
@@ -63,6 +65,7 @@ export const mockEvents: GameEvent[] = [
     date: "2026-01-10",
     lat: 42.419,
     lng: 12.1077,
+    baseRewards: { xp: 45, cachet: 35, reputation: 12 },
     focusRole: "fonico",
   },
   {
@@ -72,6 +75,7 @@ export const mockEvents: GameEvent[] = [
     date: "2026-02-02",
     lat: 41.8581,
     lng: 12.4816,
+    baseRewards: { xp: 60, cachet: 50, reputation: 18 },
     focusRole: "luci",
   },
 ];

--- a/apps/pwa/src/style.css
+++ b/apps/pwa/src/style.css
@@ -524,6 +524,140 @@ code {
   display: block;
 }
 
+.drawer-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.6rem;
+  margin-bottom: 0.5rem;
+}
+
+.drawer-filters .field.inline span {
+  font-size: 0.9rem;
+  color: var(--color-neutral-375);
+}
+
+.drawer-filters .field.inline input,
+.drawer-filters .field.inline select {
+  padding: 0.45rem 0.6rem;
+}
+
+.focus-row {
+  margin: 0.35rem 0;
+}
+
+.focus-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 10px;
+  border: 1px solid var(--surface-veil-strong);
+  background: var(--surface-veil);
+  color: var(--color-neutral-200);
+  font-size: 0.9rem;
+}
+
+.focus-pill.match {
+  border-color: var(--border-success);
+  color: var(--color-success-200);
+  background: rgba(34, 197, 94, 0.12);
+}
+
+.focus-pill.active {
+  border-color: var(--surface-veil-highlight);
+  background: var(--surface-veil-soft);
+}
+
+.event-detail {
+  border: 1px solid var(--border-soft);
+  border-radius: 12px;
+  padding: 0.75rem 0.85rem;
+  background: var(--surface-veil);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.detail-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.detail-head h3 {
+  margin: 0;
+}
+
+.detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.inline-feedback {
+  font-size: 0.95rem;
+  color: var(--color-neutral-300);
+  padding: 0.35rem 0.55rem;
+  border-radius: 8px;
+  background: var(--surface-veil-soft);
+}
+
+.compact-note {
+  font-size: 0.95rem;
+  color: var(--color-warning-200);
+  border: 1px dashed var(--border-warning);
+  padding: 0.5rem 0.65rem;
+  border-radius: 10px;
+  background: rgba(234, 179, 8, 0.06);
+}
+
+.event-card {
+  width: 100%;
+  text-align: left;
+  background: var(--surface-veil);
+  border: 1px solid var(--border-soft);
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  color: var(--text-primary);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.event-card.active {
+  border-color: var(--focus-ring);
+  box-shadow: 0 0 0 3px var(--surface-veil-highlight);
+}
+
+.event-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.event-card__meta {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.event-card strong {
+  display: block;
+}
+
+.event-card:focus-visible {
+  border-color: var(--focus-ring);
+  outline: none;
+  box-shadow: 0 0 0 3px var(--surface-veil-highlight);
+}
+
 .map-overlay {
   position: absolute;
   left: 0;
@@ -569,6 +703,10 @@ code {
     right: 1rem;
     max-width: unset;
     max-height: 50vh;
+  }
+
+  .drawer-filters {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- sync event list selections with Leaflet markers, provide detailed drawer view, and allow registering turns directly from the map
- add role/date/distance filters with focus-role indicators, loading hints, and compact viewport guidance for the events drawer
- enhance accessibility for drawer tabs and event controls with ARIA roles, focus states, keyboard shortcuts, and refreshed styles

## Testing
- npm run build:pwa

## Screenshots
- Map updates and event detail
![Map updates and event detail](browser:/tmp/codex_browser_invocations/e66778a6b1d8e0b9/artifacts/artifacts/map-accessibility.png)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957cb6ce07083269934f3d31f241d53)