### PR TITLE
Refine QR auth redirects and remote-data validation

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -154,6 +154,8 @@ function getScreenToPersist(screen: Screen, activeTab: Tab): Screen {
 function AppShell() {
   const {
     authUserId,
+    authReady,
+    hasHydratedRemote,
     state,
     roles,
     events,
@@ -201,6 +203,7 @@ function AppShell() {
   const currentScreenRef = useRef(currentScreen);
   const lastNotifiedBadgeId = useRef<string | null>(null);
   const lastNotifiedEventId = useRef<string | null>(null);
+  const hasHandledQrLanding = useRef(false);
 
   const upcomingEvent = useMemo(() => followedEvents[0], [followedEvents]);
   const unlockedBadges = useMemo(() => badges.filter((badge) => badge.unlocked), [badges]);
@@ -213,6 +216,12 @@ function AppShell() {
     if (!newBadges.length) return null;
     return [...newBadges].sort((a, b) => (b.unlockedAt ?? 0) - (a.unlockedAt ?? 0))[0];
   }, [newBadges]);
+  const hasValidEmail = Boolean(state.profile.email && state.profile.email.includes('@'));
+  const isAuthValid = useMemo(() => {
+    if (!isSupabaseConfigured) return true;
+    if (!authReady) return false;
+    return Boolean(authUserId && hasHydratedRemote && hasValidEmail);
+  }, [authReady, authUserId, hasHydratedRemote, hasValidEmail]);
 
   useEffect(() => {
     if (!events.length) {
@@ -268,16 +277,22 @@ function AppShell() {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (hasHandledQrLanding.current) return;
     const search = new URLSearchParams(window.location.search);
     if (search.get('from') !== 'qr') return;
-
-    setCurrentScreen('install');
+    if (!authReady) return;
+    hasHandledQrLanding.current = true;
+    if (!isAuthValid) {
+      setCurrentScreen('welcome');
+    } else {
+      setCurrentScreen('install');
+    }
     try {
       window.history.replaceState({}, '', window.location.pathname);
     } catch {
       // ignore
     }
-  }, []);
+  }, [authReady, isAuthValid]);
 
   const handleStart = () => setCurrentScreen('signup');
 
@@ -350,6 +365,13 @@ function AppShell() {
   };
 
   const handleQRScanAttempt = (code: string) => {
+    if (!authReady) {
+      return { ok: false as const, error: 'Sto verificando la sessione, riprova tra poco.' };
+    }
+    if (!isAuthValid) {
+      setCurrentScreen('welcome');
+      return { ok: false as const, error: 'Effettua il login per continuare.' };
+    }
     if (!events.length) {
       return { ok: false as const, error: 'Nessun evento disponibile al momento.' };
     }
@@ -444,6 +466,17 @@ function AppShell() {
     setCurrentScreen('account-settings');
   };
 
+  const handleOpenQRScanner = () => {
+    if (!authReady) {
+      return;
+    }
+    if (!isAuthValid) {
+      setCurrentScreen('welcome');
+      return;
+    }
+    setCurrentScreen('qr-scanner');
+  };
+
   const openTerms = (from: LegalReturnScreen) => {
     setLegalReturnScreen(from);
     setCurrentScreen('terms');
@@ -462,6 +495,23 @@ function AppShell() {
     setCurrentScreen('welcome');
     setActiveTab('home');
   };
+
+  useEffect(() => {
+    if (!isSupabaseConfigured) return;
+    if (!authReady || !authUserId) return;
+    if (hasHydratedRemote && hasValidEmail) return;
+    if (typeof window === 'undefined') return;
+
+    const timeoutId = window.setTimeout(() => {
+      if (!hasHydratedRemote || !hasValidEmail) {
+        handleLogout();
+      }
+    }, 4000);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [authReady, authUserId, handleLogout, hasHydratedRemote, hasValidEmail]);
 
   const handleUploadProfileImage = async (file: File) => {
     if (!supabase || !authUserId) {
@@ -605,6 +655,10 @@ function AppShell() {
         return (
           <InstallApp
             onContinue={() => {
+              if (!isAuthValid) {
+                setCurrentScreen('welcome');
+                return;
+              }
               setCurrentScreen(state.profile.roleId ? 'home' : 'welcome');
             }}
           />
@@ -622,7 +676,7 @@ function AppShell() {
             xp={state.profile.xp}
             xpToNextLevel={state.profile.xpToNextLevel}
             reputation={state.profile.reputation}
-            onScanQR={() => setCurrentScreen('qr-scanner')}
+            onScanQR={handleOpenQRScanner}
             onViewActivities={() => handleTabChange('attivita')}
             onViewTurni={() => handleTabChange('turni')}
             onViewEventDetails={handleViewEventDetails}
@@ -651,7 +705,7 @@ function AppShell() {
               setScannedEventId(eventId);
               setCurrentScreen('event-details');
             }}
-            onScanQR={() => setCurrentScreen('qr-scanner')}
+            onScanQR={handleOpenQRScanner}
           />
         );
 

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -451,6 +451,8 @@ export function computeTurnRewards(event: GameEvent, roleId: RoleId): Rewards {
 
 type GameContextValue = {
   authUserId: string | null;
+  authReady: boolean;
+  hasHydratedRemote: boolean;
   state: GameState;
   roles: Role[];
   events: GameEvent[];
@@ -489,6 +491,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     activities,
   }));
   const [authUserId, setAuthUserId] = useState<string | null>(null);
+  const [authReady, setAuthReady] = useState(!isSupabaseConfigured);
   const [hasHydratedRemote, setHasHydratedRemote] = useState(false);
   const localTurnStats = useMemo(() => computeTurnStatsFromTurns(state.turns), [state.turns]);
   const localTheatreReputation = useMemo(
@@ -667,6 +670,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       if (!isMounted) return;
       persistStoredSession(data.session ?? null);
       setAuthUserId(data.session?.user.id ?? null);
+      setAuthReady(true);
     };
 
     restoreSession();
@@ -675,6 +679,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       persistStoredSession(session ?? null);
       if (!isMounted) return;
       setAuthUserId(session?.user.id ?? null);
+      setAuthReady(true);
     });
 
     return () => {
@@ -1344,6 +1349,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   const value = useMemo<GameContextValue>(
     () => ({
       authUserId,
+      authReady,
+      hasHydratedRemote,
       state,
       roles: catalog.roles,
       events: catalog.events,
@@ -1373,6 +1380,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     }),
     [
       authUserId,
+      authReady,
+      hasHydratedRemote,
       state,
       catalog,
       turnStats,


### PR DESCRIPTION
### Motivation
- Ensure the QR deep-link landing (`?from=qr`) and scanner entry perform immediate auth validation and redirect to the welcome screen if login is missing or malformed. 
- Make sure authenticated UI only proceeds when remote user/profile data has been hydrated from the database to avoid stale or incomplete profiles. 
- Provide a fallback forced-logout when remote hydration or profile email validation never completes, avoiding a stuck/incorrect logged-in state. 
- Centralize gating so all QR entry points and the install flow behave consistently when Supabase is enabled.

### Description
- Exposed a `hasHydratedRemote` flag and `authReady` in the game context by updating `apps/mobile/src/state/store.tsx` so consumers can detect when remote profile data is available. 
- Added an `isAuthValid` check in `apps/mobile/src/App.tsx` that requires `authReady`, `authUserId`, `hasHydratedRemote`, and a valid email before allowing QR flows to proceed. 
- Gate QR deep-link handling and scanner entry by updating the `from=qr` landing logic and the `handleQRScanAttempt` / `handleOpenQRScanner` handlers to redirect to `welcome` when auth is invalid, and apply the same gating to the `InstallApp` continue action. 
- Added a timeout-based safeguard effect that calls `handleLogout` after 4 seconds if remote hydration or email validation fails, to force a clean welcome state rather than leaving the app in a broken authenticated state.

### Testing
- No automated tests were executed for these changes. 
- TypeScript/IDE type checks were not run as part of this update. 
- CI/test runs were not triggered by this update. 
- Changes were implemented in `apps/mobile/src/App.tsx` and `apps/mobile/src/state/store.tsx` and should be covered by future integration or E2E tests that exercise QR landing and Supabase session hydration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965289b45d88326a3deba51976bbcb0)