### PR TITLE
Add leaderboard screen to mobile app

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -10,6 +10,7 @@ import { QRScanner } from './components/screens/QRScanner';
 import { EventConfirmation } from './components/screens/EventConfirmation';
 import { Attivita } from './components/screens/Attivita';
 import { ActivityDetail } from './components/screens/ActivityDetail';
+import { Leaderboard } from './components/screens/Leaderboard';
 import { Profilo } from './components/screens/Profilo';
 import { AccountSettings } from './components/screens/AccountSettings';
 import { ChangePassword } from './components/screens/ChangePassword';
@@ -28,6 +29,7 @@ type Screen =
   | 'role-selection'
   | 'home'
   | 'turni'
+  | 'leaderboard'
   | 'qr-scanner'
   | 'event-confirmation'
   | 'attivita'
@@ -40,7 +42,7 @@ type Screen =
   | 'privacy'
   | 'titoli-ottenuti';
 
-type Tab = 'home' | 'turni' | 'attivita' | 'profilo';
+type Tab = 'home' | 'turni' | 'leaderboard' | 'attivita' | 'profilo';
 
 type LegalReturnScreen = Exclude<Screen, 'terms' | 'privacy'>;
 
@@ -64,6 +66,7 @@ const VALID_SCREENS = new Set<Screen>([
   'role-selection',
   'home',
   'turni',
+  'leaderboard',
   'qr-scanner',
   'event-confirmation',
   'attivita',
@@ -77,7 +80,7 @@ const VALID_SCREENS = new Set<Screen>([
   'titoli-ottenuti',
 ]);
 
-const VALID_TABS = new Set<Tab>(['home', 'turni', 'attivita', 'profilo']);
+const VALID_TABS = new Set<Tab>(['home', 'turni', 'leaderboard', 'attivita', 'profilo']);
 
 const VALID_LEGAL_RETURN_SCREENS = new Set<LegalReturnScreen>([
   'welcome',
@@ -140,6 +143,7 @@ function getScreenToPersist(screen: Screen, activeTab: Tab): Screen {
 
 function AppShell() {
   const {
+    authUserId,
     state,
     roles,
     events,
@@ -274,6 +278,9 @@ function AppShell() {
       case 'turni':
         setCurrentScreen('turni');
         break;
+      case 'leaderboard':
+        setCurrentScreen('leaderboard');
+        break;
       case 'attivita':
         setCurrentScreen('attivita');
         break;
@@ -348,13 +355,13 @@ function AppShell() {
   };
 
   const handleUploadProfileImage = async (file: File) => {
-    if (!supabase || !state.authUserId) {
+    if (!supabase || !authUserId) {
       throw new Error('Supabase non configurato o utente non autenticato');
     }
 
     // Create a unique filename
     const fileExt = file.name.split('.').pop();
-    const fileName = `${state.authUserId}/profile.${fileExt}`;
+    const fileName = `${authUserId}/profile.${fileExt}`;
 
     // Upload to Supabase storage
     const { data, error } = await supabase.storage
@@ -521,6 +528,9 @@ function AppShell() {
           />
         );
 
+      case 'leaderboard':
+        return <Leaderboard />;
+
       case 'qr-scanner':
         return (
           <QRScanner
@@ -650,7 +660,7 @@ function AppShell() {
     }
   };
 
-  const showBottomNav = ['home', 'turni', 'attivita', 'profilo', 'carriera', 'titoli-ottenuti'].includes(currentScreen);
+  const showBottomNav = ['home', 'turni', 'leaderboard', 'attivita', 'profilo', 'carriera', 'titoli-ottenuti'].includes(currentScreen);
 
   return (
     <div className="min-h-screen app-gradient app-shell">

--- a/apps/mobile/src/components/BottomNav.tsx
+++ b/apps/mobile/src/components/BottomNav.tsx
@@ -1,15 +1,16 @@
 ﻿import React from 'react';
-import { Home, ListChecks, Ticket, User } from 'lucide-react';
+import { Home, ListChecks, Ticket, Trophy, User } from 'lucide-react';
 
 interface BottomNavProps {
-  activeTab: 'home' | 'turni' | 'attivita' | 'profilo';
-  onTabChange: (tab: 'home' | 'turni' | 'attivita' | 'profilo') => void;
+  activeTab: 'home' | 'turni' | 'leaderboard' | 'attivita' | 'profilo';
+  onTabChange: (tab: 'home' | 'turni' | 'leaderboard' | 'attivita' | 'profilo') => void;
 }
 
 export function BottomNav({ activeTab, onTabChange }: BottomNavProps) {
   const tabs = [
     { id: 'home' as const, icon: Home, label: 'Home' },
     { id: 'turni' as const, icon: Ticket, label: 'Turni ATCL' },
+    { id: 'leaderboard' as const, icon: Trophy, label: 'Classifica' },
     { id: 'attivita' as const, icon: ListChecks, label: 'Attività' },
     { id: 'profilo' as const, icon: User, label: 'Profilo' }
   ];
@@ -17,7 +18,7 @@ export function BottomNav({ activeTab, onTabChange }: BottomNavProps) {
   return (
     <nav className="fixed bottom-0 left-0 right-0 w-full app-nav bg-[#1a1617] border-t border-[#2d2728] z-50">
       <div className="app-content flex items-end justify-center h-[80px] pb-[20px] pt-px">
-        <div className="flex items-center justify-between w-[280px]">
+        <div className="flex items-center justify-between w-[350px]">
           {tabs.map((tab) => {
             const Icon = tab.icon;
             const isActive = activeTab === tab.id;

--- a/apps/mobile/src/components/screens/Leaderboard.tsx
+++ b/apps/mobile/src/components/screens/Leaderboard.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useMemo } from 'react';
+import { Trophy } from 'lucide-react';
+import { useGameState } from '../../state/store';
+import { Card } from '../ui/Card';
+import { Tag } from '../ui/Tag';
+
+export function Leaderboard() {
+  const { authUserId, leaderboard, leaderboardLoading, refreshLeaderboard, roles } = useGameState();
+
+  useEffect(() => {
+    refreshLeaderboard();
+  }, [refreshLeaderboard]);
+
+  const sorted = useMemo(() => {
+    return [...leaderboard].sort((a, b) => b.xpTotal - a.xpTotal);
+  }, [leaderboard]);
+
+  return (
+    <div
+      className="min-h-screen flex flex-col justify-center items-center"
+      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 96px)' }}
+    >
+      <div className="w-full app-content px-6 pt-6 pb-8 space-y-6">
+        <header className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl text-white font-semibold leading-tight">Classifica</h2>
+            <button
+              onClick={() => refreshLeaderboard()}
+              className="text-sm text-[#f4bf4f] hover:text-[#e6a23c] px-3 py-[12px] rounded-lg"
+              disabled={leaderboardLoading}
+            >
+              Aggiorna
+            </button>
+          </div>
+          <p className="text-sm text-[#b8b2b3]">Top giocatori per XP</p>
+        </header>
+
+        {leaderboardLoading ? (
+          <p className="text-[#b8b2b3]">Caricamento...</p>
+        ) : sorted.length === 0 ? (
+          <Card>
+            <p className="text-[#b8b2b3]">Nessun dato disponibile.</p>
+          </Card>
+        ) : (
+          <div className="space-y-3">
+            {sorted.map((entry, index) => {
+              const roleName = roles.find((role) => role.id === entry.roleId)?.name ?? 'Ruolo';
+              const isMe = Boolean(authUserId) && entry.id === authUserId;
+              const initial = (entry.name?.slice(0, 1) ?? 'P').toUpperCase();
+
+              return (
+                <Card key={entry.id}>
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 text-center text-[#b8b2b3]">{index + 1}</div>
+
+                    <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-[#241f20] overflow-hidden">
+                      {entry.profileImage ? (
+                        <img src={entry.profileImage} alt={entry.name} className="w-full h-full object-cover" />
+                      ) : (
+                        <span className="text-white font-semibold">{initial}</span>
+                      )}
+                    </div>
+
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <p className="text-white font-semibold truncate">{entry.name}</p>
+                        {isMe ? <Tag size="sm">Tu</Tag> : null}
+                      </div>
+                      <p className="text-sm text-[#b8b2b3] truncate">{roleName}</p>
+                    </div>
+
+                    <div className="flex items-center gap-2 text-[#f4bf4f]">
+                      <Trophy size={18} />
+                      <span className="text-white font-semibold">{entry.xpTotal}</span>
+                    </div>
+                  </div>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -77,6 +77,18 @@ export type TheatreReputation = {
   totalTurns: number;
 };
 
+export type LeaderboardEntry = {
+  id: string;
+  name: string;
+  roleId: RoleId;
+  xpTotal: number;
+  cachet: number;
+  reputation: number;
+  turnsCount: number;
+  profileImage?: string;
+  lastActivityAt?: number;
+};
+
 export type BadgeMetric = 'total_turns' | 'turns_this_month' | 'unique_theatres' | 'manual';
 
 export type Badge = {
@@ -422,6 +434,7 @@ export function computeTurnRewards(event: GameEvent, roleId: RoleId): Rewards {
 }
 
 type GameContextValue = {
+  authUserId: string | null;
   state: GameState;
   roles: Role[];
   events: GameEvent[];
@@ -430,10 +443,13 @@ type GameContextValue = {
   statsLoading: boolean;
   theatreReputation: TheatreReputation[];
   theatreReputationLoading: boolean;
+  leaderboard: LeaderboardEntry[];
+  leaderboardLoading: boolean;
+  refreshLeaderboard: () => Promise<void>;
   badges: Badge[];
   badgesLoading: boolean;
   markBadgesSeen: () => void;
-  updateProfile: (updates: Partial<Pick<PlayerProfile, 'name' | 'email' | 'roleId'>>) => void;
+  updateProfile: (updates: Partial<Pick<PlayerProfile, 'name' | 'email' | 'roleId' | 'profileImage'>>) => void;
   registerTurn: (eventId: string, roleId: RoleId) => TurnRecord | null;
   completeActivity: (activityId: string) => { activity: Activity; rewards: Rewards } | null;
   resetProgress: () => Promise<void>;
@@ -462,6 +478,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   const [statsLoading, setStatsLoading] = useState(false);
   const [remoteTheatreReputation, setRemoteTheatreReputation] = useState<TheatreReputation[]>([]);
   const [theatreReputationLoading, setTheatreReputationLoading] = useState(false);
+  const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
+  const [leaderboardLoading, setLeaderboardLoading] = useState(false);
   const [remoteBadges, setRemoteBadges] = useState<Badge[]>([]);
   const [badgesLoading, setBadgesLoading] = useState(false);
 
@@ -551,27 +569,52 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     setBadgesLoading(false);
   }, [authUserId]);
 
+  type LeaderboardRow = {
+    id: string;
+    name: string | null;
+    role_id: string | null;
+    xp_total: number | null;
+    cachet: number | null;
+    reputation: number | null;
+    profile_image: string | null;
+    last_activity_at: string | null;
+    turns_count: number | null;
+  };
+
   const refreshLeaderboard = useCallback(async () => {
     if (!supabase) return;
     setLeaderboardLoading(true);
-    const { data, error } = await supabase!
-      .from('profiles')
-      .select('id,name,xp_total,level,role_id,profile_image')
-      .order('xp_total', { ascending: false })
-      .limit(50);
 
-    if (!error && data) {
-      const nextLeaderboard: LeaderboardEntry[] = data.map((row: any) => ({
-        id: row.id,
-        name: row.name,
-        xpTotal: row.xp_total ?? 0,
-        level: row.level ?? 1,
-        roleId: (row.role_id as RoleId) ?? 'attore',
-        profileImage: row.profile_image,
-      }));
+    try {
+      const { data, error } = await supabase.rpc('get_leaderboard', { p_limit: 50 });
+      if (error) throw error;
+
+      const rows = (data as LeaderboardRow[]) ?? [];
+      const nextLeaderboard: LeaderboardEntry[] = rows.map((row) => {
+        const roleCandidate = row.role_id ?? 'attore';
+        const roleId: RoleId = (roleCandidate === 'attore' || roleCandidate === 'luci' || roleCandidate === 'fonico' || roleCandidate === 'attrezzista' || roleCandidate === 'palco')
+          ? (roleCandidate as RoleId)
+          : 'attore';
+        const lastActivityAt = row.last_activity_at ? new Date(row.last_activity_at).getTime() : undefined;
+        return {
+          id: row.id,
+          name: row.name ?? 'Player',
+          roleId,
+          xpTotal: row.xp_total ?? 0,
+          cachet: row.cachet ?? 0,
+          reputation: row.reputation ?? 0,
+          turnsCount: row.turns_count ?? 0,
+          profileImage: row.profile_image ?? undefined,
+          lastActivityAt,
+        };
+      });
       setLeaderboard(nextLeaderboard);
+    } catch (error) {
+      console.warn('Supabase leaderboard fetch failed', error);
+      setLeaderboard([]);
+    } finally {
+      setLeaderboardLoading(false);
     }
-    setLeaderboardLoading(false);
   }, []);
 
   const markBadgesSeen = useCallback(async () => {
@@ -631,6 +674,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     refreshTurnStats();
     refreshTheatreReputation();
     refreshBadges();
+    refreshLeaderboard();
   }, [authUserId, refreshBadges, refreshTheatreReputation, refreshTurnStats]);
 
   useEffect(() => {
@@ -1169,6 +1213,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
   const value = useMemo<GameContextValue>(
     () => ({
+      authUserId,
       state,
       roles: catalog.roles,
       events: catalog.events,
@@ -1177,6 +1222,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       statsLoading,
       theatreReputation,
       theatreReputationLoading,
+      leaderboard,
+      leaderboardLoading,
+      refreshLeaderboard,
       badges,
       badgesLoading,
       markBadgesSeen,
@@ -1189,12 +1237,16 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       resetState,
     }),
     [
+      authUserId,
       state,
       catalog,
       turnStats,
       statsLoading,
       theatreReputation,
       theatreReputationLoading,
+      leaderboard,
+      leaderboardLoading,
+      refreshLeaderboard,
       badges,
       badgesLoading,
       markBadgesSeen,

--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "turni-di-palco-vbe4c9add";
+const CACHE_NAME = "turni-di-palco-v26442dfc";
 const OFFLINE_URL = "/index.html";
 const CORE_ASSETS = [
   "/",


### PR DESCRIPTION
Introduces a new Leaderboard screen displaying top players by XP, updates navigation to include the leaderboard tab, and integrates leaderboard state management and data fetching via Supabase. Also updates BottomNav and AppShell to support the new tab and screen.