### PR TITLE
Add notification helpers and settings toggle for mobile

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -21,6 +21,7 @@ import { PrivacyPolicy } from './components/screens/PrivacyPolicy';
 import { TitoliOttenuti } from './components/screens/TitoliOttenuti';
 import { GameStateProvider, useGameState } from './state/store';
 import { isSupabaseConfigured, supabase } from './lib/supabase';
+import { getPermission, notify } from './lib/notifications';
 
 
 type Screen =
@@ -192,6 +193,8 @@ function AppShell() {
   const [selectedActivityId, setSelectedActivityId] = useState<string>(() => persistedNavState?.selectedActivityId ?? '');
   const [authError, setAuthError] = useState<string | null>(null);
   const currentScreenRef = useRef(currentScreen);
+  const lastNotifiedBadgeId = useRef<string | null>(null);
+  const lastNotifiedEventId = useRef<string | null>(null);
 
   const upcomingEvent = useMemo(() => followedEvents[0], [followedEvents]);
   const unlockedBadges = useMemo(() => badges.filter((badge) => badge.unlocked), [badges]);
@@ -220,6 +223,30 @@ function AppShell() {
   useEffect(() => {
     currentScreenRef.current = currentScreen;
   }, [currentScreen]);
+
+  useEffect(() => {
+    if (!newestNewBadge) return;
+    if (lastNotifiedBadgeId.current === newestNewBadge.id) return;
+    if (getPermission() !== 'granted') return;
+
+    notify('Nuovo badge sbloccato', {
+      body: newestNewBadge.title,
+      tag: `badge-${newestNewBadge.id}`,
+    });
+    lastNotifiedBadgeId.current = newestNewBadge.id;
+  }, [newestNewBadge]);
+
+  useEffect(() => {
+    if (!upcomingEvent) return;
+    if (lastNotifiedEventId.current === upcomingEvent.id) return;
+    if (getPermission() !== 'granted') return;
+
+    notify('Nuovo evento in agenda', {
+      body: `${upcomingEvent.name} · ${upcomingEvent.date} ${upcomingEvent.time}`,
+      tag: `event-${upcomingEvent.id}`,
+    });
+    lastNotifiedEventId.current = upcomingEvent.id;
+  }, [upcomingEvent]);
 
   useEffect(() => {
     writeNavState({

--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import {
   ArrowLeft,
+  Bell,
   ChevronRight,
   FileText,
   History,
@@ -11,6 +12,12 @@ import {
 } from 'lucide-react';
 import { Screen } from '../ui/Screen';
 import { isSupabaseConfigured, supabase } from '../../lib/supabase';
+import { Switch } from '../ui/switch';
+import {
+  getPermission,
+  requestPermission,
+  type NotificationPermissionState,
+} from '../../lib/notifications';
 
 interface AccountSettingsProps {
   userName: string;
@@ -57,6 +64,20 @@ export function AccountSettings({
   const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
   const [appInfoStatus, setAppInfoStatus] = useState<'idle' | 'loading' | 'error'>('idle');
   const [appInfoError, setAppInfoError] = useState<string | null>(null);
+  const [notificationPermission, setNotificationPermission] = useState<NotificationPermissionState>(() => getPermission());
+
+  const notificationStatusLabel = (() => {
+    switch (notificationPermission) {
+      case 'granted':
+        return 'Attive';
+      case 'denied':
+        return 'Bloccate';
+      case 'default':
+        return 'Da abilitare';
+      default:
+        return 'Non supportate';
+    }
+  })();
 
   useEffect(() => {
     let mounted = true;
@@ -98,6 +119,30 @@ export function AccountSettings({
       mounted = false;
     };
   }, []);
+
+  useEffect(() => {
+    setNotificationPermission(getPermission());
+  }, []);
+
+  const handleNotificationToggle = async (checked: boolean) => {
+    if (notificationPermission === 'unsupported') {
+      window.alert('Le notifiche di sistema non sono supportate su questo dispositivo.');
+      return;
+    }
+
+    if (!checked) {
+      window.alert('Puoi disattivare le notifiche dalle impostazioni del browser o del dispositivo.');
+      setNotificationPermission(getPermission());
+      return;
+    }
+
+    const nextPermission = await requestPermission();
+    setNotificationPermission(nextPermission);
+
+    if (nextPermission !== 'granted') {
+      window.alert('Permesso notifiche non concesso.');
+    }
+  };
 
   const handleReset = () => {
     if (typeof window === 'undefined') return;
@@ -191,6 +236,35 @@ export function AccountSettings({
               </p>
             ) : null}
           </div>
+        </div>
+
+        <div className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] px-[12px] py-[12px] flex flex-col gap-[8px]">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-[12px]">
+              <Bell className="text-[#f4bf4f]" size={24} />
+              <div className="text-left">
+                <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">
+                  Notifiche di sistema
+                </p>
+                <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">
+                  Aggiornamenti su badge ed eventi
+                </p>
+              </div>
+            </div>
+            <Switch
+              checked={notificationPermission === 'granted'}
+              onCheckedChange={handleNotificationToggle}
+              disabled={notificationPermission === 'unsupported'}
+            />
+          </div>
+          <p className="text-[14px] leading-[20px] text-[#b8b2b3]">
+            Stato: {notificationStatusLabel}
+          </p>
+          {notificationPermission === 'unsupported' ? (
+            <p className="text-[14px] leading-[20px] text-[#ff4d4f]">
+              Le notifiche di sistema non sono disponibili su questo dispositivo.
+            </p>
+          ) : null}
         </div>
 
         <div className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] px-[12px] py-[12px] flex flex-col gap-[8px]">

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -1,0 +1,36 @@
+export type NotificationPermissionState = NotificationPermission | 'unsupported';
+
+export function isNotificationSupported() {
+  return typeof window !== 'undefined' && 'Notification' in window;
+}
+
+export function getPermission(): NotificationPermissionState {
+  if (!isNotificationSupported()) return 'unsupported';
+  return Notification.permission;
+}
+
+export async function requestPermission(): Promise<NotificationPermissionState> {
+  if (!isNotificationSupported()) return 'unsupported';
+
+  try {
+    return await Notification.requestPermission();
+  } catch (error) {
+    console.error('Notification permission request failed', error);
+    return Notification.permission;
+  }
+}
+
+export function notify(title: string, options?: NotificationOptions) {
+  if (!isNotificationSupported()) {
+    console.warn('Notifications are not supported in this environment.');
+    return null;
+  }
+  if (Notification.permission !== 'granted') return null;
+
+  try {
+    return new Notification(title, options);
+  } catch (error) {
+    console.error('Notification delivery failed', error);
+    return null;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a small, safe wrapper around the Web Notifications API to centralize support/permission checks and delivery.
- Surface system notifications to users for important mobile app events like newly unlocked badges and upcoming followed events.
- Give users a simple UI control and clear messaging in settings to request/inspect notification permission and handle unsupported environments.

### Description
- Added `apps/mobile/src/lib/notifications.ts` with `isNotificationSupported()`, `getPermission()`, `requestPermission()` and `notify()` helpers that safely handle unsupported environments and errors.
- Integrated notification delivery in `apps/mobile/src/App.tsx` to send a system notification when a new badge is unlocked or when an `upcomingEvent` appears, guarded by permission checks and deduplicated with in-memory refs.
- Added a notifications section in `apps/mobile/src/components/screens/AccountSettings.tsx` that shows permission status, an enable toggle (using `Switch`), and clear messaging for the `unsupported` state and denial cases.
- Minor imports and state additions to wire the above (`getPermission`, `requestPermission`, `notify`, UI `Bell` icon and `Switch`).

### Testing
- Launched the mobile dev server with `npm --prefix apps/mobile run dev` which started Vite and served the app locally (server startup succeeded).
- Attempted a Playwright-based UI run to capture the settings screen and validate the new UI, but the browser automation failed to load the local site due to SSL/cipher errors and network timeouts (failed).
- No unit tests were added or executed as part of this change (none run).
- Manual smoke checks were attempted via automated screenshot script but were unsuccessful due to the environment SSL issues (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964d99256b883268d32a0b1095a0028)