### PR TITLE
feat(leaderboard): Supabase-backed leaderboard in PWA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,4 @@
 |-------|:--------------------------------------:|----------------------------------------|
 | Codex | Codex                                | codex@users.noreply.github.com         |
 | Gemini | Gemini | gemini-code-assist@users.noreply.github.com |
+| Cascade | Cascade | cascade@users.noreply.github.com |

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -551,6 +551,29 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     setBadgesLoading(false);
   }, [authUserId]);
 
+  const refreshLeaderboard = useCallback(async () => {
+    if (!supabase) return;
+    setLeaderboardLoading(true);
+    const { data, error } = await supabase!
+      .from('profiles')
+      .select('id,name,xp_total,level,role_id,profile_image')
+      .order('xp_total', { ascending: false })
+      .limit(50);
+
+    if (!error && data) {
+      const nextLeaderboard: LeaderboardEntry[] = data.map((row: any) => ({
+        id: row.id,
+        name: row.name,
+        xpTotal: row.xp_total ?? 0,
+        level: row.level ?? 1,
+        roleId: (row.role_id as RoleId) ?? 'attore',
+        profileImage: row.profile_image,
+      }));
+      setLeaderboard(nextLeaderboard);
+    }
+    setLeaderboardLoading(false);
+  }, []);
+
   const markBadgesSeen = useCallback(async () => {
     if (!supabase || !authUserId) return;
     try {

--- a/apps/pwa/leaderboard.html
+++ b/apps/pwa/leaderboard.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Turni di Palco - Classifica</title>
+    <meta name="description" content="Classifica Turni di Palco" />
+    <meta name="theme-color" content="#05070d" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" type="image/png" sizes="192x192" href="/icons/pwa-192.png" />
+    <link rel="icon" type="image/png" sizes="512x512" href="/icons/pwa-512.png" />
+    <link rel="apple-touch-icon" href="/icons/pwa-192.png" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  </head>
+  <body data-theme="dark">
+    <div id="app"></div>
+    <script type="module" src="/src/leaderboard.ts"></script>
+  </body>
+</html>

--- a/apps/pwa/package.json
+++ b/apps/pwa/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@types/leaflet": "^1.9.21",
+    "@supabase/supabase-js": "^2.50.0",
     "leaflet": "^1.9.4"
   }
 }

--- a/apps/pwa/src/components/leaderboard.ts
+++ b/apps/pwa/src/components/leaderboard.ts
@@ -1,0 +1,197 @@
+import { LeaderboardEntry, LeaderboardStats, formatLeaderboardPosition, resolveRole, getAvatarVisual } from "../state";
+
+export type LeaderboardViewMode = "xp" | "reputation" | "cachet";
+
+export interface LeaderboardComponentOptions {
+  entries: LeaderboardEntry[];
+  stats: LeaderboardStats;
+  currentUserId?: string;
+  viewMode?: LeaderboardViewMode;
+  onViewModeChange?: (mode: LeaderboardViewMode) => void;
+}
+
+export function renderLeaderboard(options: LeaderboardComponentOptions): string {
+  const { entries, stats, currentUserId, viewMode = "xp", onViewModeChange } = options;
+  
+  const sortedEntries = sortEntries(entries, viewMode);
+  const userPosition = currentUserId ? sortedEntries.findIndex(entry => entry.id === currentUserId) : -1;
+  const userEntry = userPosition >= 0 ? sortedEntries[userPosition] : null;
+
+  return `
+    <div class="leaderboard-container">
+      <div class="leaderboard-header">
+        <h2>Classifica</h2>
+        <div class="leaderboard-stats">
+          <div class="stat-chip">
+            <span>Giocatori</span>
+            <strong>${stats.totalPlayers}</strong>
+          </div>
+          <div class="stat-chip">
+            <span>Media XP</span>
+            <strong>${stats.averageXp}</strong>
+          </div>
+          <div class="stat-chip">
+            <span>Top XP</span>
+            <strong>${stats.topXp}</strong>
+          </div>
+        </div>
+      </div>
+
+      <div class="leaderboard-controls">
+        <div class="view-mode-tabs" role="tablist">
+          <button 
+            class="tab-button ${viewMode === "xp" ? "active" : ""}" 
+            data-mode="xp" 
+            role="tab" 
+            aria-selected="${viewMode === "xp"}"
+            ${onViewModeChange ? 'data-action="change-mode"' : ''}
+          >
+            XP
+          </button>
+          <button 
+            class="tab-button ${viewMode === "reputation" ? "active" : ""}" 
+            data-mode="reputation" 
+            role="tab" 
+            aria-selected="${viewMode === "reputation"}"
+            ${onViewModeChange ? 'data-action="change-mode"' : ''}
+          >
+            Reputazione
+          </button>
+          <button 
+            class="tab-button ${viewMode === "cachet" ? "active" : ""}" 
+            data-mode="cachet" 
+            role="tab" 
+            aria-selected="${viewMode === "cachet"}"
+            ${onViewModeChange ? 'data-action="change-mode"' : ''}
+          >
+            Cachet
+          </button>
+        </div>
+      </div>
+
+      <div class="leaderboard-list">
+        ${sortedEntries
+          .slice(0, 20)
+          .map((entry, index) => renderLeaderboardEntry(entry, index + 1, entry.id === currentUserId, viewMode))
+          .join("")}
+      </div>
+
+      ${userEntry && userPosition >= 20 ? `
+        <div class="leaderboard-user-position">
+          <h3>La tua posizione</h3>
+          ${renderLeaderboardEntry(userEntry, userPosition + 1, true, viewMode)}
+        </div>
+      ` : ""}
+
+      ${entries.length === 0 ? `
+        <div class="leaderboard-empty">
+          <p class="muted">Nessun giocatore nella classifica.</p>
+        </div>
+      ` : ""}
+    </div>
+  `;
+}
+
+function sortEntries(entries: LeaderboardEntry[], mode: LeaderboardViewMode): LeaderboardEntry[] {
+  const sorted = [...entries];
+  
+  switch (mode) {
+    case "xp":
+      return sorted.sort((a, b) => b.xpTotal - a.xpTotal);
+    case "reputation":
+      return sorted.sort((a, b) => b.reputation - a.reputation);
+    case "cachet":
+      return sorted.sort((a, b) => b.cachet - a.cachet);
+    default:
+      return sorted;
+  }
+}
+
+function colorFromString(input: string): string {
+  let hash = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash << 5) - hash + input.charCodeAt(i);
+    hash |= 0;
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue}deg 75% 55%)`;
+}
+
+function renderLeaderboardEntry(entry: LeaderboardEntry, position: number, isCurrentUser: boolean, viewMode: LeaderboardViewMode): string {
+  const role = resolveRole(entry.roleId);
+  const avatarVisual = getAvatarVisual({ hue: 210, icon: "mask", rpmThumbnail: entry.profileImage || "" });
+  const positionDisplay = formatLeaderboardPosition(position);
+  const fallbackColor = colorFromString(entry.id);
+  
+  return `
+    <div class="leaderboard-entry ${isCurrentUser ? "current-user" : ""}" data-player-id="${entry.id}">
+      <div class="leaderboard-position">
+        <span class="position-badge">${positionDisplay}</span>
+      </div>
+      
+      <div class="leaderboard-avatar">
+        <div class="avatar-display small" style="--avatar-color: ${avatarVisual.color || fallbackColor}; --avatar-hue: 210deg;">
+          ${entry.profileImage ? `<img src="${entry.profileImage}" alt="${entry.name}" />` : `<span class="avatar-icon">${entry.name.slice(0, 1).toUpperCase()}</span>`}
+        </div>
+      </div>
+
+      <div class="leaderboard-info">
+        <div class="player-name">
+          ${entry.name}
+          ${isCurrentUser ? '<span class="current-user-badge">Tu</span>' : ""}
+        </div>
+        <div class="player-role">${role.name}</div>
+        <div class="player-stats">
+          <span class="stat-item">${entry.xpTotal} XP</span>
+          <span class="stat-item">${entry.reputation} rep</span>
+          <span class="stat-item">${entry.turnsCount} turni</span>
+        </div>
+      </div>
+
+      <div class="leaderboard-score">
+        <div class="score-value">${getScoreValue(entry, viewMode)}</div>
+        <div class="score-label">${getScoreLabel(viewMode)}</div>
+      </div>
+    </div>
+  `;
+}
+
+function getScoreValue(entry: LeaderboardEntry, mode: LeaderboardViewMode): number {
+  switch (mode) {
+    case "reputation":
+      return entry.reputation;
+    case "cachet":
+      return entry.cachet;
+    default:
+      return entry.xpTotal;
+  }
+}
+
+function getScoreLabel(mode: LeaderboardViewMode): string {
+  switch (mode) {
+    case "reputation":
+      return "Reputazione";
+    case "cachet":
+      return "Cachet";
+    default:
+      return "XP";
+  }
+}
+
+export function attachLeaderboardListeners(
+  container: HTMLElement,
+  onViewModeChange?: (mode: LeaderboardViewMode) => void
+): void {
+  const modeButtons = container.querySelectorAll('[data-action="change-mode"]');
+  
+  modeButtons.forEach(button => {
+    button.addEventListener("click", (event) => {
+      const target = event.target as HTMLElement;
+      const mode = target.dataset.mode as LeaderboardViewMode;
+      
+      if (mode && onViewModeChange) {
+        onViewModeChange(mode);
+      }
+    });
+  });
+}

--- a/apps/pwa/src/game.ts
+++ b/apps/pwa/src/game.ts
@@ -26,6 +26,7 @@ const pageHero = renderPageHero({
     { id: "avatar", label: "Avatar", href: "/avatar.html", variant: "ghost" },
     { id: "profile", label: "Profilo", href: "/profile.html", variant: "ghost" },
     { id: "turns", label: "Turni", href: "/turns.html", variant: "ghost" },
+    { id: "leaderboard", label: "Classifica", href: "/leaderboard.html", variant: "ghost" },
   ],
   quickActions: [{ id: "dev", label: "Dev playground", href: "/dev.html", icon: "🛠️" }],
 });

--- a/apps/pwa/src/leaderboard.ts
+++ b/apps/pwa/src/leaderboard.ts
@@ -1,0 +1,164 @@
+import "../../../shared/styles/main.css";
+import { renderPageHero } from "./components/page-hero";
+import { renderLeaderboard, attachLeaderboardListeners, LeaderboardViewMode } from "./components/leaderboard";
+import { calculateLeaderboardStats, loadState, STORAGE_KEY, LeaderboardEntry, RoleId } from "./state";
+import { supabase, isSupabaseConfigured } from "./services/supabase";
+
+const root = document.querySelector<HTMLDivElement>("#app");
+
+if (!root) {
+  throw new Error("Root container missing");
+}
+
+const pageHero = renderPageHero({
+  title: "Classifica",
+  description: "Le migliori performance dei tecnici teatrali ATCL.",
+  currentPage: "leaderboard",
+  breadcrumbs: [
+    { label: "Hub", href: "/game.html" },
+    { label: "Classifica" },
+  ],
+  backHref: "/game.html",
+  backLabel: "Torna all'hub",
+});
+
+let currentViewMode: LeaderboardViewMode = "xp";
+let leaderboardEntries: LeaderboardEntry[] = [];
+let leaderboardStats = calculateLeaderboardStats(leaderboardEntries);
+let isLoading = false;
+let loadError: string | null = null;
+let currentUserId: string | undefined;
+
+type LeaderboardRow = {
+  id: string;
+  name: string;
+  role_id: string | null;
+  xp_total: number | null;
+  cachet: number | null;
+  reputation: number | null;
+  profile_image: string | null;
+  last_activity_at: string | null;
+  turns_count: number | null;
+};
+
+function renderLeaderboardPage() {
+  if (!root) return;
+  
+  const sortedEntries = sortEntriesByMode(leaderboardEntries, currentViewMode);
+  
+  root.innerHTML = `
+    <main class="page page-game layout-shell">
+      ${pageHero}
+
+      <section class="card">
+        ${isLoading ? '<p class="muted">Caricamento classifica...</p>' : ""}
+        ${loadError ? `<p class="muted">${loadError}</p>` : ""}
+        ${!isLoading && !loadError ? renderLeaderboard({
+            entries: sortedEntries,
+            stats: leaderboardStats,
+            currentUserId,
+            viewMode: currentViewMode,
+            onViewModeChange: handleViewModeChange,
+          }) : ""}
+      </section>
+    </main>
+  `;
+
+  attachLeaderboardListeners(root, handleViewModeChange);
+}
+
+function sortEntriesByMode(entries: LeaderboardEntry[], mode: LeaderboardViewMode): LeaderboardEntry[] {
+  const sorted = [...entries];
+  
+  switch (mode) {
+    case "xp":
+      return sorted.sort((a, b) => b.xpTotal - a.xpTotal);
+    case "reputation":
+      return sorted.sort((a, b) => b.reputation - a.reputation);
+    case "cachet":
+      return sorted.sort((a, b) => b.cachet - a.cachet);
+    default:
+      return sorted;
+  }
+}
+
+async function loadLeaderboard() {
+  isLoading = true;
+  loadError = null;
+  renderLeaderboardPage();
+
+  if (!isSupabaseConfigured || !supabase) {
+    isLoading = false;
+    loadError = "Supabase non configurato (mancano VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY).";
+    renderLeaderboardPage();
+    return;
+  }
+
+  try {
+    const { data: authData } = await supabase.auth.getUser();
+    currentUserId = authData.user?.id;
+
+    const { data, error } = await supabase.rpc("get_leaderboard", { p_limit: 100 });
+    if (error) throw error;
+
+    const rows = (data as LeaderboardRow[]) ?? [];
+    leaderboardEntries = rows.map((row) => {
+      const roleCandidate = row.role_id ?? "attore";
+      const roleId: RoleId = (roleCandidate === "attore" || roleCandidate === "luci" || roleCandidate === "fonico" || roleCandidate === "attrezzista" || roleCandidate === "palco")
+        ? (roleCandidate as RoleId)
+        : "attore";
+
+      const lastActivityAt = row.last_activity_at ? Date.parse(row.last_activity_at) : undefined;
+      return {
+        id: row.id,
+        name: row.name ?? "Player",
+        roleId,
+        xpTotal: row.xp_total ?? 0,
+        cachet: row.cachet ?? 0,
+        reputation: row.reputation ?? 0,
+        turnsCount: row.turns_count ?? 0,
+        lastActivityAt,
+        profileImage: row.profile_image ?? undefined,
+      };
+    });
+
+    leaderboardStats = calculateLeaderboardStats(leaderboardEntries);
+    isLoading = false;
+    renderLeaderboardPage();
+  } catch (error) {
+    isLoading = false;
+    loadError = error instanceof Error ? error.message : "Errore durante il caricamento della classifica.";
+    renderLeaderboardPage();
+  }
+}
+
+function handleViewModeChange(mode: LeaderboardViewMode) {
+  currentViewMode = mode;
+  
+  const url = new URL(window.location.href);
+  url.searchParams.set("mode", mode);
+  window.history.replaceState({}, "", url.toString());
+  
+  renderLeaderboardPage();
+}
+
+function showSyncBadge(message = "Stato aggiornato") {
+  const syncBadge = document.querySelector<HTMLElement>('[data-sync-badge]');
+  if (!syncBadge) return;
+  
+  syncBadge.textContent = message;
+  syncBadge.style.display = "inline-flex";
+  
+  setTimeout(() => {
+    if (syncBadge) syncBadge.style.display = "none";
+  }, 2500);
+}
+
+window.addEventListener("storage", (event) => {
+  if (event.key !== STORAGE_KEY) return;
+  loadState();
+  showSyncBadge();
+});
+
+renderLeaderboardPage();
+loadLeaderboard();

--- a/apps/pwa/src/services/supabase.ts
+++ b/apps/pwa/src/services/supabase.ts
@@ -1,0 +1,15 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseAnonKey);
+
+export const supabase = isSupabaseConfigured
+  ? createClient(supabaseUrl!, supabaseAnonKey!, {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+      },
+    })
+  : null;

--- a/apps/pwa/src/state.ts
+++ b/apps/pwa/src/state.ts
@@ -32,6 +32,24 @@ export type TurnRecord = {
 export type PlayerProfile = { name: string; roleId: RoleId; xp: number; cachet: number; repAtcl: number; avatar: AvatarSettings };
 export type ActivityStats = { runs: number; lastPlayedAt?: number };
 export type TutorialState = { firstChoiceComplete: boolean };
+export type LeaderboardEntry = {
+  id: string;
+  name: string;
+  roleId: RoleId;
+  xpTotal: number;
+  cachet: number;
+  reputation: number;
+  turnsCount: number;
+  lastActivityAt?: number;
+  profileImage?: string;
+};
+export type LeaderboardStats = {
+  totalPlayers: number;
+  averageXp: number;
+  topXp: number;
+  averageReputation: number;
+  topReputation: number;
+};
 export type GameState = {
   version: number;
   profile: PlayerProfile;
@@ -319,4 +337,36 @@ export function saveState(state: GameState): SaveStateResult {
     memoryFallback = prepared;
     return { ok: false, state: prepared, error: error instanceof Error ? error.message : "Unknown storage error" };
   }
+}
+
+export function calculateLeaderboardStats(entries: LeaderboardEntry[]): LeaderboardStats {
+  if (entries.length === 0) {
+    return {
+      totalPlayers: 0,
+      averageXp: 0,
+      topXp: 0,
+      averageReputation: 0,
+      topReputation: 0
+    };
+  }
+
+  const totalXp = entries.reduce((sum, entry) => sum + entry.xpTotal, 0);
+  const totalReputation = entries.reduce((sum, entry) => sum + entry.reputation, 0);
+  const topXp = Math.max(...entries.map((entry) => entry.xpTotal));
+  const topReputation = Math.max(...entries.map((entry) => entry.reputation));
+
+  return {
+    totalPlayers: entries.length,
+    averageXp: Math.round(totalXp / entries.length),
+    topXp,
+    averageReputation: Math.round(totalReputation / entries.length),
+    topReputation
+  };
+}
+
+export function formatLeaderboardPosition(position: number): string {
+  if (position === 1) return "🥇";
+  if (position === 2) return "🥈";
+  if (position === 3) return "🥉";
+  return `${position}`;
 }

--- a/apps/pwa/vite.config.ts
+++ b/apps/pwa/vite.config.ts
@@ -1,12 +1,13 @@
 import fs from "fs";
 import path from "path";
+import type { ServerOptions as HttpsServerOptions } from "https";
 import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 
-function resolveHttps() {
+function resolveHttps(): HttpsServerOptions | undefined {
   const httpsEnv = process.env.HTTPS;
   if (httpsEnv === "false" || httpsEnv === "0") {
-    return false;
+    return undefined;
   }
 
   const flag = httpsEnv === "true" || httpsEnv === "1";
@@ -37,7 +38,8 @@ function resolveHttps() {
     }
   }
 
-  return flag || true;
+  if (flag) return {};
+  return {};
 }
 
 const httpsOption = resolveHttps();
@@ -56,6 +58,7 @@ export default defineConfig({
         profile: path.resolve(__dirname, "profile.html"),
         events: path.resolve(__dirname, "events.html"),
         turns: path.resolve(__dirname, "turns.html"),
+        leaderboard: path.resolve(__dirname, "leaderboard.html"),
       },
     },
   },

--- a/supabase/migrations/20260107_leaderboard_rpc.sql
+++ b/supabase/migrations/20260107_leaderboard_rpc.sql
@@ -1,0 +1,37 @@
+create or replace function public.get_leaderboard(p_limit int default 50)
+returns table (
+  id uuid,
+  name text,
+  role_id text,
+  xp_total int,
+  cachet int,
+  reputation int,
+  profile_image text,
+  last_activity_at timestamptz,
+  turns_count int
+)
+language sql
+security definer
+set search_path = public
+as $$
+  select
+    p.id,
+    p.name,
+    p.role_id,
+    p.xp_total,
+    p.cachet,
+    p.reputation,
+    p.profile_image,
+    p.last_activity_at,
+    (
+      select count(*)::int
+      from public.turns t
+      where t.user_id = p.id
+    ) as turns_count
+  from public.profiles p
+  order by p.xp_total desc nulls last
+  limit greatest(1, least(p_limit, 200));
+$$;
+
+revoke execute on function public.get_leaderboard(int) from public;
+grant execute on function public.get_leaderboard(int) to authenticated;


### PR DESCRIPTION
## Intent
Implementare una leaderboard **senza mock** nella PWA, alimentata da Supabase, con pagina dedicata e caricamento via RPC per rispettare la RLS su `public.profiles`.

## Cosa cambia
- Aggiunta pagina `leaderboard.html` e entry MPA in `apps/pwa/vite.config.ts`
- Nuovo client Supabase PWA: `apps/pwa/src/services/supabase.ts`
  - Env richieste: `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`
- Nuova RPC Supabase: `public.get_leaderboard(p_limit int default 50)`
  - `security definer` + `grant` a `authenticated`
- Leaderboard reale in `apps/pwa/src/leaderboard.ts` (loading/error/empty + sorting per view mode)
- Componente UI `apps/pwa/src/components/leaderboard.ts` allineato ai campi DB (`xp_total`, `reputation`, `cachet`, `profile_image`, `last_activity_at`)
- Link alla leaderboard dallhub: `apps/pwa/src/game.ts`
- Aggiunta dipendenza `@supabase/supabase-js` nel workspace PWA

## Note DB / RLS
La tabella `public.profiles` ha RLS abilitata: la lettura globale viene esposta tramite RPC `get_leaderboard` (`security definer`) e non tramite query dirette.

## Come testare
1. Applicare la migration `supabase/migrations/20260107_leaderboard_rpc.sql` nel progetto Supabase
2. Impostare in `apps/pwa/.env`:
   - `VITE_SUPABASE_URL=...`
   - `VITE_SUPABASE_ANON_KEY=...`
3. `npm install` (root repo)
4. `npm run dev:pwa`
5. Login (utente Supabase) e aprire `/leaderboard.html`
6. Verificare:
   - caricamento dati reali
   - stati loading/errore
   - sorting XP/Reputazione/Cachet

## Checklist
- [ ] Migration applicata su Supabase
- [ ] Env configurate in PWA
- [ ] Test manuale effettuato