### PR TITLE
Add Supabase dev access gate for PWA entry points

### DIFF
--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -1,5 +1,5 @@
-const CORE_CACHE_NAME = "turni-di-palco-v0d5eb66f";
-const TILE_CACHE_NAME = "turni-di-palco-tiles-v0d5eb66f";
+const CORE_CACHE_NAME = "turni-di-palco-v3f5a2b7e";
+const TILE_CACHE_NAME = "turni-di-palco-tiles-v3f5a2b7e";
 const TILE_HOSTS = new Set([
   "tile.openstreetmap.org",
   "a.tile.openstreetmap.org",

--- a/apps/pwa/src/avatar.ts
+++ b/apps/pwa/src/avatar.ts
@@ -3,219 +3,227 @@ import { renderPageHero } from "./components/page-hero";
 import { registerServiceWorker } from "./pwa/register-sw";
 import { promptServiceWorkerUpdate } from "./pwa/sw-update";
 import { deriveRpmThumbnail, getAvatarVisual, loadState, saveState, SaveStateResult, STORAGE_KEY } from "./state";
+import { requireDevAccess } from "./services/dev-gate";
 
-const RPM_ORIGIN = "https://readyplayer.me";
-const RPM_SRC = "https://readyplayer.me/avatar?frameApi";
+const start = async () => {
+  if (!(await requireDevAccess())) return;
 
-const root = document.querySelector<HTMLDivElement>("#app");
 
-if (!root) {
-  throw new Error("Root container missing");
-}
+  const RPM_ORIGIN = "https://readyplayer.me";
+  const RPM_SRC = "https://readyplayer.me/avatar?frameApi";
 
-const pageHero = renderPageHero({
-  title: "Avatar ReadyPlayer.Me",
-  description: "Crea o aggiorna il tuo avatar 3D. Il risultato verrà salvato nel profilo e usato nelle altre pagine.",
-  currentPage: "avatar",
-  breadcrumbs: [
-    { label: "Hub", href: "/game.html" },
-    { label: "Avatar" },
-  ],
-  backHref: "/game.html",
-  backLabel: "Torna all'hub",
-});
+  const root = document.querySelector<HTMLDivElement>("#app");
 
-root.innerHTML = `
-  <main class="page page-game layout-shell">
-    ${pageHero}
+  if (!root) {
+    throw new Error("Root container missing");
+  }
 
-    <section class="grid layout-grid">
-      <article class="card layout-span-2">
-        <h2>Editor ReadyPlayer.Me</h2>
-        <div class="rpm-frame">
-          <iframe title="ReadyPlayer.Me avatar" data-rpm-frame src="${RPM_SRC}" allow="camera *; microphone *" referrerpolicy="no-referrer"></iframe>
-        </div>
-        <div class="result-box" data-rpm-status>Apri l'editor, esporta l'avatar e verrà salvato qui.</div>
-      </article>
+  const pageHero = renderPageHero({
+    title: "Avatar ReadyPlayer.Me",
+    description: "Crea o aggiorna il tuo avatar 3D. Il risultato verrà salvato nel profilo e usato nelle altre pagine.",
+    currentPage: "avatar",
+    breadcrumbs: [
+      { label: "Hub", href: "/game.html" },
+      { label: "Avatar" },
+    ],
+    backHref: "/game.html",
+    backLabel: "Torna all'hub",
+  });
 
-      <article class="card">
-        <h2>Anteprima avatar</h2>
-        <div class="profile-pane">
-          <div class="avatar-display large" data-avatar="preview">
-            <img data-avatar-img alt="Avatar ReadyPlayerMe" />
-            <span class="avatar-icon" data-avatar-label></span>
+  root.innerHTML = `
+    <main class="page page-game layout-shell">
+      ${pageHero}
+
+      <section class="grid layout-grid">
+        <article class="card layout-span-2">
+          <h2>Editor ReadyPlayer.Me</h2>
+          <div class="rpm-frame">
+            <iframe title="ReadyPlayer.Me avatar" data-rpm-frame src="${RPM_SRC}" allow="camera *; microphone *" referrerpolicy="no-referrer"></iframe>
           </div>
-          <div>
-            <p class="muted" data-avatar-meta>Nessun avatar ReadyPlayer.Me salvato.</p>
-            <div class="pill-row">
-              <span class="pill ghost" data-avatar-updated>Mai sincronizzato</span>
+          <div class="result-box" data-rpm-status>Apri l'editor, esporta l'avatar e verrà salvato qui.</div>
+        </article>
+
+        <article class="card">
+          <h2>Anteprima avatar</h2>
+          <div class="profile-pane">
+            <div class="avatar-display large" data-avatar="preview">
+              <img data-avatar-img alt="Avatar ReadyPlayerMe" />
+              <span class="avatar-icon" data-avatar-label></span>
+            </div>
+            <div>
+              <p class="muted" data-avatar-meta>Nessun avatar ReadyPlayer.Me salvato.</p>
+              <div class="pill-row">
+                <span class="pill ghost" data-avatar-updated>Mai sincronizzato</span>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="cta-row">
-          <button class="button ghost" type="button" data-action="clear-avatar">Rimuovi avatar RPM</button>
-          <a class="button primary" href="/map.html">Usa nella mappa</a>
-        </div>
-      </article>
-    </section>
-  </main>
-`;
+          <div class="cta-row">
+            <button class="button ghost" type="button" data-action="clear-avatar">Rimuovi avatar RPM</button>
+            <a class="button primary" href="/map.html">Usa nella mappa</a>
+          </div>
+        </article>
+      </section>
+    </main>
+  `;
 
-const iframe = root.querySelector<HTMLIFrameElement>('[data-rpm-frame]');
-const statusBox = root.querySelector<HTMLElement>('[data-rpm-status]');
-const avatarDisplay = root.querySelector<HTMLElement>('[data-avatar="preview"]');
-const avatarImg = root.querySelector<HTMLImageElement>('[data-avatar-img]');
-const avatarLabel = root.querySelector<HTMLElement>('[data-avatar-label]');
-const avatarMeta = root.querySelector<HTMLElement>('[data-avatar-meta]');
-const avatarUpdated = root.querySelector<HTMLElement>('[data-avatar-updated]');
-const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
+  const iframe = root.querySelector<HTMLIFrameElement>('[data-rpm-frame]');
+  const statusBox = root.querySelector<HTMLElement>('[data-rpm-status]');
+  const avatarDisplay = root.querySelector<HTMLElement>('[data-avatar="preview"]');
+  const avatarImg = root.querySelector<HTMLImageElement>('[data-avatar-img]');
+  const avatarLabel = root.querySelector<HTMLElement>('[data-avatar-label]');
+  const avatarMeta = root.querySelector<HTMLElement>('[data-avatar-meta]');
+  const avatarUpdated = root.querySelector<HTMLElement>('[data-avatar-updated]');
+  const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
 
-let state = loadState();
-let syncBadgeTimeout: number | undefined;
+  let state = loadState();
+  let syncBadgeTimeout: number | undefined;
 
-function showSyncBadge(message = "Stato aggiornato") {
-  if (!syncBadge) return;
-  syncBadge.textContent = message;
-  syncBadge.style.display = "inline-flex";
-  if (syncBadgeTimeout) {
-    window.clearTimeout(syncBadgeTimeout);
+  function showSyncBadge(message = "Stato aggiornato") {
+    if (!syncBadge) return;
+    syncBadge.textContent = message;
+    syncBadge.style.display = "inline-flex";
+    if (syncBadgeTimeout) {
+      window.clearTimeout(syncBadgeTimeout);
+    }
+    syncBadgeTimeout = window.setTimeout(() => {
+      if (syncBadge) syncBadge.style.display = "none";
+    }, 2500);
   }
-  syncBadgeTimeout = window.setTimeout(() => {
-    if (syncBadge) syncBadge.style.display = "none";
-  }, 2500);
-}
 
-function persistState(nextState: typeof state, feedback?: HTMLElement): SaveStateResult {
-  const result = saveState(nextState);
-  state = result.state;
-  if (!result.ok && feedback) {
-    feedback.dataset.state = "warn";
-    feedback.textContent = "Salvataggio locale non riuscito: manteniamo una copia in memoria.";
+  function persistState(nextState: typeof state, feedback?: HTMLElement): SaveStateResult {
+    const result = saveState(nextState);
+    state = result.state;
+    if (!result.ok && feedback) {
+      feedback.dataset.state = "warn";
+      feedback.textContent = "Salvataggio locale non riuscito: manteniamo una copia in memoria.";
+    }
+    return result;
   }
-  return result;
-}
 
-function renderPreview() {
-  const avatarVisual = getAvatarVisual(state.profile.avatar);
-  if (avatarDisplay) {
-    avatarDisplay.style.setProperty("--avatar-color", avatarVisual.color);
-    avatarDisplay.classList.toggle("has-image", !!avatarVisual.image);
-  }
-  if (avatarImg) {
-    if (avatarVisual.image) {
-      avatarImg.src = avatarVisual.image;
-      avatarImg.style.display = "block";
-    } else {
-      avatarImg.removeAttribute("src");
-      avatarImg.style.display = "none";
+  function renderPreview() {
+    const avatarVisual = getAvatarVisual(state.profile.avatar);
+    if (avatarDisplay) {
+      avatarDisplay.style.setProperty("--avatar-color", avatarVisual.color);
+      avatarDisplay.classList.toggle("has-image", !!avatarVisual.image);
+    }
+    if (avatarImg) {
+      if (avatarVisual.image) {
+        avatarImg.src = avatarVisual.image;
+        avatarImg.style.display = "block";
+      } else {
+        avatarImg.removeAttribute("src");
+        avatarImg.style.display = "none";
+      }
+    }
+    if (avatarLabel) {
+      avatarLabel.textContent = avatarVisual.icon;
+    }
+    if (avatarMeta) {
+      avatarMeta.textContent = state.profile.avatar.rpmUrl
+        ? `Avatar pronto: ${state.profile.avatar.rpmId || "ReadyPlayer.Me"}`
+        : "Nessun avatar ReadyPlayer.Me salvato.";
+    }
+    if (avatarUpdated) {
+      const updated = state.profile.avatar.updatedAt;
+      avatarUpdated.textContent = updated ? `Aggiornato: ${new Date(updated).toLocaleString()}` : "Mai sincronizzato";
     }
   }
-  if (avatarLabel) {
-    avatarLabel.textContent = avatarVisual.icon;
-  }
-  if (avatarMeta) {
-    avatarMeta.textContent = state.profile.avatar.rpmUrl
-      ? `Avatar pronto: ${state.profile.avatar.rpmId || "ReadyPlayer.Me"}`
-      : "Nessun avatar ReadyPlayer.Me salvato.";
-  }
-  if (avatarUpdated) {
-    const updated = state.profile.avatar.updatedAt;
-    avatarUpdated.textContent = updated ? `Aggiornato: ${new Date(updated).toLocaleString()}` : "Mai sincronizzato";
-  }
-}
 
-function isRpmEvent(event: MessageEvent) {
-  const origin = event.origin || "";
-  const allowed = origin === RPM_ORIGIN || origin.endsWith(".readyplayer.me");
-  const sourceOk = typeof event.data === "object" && event.data?.source === "readyplayer.me";
-  return allowed && sourceOk;
-}
+  function isRpmEvent(event: MessageEvent) {
+    const origin = event.origin || "";
+    const allowed = origin === RPM_ORIGIN || origin.endsWith(".readyplayer.me");
+    const sourceOk = typeof event.data === "object" && event.data?.source === "readyplayer.me";
+    return allowed && sourceOk;
+  }
 
-function subscribe(eventName: string) {
-  iframe?.contentWindow?.postMessage(
-    {
-      target: "readyplayer.me",
-      type: "subscribe",
-      eventName,
-    },
-    "*"
-  );
-}
+  function subscribe(eventName: string) {
+    iframe?.contentWindow?.postMessage(
+      {
+        target: "readyplayer.me",
+        type: "subscribe",
+        eventName,
+      },
+      "*"
+    );
+  }
 
-function handleExported(url?: string, id?: string, thumb?: string) {
-  if (!url) {
+  function handleExported(url?: string, id?: string, thumb?: string) {
+    if (!url) {
+      if (statusBox) {
+        statusBox.dataset.state = "warn";
+        statusBox.textContent = "Avatar non ricevuto: riprova l'esportazione.";
+      }
+      return;
+    }
+    const derivedThumb = thumb || deriveRpmThumbnail(url);
+    state = {
+      ...state,
+      profile: {
+        ...state.profile,
+        avatar: { ...state.profile.avatar, rpmUrl: url, rpmThumbnail: derivedThumb, rpmId: id || "", updatedAt: Date.now() },
+      },
+    };
+    const result = persistState(state, statusBox);
+    renderPreview();
     if (statusBox) {
-      statusBox.dataset.state = "warn";
-      statusBox.textContent = "Avatar non ricevuto: riprova l'esportazione.";
+      statusBox.dataset.state = result.ok ? "ok" : "warn";
+      statusBox.textContent = result.ok ? "Avatar salvato nel profilo." : "Avatar salvato solo in memoria: riprova il salvataggio.";
     }
-    return;
   }
-  const derivedThumb = thumb || deriveRpmThumbnail(url);
-  state = {
-    ...state,
-    profile: {
-      ...state.profile,
-      avatar: { ...state.profile.avatar, rpmUrl: url, rpmThumbnail: derivedThumb, rpmId: id || "", updatedAt: Date.now() },
+
+  window.addEventListener("message", (event) => {
+    if (!isRpmEvent(event)) return;
+    const payload = event.data;
+    const type = payload?.eventName || payload?.type;
+    if (type === "v1.frame.ready") {
+      subscribe("v1.avatar.exported");
+      return;
+    }
+    if (type === "v1.avatar.exported") {
+      const url = payload?.data?.url || payload?.url;
+      const avatarId = payload?.data?.avatarId || payload?.data?.id || payload?.avatarId;
+      const thumb = payload?.data?.thumbnailUrl || payload?.data?.thumb || payload?.thumb;
+      handleExported(url, avatarId, thumb);
+    }
+  });
+
+  root.querySelector<HTMLButtonElement>('[data-action="clear-avatar"]')?.addEventListener("click", () => {
+    state = {
+      ...state,
+      profile: { ...state.profile, avatar: { ...state.profile.avatar, rpmUrl: "", rpmThumbnail: "", rpmId: "", updatedAt: undefined } },
+    };
+    const result = persistState(state, statusBox);
+    renderPreview();
+    if (statusBox) {
+      statusBox.dataset.state = result.ok ? "info" : "warn";
+      statusBox.textContent = result.ok
+        ? "Avatar RPM rimosso. Verrà usato il fallback locale."
+        : "Avatar rimosso solo in memoria: controlla i permessi di storage.";
+    }
+  });
+
+  renderPreview();
+
+  window.addEventListener("storage", (event) => {
+    if (event.key !== STORAGE_KEY) return;
+    state = loadState();
+    renderPreview();
+    showSyncBadge();
+    if (statusBox) {
+      statusBox.dataset.state = "info";
+      statusBox.textContent = "Stato aggiornato da un'altra scheda.";
+    }
+  });
+
+  registerServiceWorker({
+    onReady: () => undefined,
+    onUpdate: (registration) => {
+      promptServiceWorkerUpdate(registration);
     },
-  };
-  const result = persistState(state, statusBox);
-  renderPreview();
-  if (statusBox) {
-    statusBox.dataset.state = result.ok ? "ok" : "warn";
-    statusBox.textContent = result.ok ? "Avatar salvato nel profilo." : "Avatar salvato solo in memoria: riprova il salvataggio.";
-  }
-}
+    onError: (error) => {
+      console.error("Service worker registration failed", error);
+    },
+  });
+};
 
-window.addEventListener("message", (event) => {
-  if (!isRpmEvent(event)) return;
-  const payload = event.data;
-  const type = payload?.eventName || payload?.type;
-  if (type === "v1.frame.ready") {
-    subscribe("v1.avatar.exported");
-    return;
-  }
-  if (type === "v1.avatar.exported") {
-    const url = payload?.data?.url || payload?.url;
-    const avatarId = payload?.data?.avatarId || payload?.data?.id || payload?.avatarId;
-    const thumb = payload?.data?.thumbnailUrl || payload?.data?.thumb || payload?.thumb;
-    handleExported(url, avatarId, thumb);
-  }
-});
-
-root.querySelector<HTMLButtonElement>('[data-action="clear-avatar"]')?.addEventListener("click", () => {
-  state = {
-    ...state,
-    profile: { ...state.profile, avatar: { ...state.profile.avatar, rpmUrl: "", rpmThumbnail: "", rpmId: "", updatedAt: undefined } },
-  };
-  const result = persistState(state, statusBox);
-  renderPreview();
-  if (statusBox) {
-    statusBox.dataset.state = result.ok ? "info" : "warn";
-    statusBox.textContent = result.ok
-      ? "Avatar RPM rimosso. Verrà usato il fallback locale."
-      : "Avatar rimosso solo in memoria: controlla i permessi di storage.";
-  }
-});
-
-renderPreview();
-
-window.addEventListener("storage", (event) => {
-  if (event.key !== STORAGE_KEY) return;
-  state = loadState();
-  renderPreview();
-  showSyncBadge();
-  if (statusBox) {
-    statusBox.dataset.state = "info";
-    statusBox.textContent = "Stato aggiornato da un'altra scheda.";
-  }
-});
-
-registerServiceWorker({
-  onReady: () => undefined,
-  onUpdate: (registration) => {
-    promptServiceWorkerUpdate(registration);
-  },
-  onError: (error) => {
-    console.error("Service worker registration failed", error);
-  },
-});
+void start();

--- a/apps/pwa/src/dev.ts
+++ b/apps/pwa/src/dev.ts
@@ -21,712 +21,720 @@ import {
   saveState,
 } from "./state";
 import { buildProgressCopy, getEarnedMilestones, getProgressState, repMilestones, xpMilestones } from "./progression";
+import { requireDevAccess } from "./services/dev-gate";
 
-type ActivityChoice = { id: string; label: string; summary: string; rewards: Rewards };
-type Activity = { id: string; title: string; description: string; choices: ActivityChoice[] };
-type DevEvent = { id: string; name: string; theatre: string; date: string; baseRewards: Rewards; focusRole?: RoleId };
+const start = async () => {
+  if (!(await requireDevAccess())) return;
 
-const devEvents: DevEvent[] = [
-  {
-    id: "ATCL-001",
-    name: "Prova aperta - Teatro di Latina",
-    theatre: "Teatro di Latina",
-    date: "2025-12-15",
-    baseRewards: { xp: 35, cachet: 25, reputation: 8 },
-    focusRole: "attrezzista",
-  },
-  {
-    id: "ATCL-002",
-    name: "Festival Giovani Voci",
-    theatre: "Teatro dell'Unione",
-    date: "2026-01-10",
-    baseRewards: { xp: 45, cachet: 35, reputation: 12 },
-    focusRole: "fonico",
-  },
-  {
-    id: "ATCL-003",
-    name: "Prima nazionale - Circuito ATCL",
-    theatre: "Teatro Palladium",
-    date: "2026-02-02",
-    baseRewards: { xp: 60, cachet: 50, reputation: 18 },
-    focusRole: "luci",
-  },
-];
 
-const devNav = [
-  { label: "Landing", href: "/", icon: "🏠" },
-  { label: "Hub", href: "/game.html", icon: "🎛️" },
-  { label: "Mappa", href: "/map.html", icon: "🗺️" },
-  { label: "Avatar", href: "/avatar.html", icon: "🧑" },
-];
+  type ActivityChoice = { id: string; label: string; summary: string; rewards: Rewards };
+  type Activity = { id: string; title: string; description: string; choices: ActivityChoice[] };
+  type DevEvent = { id: string; name: string; theatre: string; date: string; baseRewards: Rewards; focusRole?: RoleId };
 
-const devAppBar = renderAppBar({ eyebrow: "Turni di Palco", subtitle: "Dev playground", actions: devNav });
-
-const ACTIVITY_COOLDOWN_MS = 20000;
-const MAX_ACTIVITY_RUNS = 3;
-const activities: Activity[] = [
-  {
-    id: "ritardo",
-    title: "Prova generale in ritardo",
-    description: "La compagnia e in ritardo di 20 minuti. Devi gestire il clima e chiudere la prova.",
-    choices: [
-      {
-        id: "calma",
-        label: "Rassicurare e riallineare",
-        summary: "Coordini regista e troupe, riporti calma e priorita.",
-        rewards: { xp: 18, cachet: 10, reputation: 8 },
-      },
-      {
-        id: "stringere",
-        label: "Tagliare e correre",
-        summary: "Accorci alcune scene per finire in tempo. Il ritmo regge ma qualcuno brontola.",
-        rewards: { xp: 12, cachet: 12, reputation: 5 },
-      },
-    ],
-  },
-  {
-    id: "audio",
-    title: "Prova audio critica",
-    description: "Un rientro micro crea Larsen. Il tempo stringe prima dell'apertura porte.",
-    choices: [
-      {
-        id: "diagnosi",
-        label: "Diagnosi rapida e fix",
-        summary: "Individui la catena difettosa e sistemi il gain staging.",
-        rewards: { xp: 22, cachet: 14, reputation: 10 },
-      },
-      {
-        id: "workaround",
-        label: "Workaround conservativo",
-        summary: "Riduci i livelli, il suono e meno pieno ma sicuro.",
-        rewards: { xp: 14, cachet: 16, reputation: 6 },
-      },
-    ],
-  },
-  {
-    id: "palco",
-    title: "Cambio scena rapido",
-    description: "Il cambio scena tra due atti e piu lento del previsto. Serve velocizzare.",
-    choices: [
-      {
-        id: "redistribuire",
-        label: "Redistribuisci i compiti",
-        summary: "Riassegni i movimenti di scena e guadagni tempo.",
-        rewards: { xp: 16, cachet: 12, reputation: 9 },
-      },
-      {
-        id: "semplificare",
-        label: "Semplifica gli elementi",
-        summary: "Rimuovi un paio di props superflui per restare nei tempi.",
-        rewards: { xp: 12, cachet: 10, reputation: 7 },
-      },
-    ],
-  },
-];
-
-const MAX_TURNS_STORED = 8;
-
-const root = document.querySelector<HTMLDivElement>("#app");
-
-if (!root) {
-  throw new Error("Root container missing");
-}
-
-root.innerHTML = `
-  <main class="page">
-    ${devAppBar}
-
-    <section class="hero layout-stack" id="dev">
-      <p class="eyebrow">Turni di Palco</p>
-      <h1>Dev playground</h1>
-      <p class="lede">Profilo, carriera, attivita simulate e registrazione turni di test.</p>
-      <div class="cta-row">
-        <a class="button primary" href="/game.html">Vai all'hub</a>
-        <a class="button ghost" href="/">Torna alla landing</a>
-      </div>
-      <div class="badges">
-        <span class="badge" data-sync-badge style="display:none">Stato aggiornato</span>
-      </div>
-    </section>
-
-    <section class="grid layout-grid gameplay">
-      <article class="card layout-span-2">
-        <h2>Profilo giocatore</h2>
-        <div class="form-grid" data-form="profile">
-          <label class="field">
-            <span>Nome profilo</span>
-            <input type="text" name="playerName" autocomplete="name" placeholder="Dai un nome al profilo" data-field="player-name" />
-          </label>
-          <label class="field">
-            <span>Ruolo principale</span>
-            <select name="playerRole" data-field="player-role"></select>
-          </label>
-          <div class="avatar-config">
-            <div class="avatar-display large" data-avatar="preview">
-              <img data-avatar-img alt="Avatar ReadyPlayerMe" />
-              <span class="avatar-icon" data-avatar-label></span>
-            </div>
-            <div class="form-grid compact">
-              <label class="field">
-                <span>Tinta avatar</span>
-                <input type="range" min="0" max="360" step="1" value="210" data-avatar-hue />
-              </label>
-              <label class="field">
-                <span>Icona</span>
-                <select data-avatar-icon></select>
-              </label>
-            </div>
-          </div>
-          <div class="cta-row">
-            <button class="button primary" type="button" data-action="save-profile">Salva profilo</button>
-            <button class="button ghost" type="button" data-action="reset-state">Reset stato</button>
-          </div>
-          <div class="result-box" data-profile-summary>Profilo non configurato.</div>
-          <p class="muted">I dati sono salvati in locale (localStorage) e serviranno da base per i prossimi moduli.</p>
-        </div>
-      </article>
-
-      <article class="card">
-        <h2>Carriera</h2>
-        <ul class="stat-list">
-          <li><span>XP</span><strong data-stat="xp">0</strong></li>
-          <li><span>Cachet</span><strong data-stat="cachet">0</strong></li>
-          <li><span>Reputazione ATCL</span><strong data-stat="rep">0</strong></li>
-        </ul>
-        <div class="progress-grid">
-          <div class="progress-track" data-track="xp">
-            <div class="progress-head">
-              <div>
-                <p class="eyebrow">Crescita XP</p>
-                <p class="muted" data-progress-copy="xp">Registrando turni e attivita sblocchi milestone XP.</p>
-              </div>
-              <strong data-progress-value="xp">0 XP</strong>
-            </div>
-            <div class="progress-bar" role="progressbar" aria-label="Progresso XP" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-              <span class="progress-fill" data-progress-bar="xp" style="width: 0%"></span>
-            </div>
-          </div>
-          <div class="progress-track" data-track="rep">
-            <div class="progress-head">
-              <div>
-                <p class="eyebrow">Reputazione</p>
-                <p class="muted" data-progress-copy="rep">Cura i turni per ottenere badge di reputazione.</p>
-              </div>
-              <strong data-progress-value="rep">0 rep</strong>
-            </div>
-            <div class="progress-bar" role="progressbar" aria-label="Progresso reputazione" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-              <span class="progress-fill accent" data-progress-bar="rep" style="width: 0%"></span>
-            </div>
-          </div>
-        </div>
-        <div class="pill-row" data-role-stats></div>
-        <div class="badge-panel">
-          <div class="badge-grid" data-badge-list></div>
-          <p class="muted" data-career-note>Seleziona un ruolo per vedere le competenze chiave.</p>
-        </div>
-      </article>
-
-      <article class="card">
-        <h2>Attivita simulate</h2>
-        <div class="form-grid">
-          <label class="field">
-            <span>Scenario</span>
-            <select data-field="activity-select"></select>
-          </label>
-          <p class="muted" data-activity-description>Seleziona uno scenario per avviare una micro-attivita narrativa.</p>
-          <div class="inline-alert" data-activity-tutorial>
-            <div>
-              <p class="eyebrow">Tutorial</p>
-              <p class="muted">Scegli una opzione per sbloccare le attivita e registrare la prima scelta guidata.</p>
-            </div>
-            <button class="button ghost small" type="button" data-action="dismiss-tutorial">Segna come letto</button>
-          </div>
-          <div class="meta-row">
-            <span class="meta-chip" data-activity-guard>Cooldown attivita pronto.</span>
-            <span class="meta-chip ghost" data-activity-limit>Limite sessione: 0 / ${MAX_ACTIVITY_RUNS}</span>
-          </div>
-          <div class="cta-row" data-activity-choices></div>
-          <div class="result-box" data-activity-result>Ancora nessuna attivita eseguita.</div>
-        </div>
-      </article>
-
-      <article class="card">
-        <h2>Turno ATCL (mock QR)</h2>
-        <div class="form-grid">
-          <label class="field">
-            <span>Evento</span>
-            <select data-field="event-select"></select>
-          </label>
-          <label class="field">
-            <span>Ruolo per il turno</span>
-            <select data-field="turn-role"></select>
-          </label>
-          <button class="button primary" type="button" data-action="register-turn">Registra turno di test</button>
-          <div class="result-box" data-turn-feedback>Nessun turno registrato.</div>
-          <div>
-            <p class="muted">Ultimi turni registrati:</p>
-            <ul class="log-list" data-turn-log></ul>
-          </div>
-        </div>
-      </article>
-    </section>
-  </main>
-`;
-
-const profileNameInput = root.querySelector<HTMLInputElement>('[data-field="player-name"]');
-const profileRoleSelect = root.querySelector<HTMLSelectElement>('[data-field="player-role"]');
-const profileSummaryBox = root.querySelector<HTMLElement>('[data-profile-summary]');
-const avatarPreview = root.querySelector<HTMLElement>('[data-avatar="preview"]');
-const avatarImg = root.querySelector<HTMLImageElement>('[data-avatar-img]');
-const avatarLabel = root.querySelector<HTMLElement>('[data-avatar-label]');
-const avatarHueInput = root.querySelector<HTMLInputElement>('[data-avatar-hue]');
-const avatarIconSelect = root.querySelector<HTMLSelectElement>('[data-avatar-icon]');
-const statXp = root.querySelector<HTMLElement>('[data-stat="xp"]');
-const statCachet = root.querySelector<HTMLElement>('[data-stat="cachet"]');
-const statRep = root.querySelector<HTMLElement>('[data-stat="rep"]');
-const progressCopyXp = root.querySelector<HTMLElement>('[data-progress-copy="xp"]');
-const progressCopyRep = root.querySelector<HTMLElement>('[data-progress-copy="rep"]');
-const progressValueXp = root.querySelector<HTMLElement>('[data-progress-value="xp"]');
-const progressValueRep = root.querySelector<HTMLElement>('[data-progress-value="rep"]');
-const progressBarXp = root.querySelector<HTMLElement>('[data-progress-bar="xp"]');
-const progressBarRep = root.querySelector<HTMLElement>('[data-progress-bar="rep"]');
-const badgeList = root.querySelector<HTMLElement>('[data-badge-list]');
-const roleStatsContainer = root.querySelector<HTMLElement>('[data-role-stats]');
-const careerNote = root.querySelector<HTMLElement>('[data-career-note]');
-const activitySelect = root.querySelector<HTMLSelectElement>('[data-field="activity-select"]');
-const activityDescription = root.querySelector<HTMLElement>('[data-activity-description]');
-const activityChoices = root.querySelector<HTMLElement>('[data-activity-choices]');
-const activityResultBox = root.querySelector<HTMLElement>('[data-activity-result]');
-const activityGuardChip = root.querySelector<HTMLElement>('[data-activity-guard]');
-const activityLimitChip = root.querySelector<HTMLElement>('[data-activity-limit]');
-const tutorialBox = root.querySelector<HTMLElement>('[data-activity-tutorial]');
-const eventSelect = root.querySelector<HTMLSelectElement>('[data-field="event-select"]');
-const turnRoleSelect = root.querySelector<HTMLSelectElement>('[data-field="turn-role"]');
-const turnFeedbackBox = root.querySelector<HTMLElement>('[data-turn-feedback]');
-const turnLog = root.querySelector<HTMLElement>('[data-turn-log]');
-const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
-
-let gameState: GameState = loadState();
-let syncBadgeTimeout: number | undefined;
-
-function showSyncBadge(message = "Stato aggiornato") {
-  if (!syncBadge) return;
-  syncBadge.textContent = message;
-  syncBadge.style.display = "inline-flex";
-  if (syncBadgeTimeout) {
-    window.clearTimeout(syncBadgeTimeout);
-  }
-  syncBadgeTimeout = window.setTimeout(() => {
-    if (syncBadge) {
-      syncBadge.style.display = "none";
-    }
-  }, 2500);
-}
-
-function persistState(nextState: GameState, feedback?: HTMLElement): SaveStateResult {
-  const result = saveState(nextState);
-  gameState = result.state;
-  if (!result.ok && feedback) {
-    feedback.dataset.state = "warn";
-    feedback.textContent = "Salvataggio locale non riuscito: verrà usato un backup in memoria.";
-  }
-  return result;
-}
-
-function renderAvatarPreview() {
-  if (!avatarPreview) return;
-  const { hue, icon, rpmUrl, rpmThumbnail } = gameState.profile.avatar;
-  const color = `hsl(${hue}deg 75% 55%)`;
-  const image = rpmThumbnail || deriveRpmThumbnail(rpmUrl);
-  avatarPreview.style.setProperty("--avatar-color", color);
-  avatarPreview.style.setProperty("--avatar-hue", `${hue}deg`);
-  avatarPreview.classList.toggle("has-image", !!image);
-  const iconDef = avatarIcons.find((item) => item.id === icon) ?? avatarIcons[0];
-  if (avatarImg) {
-    if (image) {
-      avatarImg.src = image;
-      avatarImg.style.display = "block";
-    } else {
-      avatarImg.removeAttribute("src");
-      avatarImg.style.display = "none";
-    }
-  }
-  if (avatarLabel) {
-    avatarLabel.textContent = iconDef.symbol;
-  }
-}
-
-function syncProfileForm() {
-  if (profileNameInput) {
-    profileNameInput.value = gameState.profile.name;
-  }
-  if (profileRoleSelect) {
-    profileRoleSelect.value = gameState.profile.roleId;
-  }
-  if (turnRoleSelect) {
-    turnRoleSelect.value = gameState.profile.roleId;
-  }
-  if (avatarHueInput) {
-    avatarHueInput.value = gameState.profile.avatar.hue.toString();
-  }
-  if (avatarIconSelect) {
-    avatarIconSelect.value = gameState.profile.avatar.icon;
-  }
-  renderAvatarPreview();
-}
-
-function renderRoleOptions(select: HTMLSelectElement | null) {
-  if (!select) return;
-  select.innerHTML = roles.map((role) => `<option value="${role.id}">${role.name}</option>`).join("");
-}
-
-function renderAvatarOptions() {
-  if (!avatarIconSelect) return;
-  avatarIconSelect.innerHTML = avatarIcons.map((item) => `<option value="${item.id}">${item.label}</option>`).join("");
-}
-
-function getActivityStats(activityId: string) {
-  return gameState.activityStats[activityId] ?? { runs: 0, lastPlayedAt: undefined };
-}
-
-function renderActivityGuard(activityId: string) {
-  if (!activityGuardChip || !activityLimitChip) return;
-  const stats = getActivityStats(activityId);
-  const now = Date.now();
-  const remainingSeconds = stats.lastPlayedAt ? Math.max(0, Math.ceil((ACTIVITY_COOLDOWN_MS - (now - stats.lastPlayedAt)) / 1000)) : 0;
-  if (remainingSeconds > 0) {
-    activityGuardChip.textContent = `Cooldown: attendi ${remainingSeconds}s prima di ripetere.`;
-    activityGuardChip.dataset.state = "warn";
-  } else {
-    activityGuardChip.textContent = "Cooldown attivita pronto.";
-    activityGuardChip.dataset.state = "ok";
-  }
-  activityLimitChip.textContent = `Limite sessione: ${Math.min(stats.runs, MAX_ACTIVITY_RUNS)} / ${MAX_ACTIVITY_RUNS}`;
-  activityLimitChip.dataset.state = stats.runs >= MAX_ACTIVITY_RUNS ? "warn" : "info";
-}
-
-function renderTutorialBox() {
-  if (!tutorialBox) return;
-  tutorialBox.style.display = gameState.tutorial.firstChoiceComplete ? "none" : "grid";
-}
-function renderEvents() {
-  if (!eventSelect) return;
-  if (!devEvents.length) {
-    eventSelect.innerHTML = `<option value="">Nessun evento mock</option>`;
-    return;
-  }
-  eventSelect.innerHTML = devEvents.map((event) => `<option value="${event.id}">${event.name} (${event.theatre})</option>`).join("");
-}
-
-function renderCareerCard() {
-  if (profileSummaryBox) {
-    const role = resolveRole(gameState.profile.roleId);
-    const playerName = gameState.profile.name || "Giocatore";
-    profileSummaryBox.textContent = `${playerName} - ${role.name} | XP ${gameState.profile.xp}, Cachet ${gameState.profile.cachet}, Rep ATCL ${gameState.profile.repAtcl}`;
-  }
-  if (statXp) statXp.textContent = gameState.profile.xp.toString();
-  if (statCachet) statCachet.textContent = gameState.profile.cachet.toString();
-  if (statRep) statRep.textContent = gameState.profile.repAtcl.toString();
-
-  const xpProgress = getProgressState(gameState.profile.xp, xpMilestones);
-  const repProgress = getProgressState(gameState.profile.repAtcl, repMilestones);
-  if (progressValueXp) progressValueXp.textContent = `${gameState.profile.xp} XP`;
-  if (progressValueRep) progressValueRep.textContent = `${gameState.profile.repAtcl} rep`;
-  if (progressCopyXp) progressCopyXp.textContent = buildProgressCopy(xpProgress, "XP");
-  if (progressCopyRep) progressCopyRep.textContent = buildProgressCopy(repProgress, "punti rep");
-  if (progressBarXp) {
-    progressBarXp.style.width = `${xpProgress.percent}%`;
-    progressBarXp.parentElement?.setAttribute("aria-valuenow", xpProgress.percent.toString());
-  }
-  if (progressBarRep) {
-    progressBarRep.style.width = `${repProgress.percent}%`;
-    progressBarRep.parentElement?.setAttribute("aria-valuenow", repProgress.percent.toString());
-  }
-
-  const earnedXp = getEarnedMilestones(gameState.profile.xp, xpMilestones);
-  const earnedRep = getEarnedMilestones(gameState.profile.repAtcl, repMilestones);
-  const seen = new Set<string>();
-  const repIds = new Set(repMilestones.map((item) => item.id));
-  const badges = [...earnedXp, ...earnedRep].filter((item) => {
-    if (seen.has(item.id)) return false;
-    seen.add(item.id);
-    return true;
-  });
-  if (badgeList) {
-    badgeList.innerHTML = badges.length
-      ? badges
-          .map(
-            (badge) =>
-              `<span class="badge-chip">${badge.label}<small>${badge.target}${repIds.has(badge.id) ? " rep" : " XP"}</small></span>`
-          )
-          .join("")
-      : '<span class="badge-chip ghost">Completa una milestone XP/rep per sbloccare un badge.</span>';
-  }
-
-  if (roleStatsContainer) {
-    const role = resolveRole(gameState.profile.roleId);
-    roleStatsContainer.innerHTML = role.stats.map((stat) => `<span class="pill ghost">${stat}</span>`).join("");
-  }
-  if (careerNote) {
-    const role = resolveRole(gameState.profile.roleId);
-    careerNote.textContent = `Focus ruolo: ${role.focus}. Potenzia queste competenze nelle attivita simulate.`;
-  }
-}
-
-function applyRewards(rewards: Rewards) {
-  gameState.profile.xp += rewards.xp;
-  gameState.profile.cachet += rewards.cachet;
-  gameState.profile.repAtcl += rewards.reputation;
-}
-
-function handleSaveProfile() {
-  const chosenRole = (profileRoleSelect?.value as RoleId) || gameState.profile.roleId;
-  const name = profileNameInput?.value.trim() ?? "";
-  const hueValue = avatarHueInput ? Number(avatarHueInput.value) : gameState.profile.avatar.hue;
-  const nextHue = Number.isFinite(hueValue) ? Math.max(0, Math.min(360, Math.round(hueValue))) : gameState.profile.avatar.hue;
-  const nextIcon = avatarIconSelect?.value as AvatarIcon;
-  const safeIcon = avatarIcons.some((item) => item.id === nextIcon) ? nextIcon : gameState.profile.avatar.icon;
-  gameState = {
-    ...gameState,
-    profile: {
-      ...gameState.profile,
-      name,
-      roleId: chosenRole in roleMap ? chosenRole : gameState.profile.roleId,
-      avatar: { ...gameState.profile.avatar, hue: nextHue, icon: safeIcon },
+  const devEvents: DevEvent[] = [
+    {
+      id: "ATCL-001",
+      name: "Prova aperta - Teatro di Latina",
+      theatre: "Teatro di Latina",
+      date: "2025-12-15",
+      baseRewards: { xp: 35, cachet: 25, reputation: 8 },
+      focusRole: "attrezzista",
     },
-  };
-  persistState(gameState, turnFeedbackBox);
-  syncProfileForm();
-  renderCareerCard();
-  renderTurnHistory();
-  renderAvatarPreview();
-  if (turnFeedbackBox) {
-    turnFeedbackBox.textContent = "Profilo aggiornato.";
-  }
-}
+    {
+      id: "ATCL-002",
+      name: "Festival Giovani Voci",
+      theatre: "Teatro dell'Unione",
+      date: "2026-01-10",
+      baseRewards: { xp: 45, cachet: 35, reputation: 12 },
+      focusRole: "fonico",
+    },
+    {
+      id: "ATCL-003",
+      name: "Prima nazionale - Circuito ATCL",
+      theatre: "Teatro Palladium",
+      date: "2026-02-02",
+      baseRewards: { xp: 60, cachet: 50, reputation: 18 },
+      focusRole: "luci",
+    },
+  ];
 
-function handleResetState() {
-  const confirmReset = window.confirm("Reset dello stato locale? Tutti i progressi mock verranno azzerati.");
-  if (!confirmReset) return;
-  gameState = createDefaultState();
-  persistState(gameState, turnFeedbackBox);
-  syncProfileForm();
-  renderCareerCard();
-  renderActivityUI();
-  if (activities.length) {
-    renderActivityGuard(activities[0].id);
-  }
-  renderTurnHistory();
-  renderAvatarPreview();
-  renderTutorialBox();
-  if (turnFeedbackBox) {
-    turnFeedbackBox.textContent = "Stato locale resettato.";
-  }
-}
+  const devNav = [
+    { label: "Landing", href: "/", icon: "🏠" },
+    { label: "Hub", href: "/game.html", icon: "🎛️" },
+    { label: "Mappa", href: "/map.html", icon: "🗺️" },
+    { label: "Avatar", href: "/avatar.html", icon: "🧑" },
+  ];
 
-function renderActivityOptions(activity: Activity) {
-  if (!activityChoices) return;
-  activityChoices.innerHTML = activity.choices
-    .map((choice) => `<button class="button ghost" type="button" data-choice-id="${choice.id}">${choice.label}</button>`)
-    .join("");
-  if (activityDescription) {
-    activityDescription.textContent = `${activity.title} - ${activity.description}`;
-  }
-}
+  const devAppBar = renderAppBar({ eyebrow: "Turni di Palco", subtitle: "Dev playground", actions: devNav });
 
-function renderActivityUI(activityId?: string) {
-  if (!activities.length) {
-    if (activityDescription) {
-      activityDescription.textContent = "Nessuna attivita configurata.";
+  const ACTIVITY_COOLDOWN_MS = 20000;
+  const MAX_ACTIVITY_RUNS = 3;
+  const activities: Activity[] = [
+    {
+      id: "ritardo",
+      title: "Prova generale in ritardo",
+      description: "La compagnia e in ritardo di 20 minuti. Devi gestire il clima e chiudere la prova.",
+      choices: [
+        {
+          id: "calma",
+          label: "Rassicurare e riallineare",
+          summary: "Coordini regista e troupe, riporti calma e priorita.",
+          rewards: { xp: 18, cachet: 10, reputation: 8 },
+        },
+        {
+          id: "stringere",
+          label: "Tagliare e correre",
+          summary: "Accorci alcune scene per finire in tempo. Il ritmo regge ma qualcuno brontola.",
+          rewards: { xp: 12, cachet: 12, reputation: 5 },
+        },
+      ],
+    },
+    {
+      id: "audio",
+      title: "Prova audio critica",
+      description: "Un rientro micro crea Larsen. Il tempo stringe prima dell'apertura porte.",
+      choices: [
+        {
+          id: "diagnosi",
+          label: "Diagnosi rapida e fix",
+          summary: "Individui la catena difettosa e sistemi il gain staging.",
+          rewards: { xp: 22, cachet: 14, reputation: 10 },
+        },
+        {
+          id: "workaround",
+          label: "Workaround conservativo",
+          summary: "Riduci i livelli, il suono e meno pieno ma sicuro.",
+          rewards: { xp: 14, cachet: 16, reputation: 6 },
+        },
+      ],
+    },
+    {
+      id: "palco",
+      title: "Cambio scena rapido",
+      description: "Il cambio scena tra due atti e piu lento del previsto. Serve velocizzare.",
+      choices: [
+        {
+          id: "redistribuire",
+          label: "Redistribuisci i compiti",
+          summary: "Riassegni i movimenti di scena e guadagni tempo.",
+          rewards: { xp: 16, cachet: 12, reputation: 9 },
+        },
+        {
+          id: "semplificare",
+          label: "Semplifica gli elementi",
+          summary: "Rimuovi un paio di props superflui per restare nei tempi.",
+          rewards: { xp: 12, cachet: 10, reputation: 7 },
+        },
+      ],
+    },
+  ];
+
+  const MAX_TURNS_STORED = 8;
+
+  const root = document.querySelector<HTMLDivElement>("#app");
+
+  if (!root) {
+    throw new Error("Root container missing");
+  }
+
+  root.innerHTML = `
+    <main class="page">
+      ${devAppBar}
+
+      <section class="hero layout-stack" id="dev">
+        <p class="eyebrow">Turni di Palco</p>
+        <h1>Dev playground</h1>
+        <p class="lede">Profilo, carriera, attivita simulate e registrazione turni di test.</p>
+        <div class="cta-row">
+          <a class="button primary" href="/game.html">Vai all'hub</a>
+          <a class="button ghost" href="/">Torna alla landing</a>
+        </div>
+        <div class="badges">
+          <span class="badge" data-sync-badge style="display:none">Stato aggiornato</span>
+        </div>
+      </section>
+
+      <section class="grid layout-grid gameplay">
+        <article class="card layout-span-2">
+          <h2>Profilo giocatore</h2>
+          <div class="form-grid" data-form="profile">
+            <label class="field">
+              <span>Nome profilo</span>
+              <input type="text" name="playerName" autocomplete="name" placeholder="Dai un nome al profilo" data-field="player-name" />
+            </label>
+            <label class="field">
+              <span>Ruolo principale</span>
+              <select name="playerRole" data-field="player-role"></select>
+            </label>
+            <div class="avatar-config">
+              <div class="avatar-display large" data-avatar="preview">
+                <img data-avatar-img alt="Avatar ReadyPlayerMe" />
+                <span class="avatar-icon" data-avatar-label></span>
+              </div>
+              <div class="form-grid compact">
+                <label class="field">
+                  <span>Tinta avatar</span>
+                  <input type="range" min="0" max="360" step="1" value="210" data-avatar-hue />
+                </label>
+                <label class="field">
+                  <span>Icona</span>
+                  <select data-avatar-icon></select>
+                </label>
+              </div>
+            </div>
+            <div class="cta-row">
+              <button class="button primary" type="button" data-action="save-profile">Salva profilo</button>
+              <button class="button ghost" type="button" data-action="reset-state">Reset stato</button>
+            </div>
+            <div class="result-box" data-profile-summary>Profilo non configurato.</div>
+            <p class="muted">I dati sono salvati in locale (localStorage) e serviranno da base per i prossimi moduli.</p>
+          </div>
+        </article>
+
+        <article class="card">
+          <h2>Carriera</h2>
+          <ul class="stat-list">
+            <li><span>XP</span><strong data-stat="xp">0</strong></li>
+            <li><span>Cachet</span><strong data-stat="cachet">0</strong></li>
+            <li><span>Reputazione ATCL</span><strong data-stat="rep">0</strong></li>
+          </ul>
+          <div class="progress-grid">
+            <div class="progress-track" data-track="xp">
+              <div class="progress-head">
+                <div>
+                  <p class="eyebrow">Crescita XP</p>
+                  <p class="muted" data-progress-copy="xp">Registrando turni e attivita sblocchi milestone XP.</p>
+                </div>
+                <strong data-progress-value="xp">0 XP</strong>
+              </div>
+              <div class="progress-bar" role="progressbar" aria-label="Progresso XP" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                <span class="progress-fill" data-progress-bar="xp" style="width: 0%"></span>
+              </div>
+            </div>
+            <div class="progress-track" data-track="rep">
+              <div class="progress-head">
+                <div>
+                  <p class="eyebrow">Reputazione</p>
+                  <p class="muted" data-progress-copy="rep">Cura i turni per ottenere badge di reputazione.</p>
+                </div>
+                <strong data-progress-value="rep">0 rep</strong>
+              </div>
+              <div class="progress-bar" role="progressbar" aria-label="Progresso reputazione" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                <span class="progress-fill accent" data-progress-bar="rep" style="width: 0%"></span>
+              </div>
+            </div>
+          </div>
+          <div class="pill-row" data-role-stats></div>
+          <div class="badge-panel">
+            <div class="badge-grid" data-badge-list></div>
+            <p class="muted" data-career-note>Seleziona un ruolo per vedere le competenze chiave.</p>
+          </div>
+        </article>
+
+        <article class="card">
+          <h2>Attivita simulate</h2>
+          <div class="form-grid">
+            <label class="field">
+              <span>Scenario</span>
+              <select data-field="activity-select"></select>
+            </label>
+            <p class="muted" data-activity-description>Seleziona uno scenario per avviare una micro-attivita narrativa.</p>
+            <div class="inline-alert" data-activity-tutorial>
+              <div>
+                <p class="eyebrow">Tutorial</p>
+                <p class="muted">Scegli una opzione per sbloccare le attivita e registrare la prima scelta guidata.</p>
+              </div>
+              <button class="button ghost small" type="button" data-action="dismiss-tutorial">Segna come letto</button>
+            </div>
+            <div class="meta-row">
+              <span class="meta-chip" data-activity-guard>Cooldown attivita pronto.</span>
+              <span class="meta-chip ghost" data-activity-limit>Limite sessione: 0 / ${MAX_ACTIVITY_RUNS}</span>
+            </div>
+            <div class="cta-row" data-activity-choices></div>
+            <div class="result-box" data-activity-result>Ancora nessuna attivita eseguita.</div>
+          </div>
+        </article>
+
+        <article class="card">
+          <h2>Turno ATCL (mock QR)</h2>
+          <div class="form-grid">
+            <label class="field">
+              <span>Evento</span>
+              <select data-field="event-select"></select>
+            </label>
+            <label class="field">
+              <span>Ruolo per il turno</span>
+              <select data-field="turn-role"></select>
+            </label>
+            <button class="button primary" type="button" data-action="register-turn">Registra turno di test</button>
+            <div class="result-box" data-turn-feedback>Nessun turno registrato.</div>
+            <div>
+              <p class="muted">Ultimi turni registrati:</p>
+              <ul class="log-list" data-turn-log></ul>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+  `;
+
+  const profileNameInput = root.querySelector<HTMLInputElement>('[data-field="player-name"]');
+  const profileRoleSelect = root.querySelector<HTMLSelectElement>('[data-field="player-role"]');
+  const profileSummaryBox = root.querySelector<HTMLElement>('[data-profile-summary]');
+  const avatarPreview = root.querySelector<HTMLElement>('[data-avatar="preview"]');
+  const avatarImg = root.querySelector<HTMLImageElement>('[data-avatar-img]');
+  const avatarLabel = root.querySelector<HTMLElement>('[data-avatar-label]');
+  const avatarHueInput = root.querySelector<HTMLInputElement>('[data-avatar-hue]');
+  const avatarIconSelect = root.querySelector<HTMLSelectElement>('[data-avatar-icon]');
+  const statXp = root.querySelector<HTMLElement>('[data-stat="xp"]');
+  const statCachet = root.querySelector<HTMLElement>('[data-stat="cachet"]');
+  const statRep = root.querySelector<HTMLElement>('[data-stat="rep"]');
+  const progressCopyXp = root.querySelector<HTMLElement>('[data-progress-copy="xp"]');
+  const progressCopyRep = root.querySelector<HTMLElement>('[data-progress-copy="rep"]');
+  const progressValueXp = root.querySelector<HTMLElement>('[data-progress-value="xp"]');
+  const progressValueRep = root.querySelector<HTMLElement>('[data-progress-value="rep"]');
+  const progressBarXp = root.querySelector<HTMLElement>('[data-progress-bar="xp"]');
+  const progressBarRep = root.querySelector<HTMLElement>('[data-progress-bar="rep"]');
+  const badgeList = root.querySelector<HTMLElement>('[data-badge-list]');
+  const roleStatsContainer = root.querySelector<HTMLElement>('[data-role-stats]');
+  const careerNote = root.querySelector<HTMLElement>('[data-career-note]');
+  const activitySelect = root.querySelector<HTMLSelectElement>('[data-field="activity-select"]');
+  const activityDescription = root.querySelector<HTMLElement>('[data-activity-description]');
+  const activityChoices = root.querySelector<HTMLElement>('[data-activity-choices]');
+  const activityResultBox = root.querySelector<HTMLElement>('[data-activity-result]');
+  const activityGuardChip = root.querySelector<HTMLElement>('[data-activity-guard]');
+  const activityLimitChip = root.querySelector<HTMLElement>('[data-activity-limit]');
+  const tutorialBox = root.querySelector<HTMLElement>('[data-activity-tutorial]');
+  const eventSelect = root.querySelector<HTMLSelectElement>('[data-field="event-select"]');
+  const turnRoleSelect = root.querySelector<HTMLSelectElement>('[data-field="turn-role"]');
+  const turnFeedbackBox = root.querySelector<HTMLElement>('[data-turn-feedback]');
+  const turnLog = root.querySelector<HTMLElement>('[data-turn-log]');
+  const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
+
+  let gameState: GameState = loadState();
+  let syncBadgeTimeout: number | undefined;
+
+  function showSyncBadge(message = "Stato aggiornato") {
+    if (!syncBadge) return;
+    syncBadge.textContent = message;
+    syncBadge.style.display = "inline-flex";
+    if (syncBadgeTimeout) {
+      window.clearTimeout(syncBadgeTimeout);
     }
-    if (activityChoices) {
-      activityChoices.innerHTML = "";
+    syncBadgeTimeout = window.setTimeout(() => {
+      if (syncBadge) {
+        syncBadge.style.display = "none";
+      }
+    }, 2500);
+  }
+
+  function persistState(nextState: GameState, feedback?: HTMLElement): SaveStateResult {
+    const result = saveState(nextState);
+    gameState = result.state;
+    if (!result.ok && feedback) {
+      feedback.dataset.state = "warn";
+      feedback.textContent = "Salvataggio locale non riuscito: verrà usato un backup in memoria.";
     }
-    renderTutorialBox();
-    return;
+    return result;
   }
 
-  const selectedId = activityId || activitySelect?.value || activities[0]?.id;
-  const activity = activities.find((item) => item.id === selectedId) ?? activities[0];
-  if (activitySelect) {
-    activitySelect.innerHTML = activities.map((item) => `<option value="${item.id}">${item.title}</option>`).join("");
-    activitySelect.value = activity.id;
-  }
-  if (activityResultBox) {
-    activityResultBox.dataset.state = "info";
-    activityResultBox.textContent = "Scegli una delle opzioni per applicare ricompense.";
-  }
-  renderActivityOptions(activity);
-  renderActivityGuard(activity.id);
-  renderTutorialBox();
-}
-
-function handleActivityChoice(choiceId: string) {
-  if (!activities.length) return;
-  const fallback = activities[0];
-  const currentActivityId = activitySelect?.value || fallback.id;
-  const activity = activities.find((item) => item.id === currentActivityId);
-  if (!activity) return;
-  const choice = activity.choices.find((item) => item.id === choiceId);
-  if (!choice) return;
-  const stats = getActivityStats(activity.id);
-  const now = Date.now();
-  const remainingMs = stats.lastPlayedAt ? ACTIVITY_COOLDOWN_MS - (now - stats.lastPlayedAt) : 0;
-  if (remainingMs > 0) {
-    const remainingSeconds = Math.max(0, Math.ceil(remainingMs / 1000));
-    if (activityResultBox) {
-      activityResultBox.dataset.state = "warn";
-      activityResultBox.textContent = `Attendi ${remainingSeconds}s prima di ripetere l'attivita.`;
+  function renderAvatarPreview() {
+    if (!avatarPreview) return;
+    const { hue, icon, rpmUrl, rpmThumbnail } = gameState.profile.avatar;
+    const color = `hsl(${hue}deg 75% 55%)`;
+    const image = rpmThumbnail || deriveRpmThumbnail(rpmUrl);
+    avatarPreview.style.setProperty("--avatar-color", color);
+    avatarPreview.style.setProperty("--avatar-hue", `${hue}deg`);
+    avatarPreview.classList.toggle("has-image", !!image);
+    const iconDef = avatarIcons.find((item) => item.id === icon) ?? avatarIcons[0];
+    if (avatarImg) {
+      if (image) {
+        avatarImg.src = image;
+        avatarImg.style.display = "block";
+      } else {
+        avatarImg.removeAttribute("src");
+        avatarImg.style.display = "none";
+      }
     }
-    renderActivityGuard(activity.id);
-    return;
-  }
-  if (stats.runs >= MAX_ACTIVITY_RUNS) {
-    if (activityResultBox) {
-      activityResultBox.dataset.state = "warn";
-      activityResultBox.textContent = "Limite sessione raggiunto per questo scenario demo.";
+    if (avatarLabel) {
+      avatarLabel.textContent = iconDef.symbol;
     }
-    renderActivityGuard(activity.id);
-    return;
   }
-  applyRewards(choice.rewards);
-  gameState = {
-    ...gameState,
-    activityStats: { ...gameState.activityStats, [activity.id]: { runs: stats.runs + 1, lastPlayedAt: now } },
-    tutorial: { ...gameState.tutorial, firstChoiceComplete: true },
-  };
-  persistState(gameState, activityResultBox);
-  renderCareerCard();
-  renderActivityGuard(activity.id);
-  renderTutorialBox();
-  if (activityResultBox) {
-    activityResultBox.dataset.state = "ok";
-    activityResultBox.textContent = `${choice.summary} (${formatRewards(choice.rewards)})`;
+
+  function syncProfileForm() {
+    if (profileNameInput) {
+      profileNameInput.value = gameState.profile.name;
+    }
+    if (profileRoleSelect) {
+      profileRoleSelect.value = gameState.profile.roleId;
+    }
+    if (turnRoleSelect) {
+      turnRoleSelect.value = gameState.profile.roleId;
+    }
+    if (avatarHueInput) {
+      avatarHueInput.value = gameState.profile.avatar.hue.toString();
+    }
+    if (avatarIconSelect) {
+      avatarIconSelect.value = gameState.profile.avatar.icon;
+    }
+    renderAvatarPreview();
   }
-}
 
-function computeTurnRewards(event: DevEvent, roleId: RoleId): Rewards {
-  const bonus = event.focusRole && event.focusRole === roleId ? 8 : 0;
-  return {
-    xp: event.baseRewards.xp + bonus,
-    cachet: event.baseRewards.cachet + Math.round(bonus / 2),
-    reputation: event.baseRewards.reputation + Math.round(bonus / 4),
-  };
-}
-
-function renderTurnHistory() {
-  if (!turnLog) return;
-  if (!gameState.turns.length) {
-    turnLog.innerHTML = '<li class="muted">Nessun turno registrato.</li>';
-    return;
+  function renderRoleOptions(select: HTMLSelectElement | null) {
+    if (!select) return;
+    select.innerHTML = roles.map((role) => `<option value="${role.id}">${role.name}</option>`).join("");
   }
-  turnLog.innerHTML = gameState.turns
-    .slice(0, MAX_TURNS_STORED)
-    .map(
-      (turn) =>
-        `<li><div><strong>${turn.eventName}</strong> - ${turn.theatre} - ${turn.date}</div><div class="muted">${resolveRole(turn.roleId).name} | ${formatRewards(turn.rewards)}</div></li>`
-    )
-    .join("");
-}
 
-function handleRegisterTurn() {
-  if (!devEvents.length) {
+  function renderAvatarOptions() {
+    if (!avatarIconSelect) return;
+    avatarIconSelect.innerHTML = avatarIcons.map((item) => `<option value="${item.id}">${item.label}</option>`).join("");
+  }
+
+  function getActivityStats(activityId: string) {
+    return gameState.activityStats[activityId] ?? { runs: 0, lastPlayedAt: undefined };
+  }
+
+  function renderActivityGuard(activityId: string) {
+    if (!activityGuardChip || !activityLimitChip) return;
+    const stats = getActivityStats(activityId);
+    const now = Date.now();
+    const remainingSeconds = stats.lastPlayedAt ? Math.max(0, Math.ceil((ACTIVITY_COOLDOWN_MS - (now - stats.lastPlayedAt)) / 1000)) : 0;
+    if (remainingSeconds > 0) {
+      activityGuardChip.textContent = `Cooldown: attendi ${remainingSeconds}s prima di ripetere.`;
+      activityGuardChip.dataset.state = "warn";
+    } else {
+      activityGuardChip.textContent = "Cooldown attivita pronto.";
+      activityGuardChip.dataset.state = "ok";
+    }
+    activityLimitChip.textContent = `Limite sessione: ${Math.min(stats.runs, MAX_ACTIVITY_RUNS)} / ${MAX_ACTIVITY_RUNS}`;
+    activityLimitChip.dataset.state = stats.runs >= MAX_ACTIVITY_RUNS ? "warn" : "info";
+  }
+
+  function renderTutorialBox() {
+    if (!tutorialBox) return;
+    tutorialBox.style.display = gameState.tutorial.firstChoiceComplete ? "none" : "grid";
+  }
+  function renderEvents() {
+    if (!eventSelect) return;
+    if (!devEvents.length) {
+      eventSelect.innerHTML = `<option value="">Nessun evento mock</option>`;
+      return;
+    }
+    eventSelect.innerHTML = devEvents.map((event) => `<option value="${event.id}">${event.name} (${event.theatre})</option>`).join("");
+  }
+
+  function renderCareerCard() {
+    if (profileSummaryBox) {
+      const role = resolveRole(gameState.profile.roleId);
+      const playerName = gameState.profile.name || "Giocatore";
+      profileSummaryBox.textContent = `${playerName} - ${role.name} | XP ${gameState.profile.xp}, Cachet ${gameState.profile.cachet}, Rep ATCL ${gameState.profile.repAtcl}`;
+    }
+    if (statXp) statXp.textContent = gameState.profile.xp.toString();
+    if (statCachet) statCachet.textContent = gameState.profile.cachet.toString();
+    if (statRep) statRep.textContent = gameState.profile.repAtcl.toString();
+
+    const xpProgress = getProgressState(gameState.profile.xp, xpMilestones);
+    const repProgress = getProgressState(gameState.profile.repAtcl, repMilestones);
+    if (progressValueXp) progressValueXp.textContent = `${gameState.profile.xp} XP`;
+    if (progressValueRep) progressValueRep.textContent = `${gameState.profile.repAtcl} rep`;
+    if (progressCopyXp) progressCopyXp.textContent = buildProgressCopy(xpProgress, "XP");
+    if (progressCopyRep) progressCopyRep.textContent = buildProgressCopy(repProgress, "punti rep");
+    if (progressBarXp) {
+      progressBarXp.style.width = `${xpProgress.percent}%`;
+      progressBarXp.parentElement?.setAttribute("aria-valuenow", xpProgress.percent.toString());
+    }
+    if (progressBarRep) {
+      progressBarRep.style.width = `${repProgress.percent}%`;
+      progressBarRep.parentElement?.setAttribute("aria-valuenow", repProgress.percent.toString());
+    }
+
+    const earnedXp = getEarnedMilestones(gameState.profile.xp, xpMilestones);
+    const earnedRep = getEarnedMilestones(gameState.profile.repAtcl, repMilestones);
+    const seen = new Set<string>();
+    const repIds = new Set(repMilestones.map((item) => item.id));
+    const badges = [...earnedXp, ...earnedRep].filter((item) => {
+      if (seen.has(item.id)) return false;
+      seen.add(item.id);
+      return true;
+    });
+    if (badgeList) {
+      badgeList.innerHTML = badges.length
+        ? badges
+            .map(
+              (badge) =>
+                `<span class="badge-chip">${badge.label}<small>${badge.target}${repIds.has(badge.id) ? " rep" : " XP"}</small></span>`
+            )
+            .join("")
+        : '<span class="badge-chip ghost">Completa una milestone XP/rep per sbloccare un badge.</span>';
+    }
+
+    if (roleStatsContainer) {
+      const role = resolveRole(gameState.profile.roleId);
+      roleStatsContainer.innerHTML = role.stats.map((stat) => `<span class="pill ghost">${stat}</span>`).join("");
+    }
+    if (careerNote) {
+      const role = resolveRole(gameState.profile.roleId);
+      careerNote.textContent = `Focus ruolo: ${role.focus}. Potenzia queste competenze nelle attivita simulate.`;
+    }
+  }
+
+  function applyRewards(rewards: Rewards) {
+    gameState.profile.xp += rewards.xp;
+    gameState.profile.cachet += rewards.cachet;
+    gameState.profile.repAtcl += rewards.reputation;
+  }
+
+  function handleSaveProfile() {
+    const chosenRole = (profileRoleSelect?.value as RoleId) || gameState.profile.roleId;
+    const name = profileNameInput?.value.trim() ?? "";
+    const hueValue = avatarHueInput ? Number(avatarHueInput.value) : gameState.profile.avatar.hue;
+    const nextHue = Number.isFinite(hueValue) ? Math.max(0, Math.min(360, Math.round(hueValue))) : gameState.profile.avatar.hue;
+    const nextIcon = avatarIconSelect?.value as AvatarIcon;
+    const safeIcon = avatarIcons.some((item) => item.id === nextIcon) ? nextIcon : gameState.profile.avatar.icon;
+    gameState = {
+      ...gameState,
+      profile: {
+        ...gameState.profile,
+        name,
+        roleId: chosenRole in roleMap ? chosenRole : gameState.profile.roleId,
+        avatar: { ...gameState.profile.avatar, hue: nextHue, icon: safeIcon },
+      },
+    };
+    persistState(gameState, turnFeedbackBox);
+    syncProfileForm();
+    renderCareerCard();
+    renderTurnHistory();
+    renderAvatarPreview();
     if (turnFeedbackBox) {
-      turnFeedbackBox.dataset.state = "warn";
-      turnFeedbackBox.textContent = "Nessun evento di test configurato.";
+      turnFeedbackBox.textContent = "Profilo aggiornato.";
     }
-    return;
   }
-  const eventId = eventSelect?.value || devEvents[0].id;
-  const selectedEvent = devEvents.find((item) => item.id === eventId) ?? devEvents[0];
-  const selectedRole = (turnRoleSelect?.value as RoleId) || gameState.profile.roleId;
-  const rewards = computeTurnRewards(selectedEvent, selectedRole);
 
-  const record: TurnRecord = {
-    id: `turn-${Date.now()}`,
-    eventId: selectedEvent.id,
-    eventName: selectedEvent.name,
-    theatre: selectedEvent.theatre,
-    date: selectedEvent.date,
-    roleId: selectedRole,
-    rewards,
-  };
-
-  applyRewards(rewards);
-  gameState = { ...gameState, turns: [record, ...gameState.turns].slice(0, MAX_TURNS_STORED) };
-  const result = persistState(gameState, turnFeedbackBox);
-  renderCareerCard();
-  renderTurnHistory();
-  renderAvatarPreview();
-  if (turnFeedbackBox) {
-    turnFeedbackBox.dataset.state = result.ok ? "ok" : "warn";
-    turnFeedbackBox.textContent = result.ok
-      ? `Turno registrato: ${selectedEvent.name} (${formatRewards(rewards)})`
-      : "Turno registrato ma salvataggio locale non riuscito: usa la stessa scheda.";
+  function handleResetState() {
+    const confirmReset = window.confirm("Reset dello stato locale? Tutti i progressi mock verranno azzerati.");
+    if (!confirmReset) return;
+    gameState = createDefaultState();
+    persistState(gameState, turnFeedbackBox);
+    syncProfileForm();
+    renderCareerCard();
+    renderActivityUI();
+    if (activities.length) {
+      renderActivityGuard(activities[0].id);
+    }
+    renderTurnHistory();
+    renderAvatarPreview();
+    renderTutorialBox();
+    if (turnFeedbackBox) {
+      turnFeedbackBox.textContent = "Stato locale resettato.";
+    }
   }
-}
 
-renderRoleOptions(profileRoleSelect);
-renderRoleOptions(turnRoleSelect);
-renderAvatarOptions();
-renderEvents();
-renderActivityUI();
-syncProfileForm();
-renderCareerCard();
-renderTurnHistory();
-renderAvatarPreview();
-renderTutorialBox();
-
-root.querySelector<HTMLButtonElement>('[data-action="save-profile"]')?.addEventListener("click", handleSaveProfile);
-root.querySelector<HTMLButtonElement>('[data-action="reset-state"]')?.addEventListener("click", handleResetState);
-root.querySelector<HTMLButtonElement>('[data-action="register-turn"]')?.addEventListener("click", handleRegisterTurn);
-
-activitySelect?.addEventListener("change", (event) => {
-  const nextId = (event.target as HTMLSelectElement).value;
-  renderActivityUI(nextId);
-});
-
-activityChoices?.addEventListener("click", (event) => {
-  const target = event.target as HTMLElement | null;
-  const button = target?.closest<HTMLButtonElement>("[data-choice-id]");
-  if (!button) return;
-  const choiceId = button.dataset.choiceId;
-  if (choiceId) {
-    handleActivityChoice(choiceId);
+  function renderActivityOptions(activity: Activity) {
+    if (!activityChoices) return;
+    activityChoices.innerHTML = activity.choices
+      .map((choice) => `<button class="button ghost" type="button" data-choice-id="${choice.id}">${choice.label}</button>`)
+      .join("");
+    if (activityDescription) {
+      activityDescription.textContent = `${activity.title} - ${activity.description}`;
+    }
   }
-});
 
-avatarHueInput?.addEventListener("input", () => {
-  handleSaveProfile();
-});
+  function renderActivityUI(activityId?: string) {
+    if (!activities.length) {
+      if (activityDescription) {
+        activityDescription.textContent = "Nessuna attivita configurata.";
+      }
+      if (activityChoices) {
+        activityChoices.innerHTML = "";
+      }
+      renderTutorialBox();
+      return;
+    }
 
-window.addEventListener("storage", (event) => {
-  if (event.key !== STORAGE_KEY) return;
-  gameState = loadState();
+    const selectedId = activityId || activitySelect?.value || activities[0]?.id;
+    const activity = activities.find((item) => item.id === selectedId) ?? activities[0];
+    if (activitySelect) {
+      activitySelect.innerHTML = activities.map((item) => `<option value="${item.id}">${item.title}</option>`).join("");
+      activitySelect.value = activity.id;
+    }
+    if (activityResultBox) {
+      activityResultBox.dataset.state = "info";
+      activityResultBox.textContent = "Scegli una delle opzioni per applicare ricompense.";
+    }
+    renderActivityOptions(activity);
+    renderActivityGuard(activity.id);
+    renderTutorialBox();
+  }
+
+  function handleActivityChoice(choiceId: string) {
+    if (!activities.length) return;
+    const fallback = activities[0];
+    const currentActivityId = activitySelect?.value || fallback.id;
+    const activity = activities.find((item) => item.id === currentActivityId);
+    if (!activity) return;
+    const choice = activity.choices.find((item) => item.id === choiceId);
+    if (!choice) return;
+    const stats = getActivityStats(activity.id);
+    const now = Date.now();
+    const remainingMs = stats.lastPlayedAt ? ACTIVITY_COOLDOWN_MS - (now - stats.lastPlayedAt) : 0;
+    if (remainingMs > 0) {
+      const remainingSeconds = Math.max(0, Math.ceil(remainingMs / 1000));
+      if (activityResultBox) {
+        activityResultBox.dataset.state = "warn";
+        activityResultBox.textContent = `Attendi ${remainingSeconds}s prima di ripetere l'attivita.`;
+      }
+      renderActivityGuard(activity.id);
+      return;
+    }
+    if (stats.runs >= MAX_ACTIVITY_RUNS) {
+      if (activityResultBox) {
+        activityResultBox.dataset.state = "warn";
+        activityResultBox.textContent = "Limite sessione raggiunto per questo scenario demo.";
+      }
+      renderActivityGuard(activity.id);
+      return;
+    }
+    applyRewards(choice.rewards);
+    gameState = {
+      ...gameState,
+      activityStats: { ...gameState.activityStats, [activity.id]: { runs: stats.runs + 1, lastPlayedAt: now } },
+      tutorial: { ...gameState.tutorial, firstChoiceComplete: true },
+    };
+    persistState(gameState, activityResultBox);
+    renderCareerCard();
+    renderActivityGuard(activity.id);
+    renderTutorialBox();
+    if (activityResultBox) {
+      activityResultBox.dataset.state = "ok";
+      activityResultBox.textContent = `${choice.summary} (${formatRewards(choice.rewards)})`;
+    }
+  }
+
+  function computeTurnRewards(event: DevEvent, roleId: RoleId): Rewards {
+    const bonus = event.focusRole && event.focusRole === roleId ? 8 : 0;
+    return {
+      xp: event.baseRewards.xp + bonus,
+      cachet: event.baseRewards.cachet + Math.round(bonus / 2),
+      reputation: event.baseRewards.reputation + Math.round(bonus / 4),
+    };
+  }
+
+  function renderTurnHistory() {
+    if (!turnLog) return;
+    if (!gameState.turns.length) {
+      turnLog.innerHTML = '<li class="muted">Nessun turno registrato.</li>';
+      return;
+    }
+    turnLog.innerHTML = gameState.turns
+      .slice(0, MAX_TURNS_STORED)
+      .map(
+        (turn) =>
+          `<li><div><strong>${turn.eventName}</strong> - ${turn.theatre} - ${turn.date}</div><div class="muted">${resolveRole(turn.roleId).name} | ${formatRewards(turn.rewards)}</div></li>`
+      )
+      .join("");
+  }
+
+  function handleRegisterTurn() {
+    if (!devEvents.length) {
+      if (turnFeedbackBox) {
+        turnFeedbackBox.dataset.state = "warn";
+        turnFeedbackBox.textContent = "Nessun evento di test configurato.";
+      }
+      return;
+    }
+    const eventId = eventSelect?.value || devEvents[0].id;
+    const selectedEvent = devEvents.find((item) => item.id === eventId) ?? devEvents[0];
+    const selectedRole = (turnRoleSelect?.value as RoleId) || gameState.profile.roleId;
+    const rewards = computeTurnRewards(selectedEvent, selectedRole);
+
+    const record: TurnRecord = {
+      id: `turn-${Date.now()}`,
+      eventId: selectedEvent.id,
+      eventName: selectedEvent.name,
+      theatre: selectedEvent.theatre,
+      date: selectedEvent.date,
+      roleId: selectedRole,
+      rewards,
+    };
+
+    applyRewards(rewards);
+    gameState = { ...gameState, turns: [record, ...gameState.turns].slice(0, MAX_TURNS_STORED) };
+    const result = persistState(gameState, turnFeedbackBox);
+    renderCareerCard();
+    renderTurnHistory();
+    renderAvatarPreview();
+    if (turnFeedbackBox) {
+      turnFeedbackBox.dataset.state = result.ok ? "ok" : "warn";
+      turnFeedbackBox.textContent = result.ok
+        ? `Turno registrato: ${selectedEvent.name} (${formatRewards(rewards)})`
+        : "Turno registrato ma salvataggio locale non riuscito: usa la stessa scheda.";
+    }
+  }
+
+  renderRoleOptions(profileRoleSelect);
+  renderRoleOptions(turnRoleSelect);
+  renderAvatarOptions();
+  renderEvents();
+  renderActivityUI();
   syncProfileForm();
   renderCareerCard();
-  renderActivityUI();
   renderTurnHistory();
   renderAvatarPreview();
-  showSyncBadge();
-});
-
-avatarIconSelect?.addEventListener("change", () => {
-  handleSaveProfile();
-});
-
-root.querySelector<HTMLButtonElement>('[data-action="dismiss-tutorial"]')?.addEventListener("click", () => {
-  gameState = { ...gameState, tutorial: { ...gameState.tutorial, firstChoiceComplete: true } };
-  saveState(gameState);
   renderTutorialBox();
-});
 
-registerServiceWorker({
-  onReady: () => undefined,
-  onUpdate: (registration) => {
-    promptServiceWorkerUpdate(registration);
-  },
-  onError: (error) => {
-    console.error("Service worker registration failed", error);
-  },
-});
+  root.querySelector<HTMLButtonElement>('[data-action="save-profile"]')?.addEventListener("click", handleSaveProfile);
+  root.querySelector<HTMLButtonElement>('[data-action="reset-state"]')?.addEventListener("click", handleResetState);
+  root.querySelector<HTMLButtonElement>('[data-action="register-turn"]')?.addEventListener("click", handleRegisterTurn);
+
+  activitySelect?.addEventListener("change", (event) => {
+    const nextId = (event.target as HTMLSelectElement).value;
+    renderActivityUI(nextId);
+  });
+
+  activityChoices?.addEventListener("click", (event) => {
+    const target = event.target as HTMLElement | null;
+    const button = target?.closest<HTMLButtonElement>("[data-choice-id]");
+    if (!button) return;
+    const choiceId = button.dataset.choiceId;
+    if (choiceId) {
+      handleActivityChoice(choiceId);
+    }
+  });
+
+  avatarHueInput?.addEventListener("input", () => {
+    handleSaveProfile();
+  });
+
+  window.addEventListener("storage", (event) => {
+    if (event.key !== STORAGE_KEY) return;
+    gameState = loadState();
+    syncProfileForm();
+    renderCareerCard();
+    renderActivityUI();
+    renderTurnHistory();
+    renderAvatarPreview();
+    showSyncBadge();
+  });
+
+  avatarIconSelect?.addEventListener("change", () => {
+    handleSaveProfile();
+  });
+
+  root.querySelector<HTMLButtonElement>('[data-action="dismiss-tutorial"]')?.addEventListener("click", () => {
+    gameState = { ...gameState, tutorial: { ...gameState.tutorial, firstChoiceComplete: true } };
+    saveState(gameState);
+    renderTutorialBox();
+  });
+
+  registerServiceWorker({
+    onReady: () => undefined,
+    onUpdate: (registration) => {
+      promptServiceWorkerUpdate(registration);
+    },
+    onError: (error) => {
+      console.error("Service worker registration failed", error);
+    },
+  });
+};
+
+void start();

--- a/apps/pwa/src/events.ts
+++ b/apps/pwa/src/events.ts
@@ -1,49 +1,57 @@
 import "../../../shared/styles/main.css";
 import { renderPageHero } from "./components/page-hero";
 import { mockEvents, resolveRole } from "./state";
+import { requireDevAccess } from "./services/dev-gate";
 
-const root = document.querySelector<HTMLDivElement>("#app");
+const start = async () => {
+  if (!(await requireDevAccess())) return;
 
-if (!root) {
-  throw new Error("Root container missing");
-}
 
-const pageHero = renderPageHero({
-  title: "Eventi mock",
-  description: "Usati per testare la registrazione turni e la mappa.",
-  currentPage: "events",
-  breadcrumbs: [
-    { label: "Hub", href: "/game.html" },
-    { label: "Eventi" },
-  ],
-  backHref: "/game.html",
-  backLabel: "Torna all'hub",
-});
+  const root = document.querySelector<HTMLDivElement>("#app");
 
-root.innerHTML = `
-  <main class="page page-game layout-shell">
-    ${pageHero}
-
-    <section class="grid layout-grid">
-      <article class="card layout-span-2">
-        <h2>Prossimi eventi</h2>
-        <ul class="log-list dense" data-event-list></ul>
-      </article>
-    </section>
-  </main>
-`;
-
-const eventList = root.querySelector<HTMLElement>('[data-event-list]');
-
-if (eventList) {
-  if (!mockEvents.length) {
-    eventList.innerHTML = `<li class="muted">Nessun evento disponibile.</li>`;
-  } else {
-    eventList.innerHTML = mockEvents
-      .map(
-        (item) =>
-          `<li><div><strong>${item.name}</strong> - ${item.theatre}</div><div class="muted">${item.date} | Focus: ${item.focusRole ? resolveRole(item.focusRole).name : "Any"} - Lat ${item.lat.toFixed(3)} / Lng ${item.lng.toFixed(3)}</div></li>`
-      )
-      .join("");
+  if (!root) {
+    throw new Error("Root container missing");
   }
-}
+
+  const pageHero = renderPageHero({
+    title: "Eventi mock",
+    description: "Usati per testare la registrazione turni e la mappa.",
+    currentPage: "events",
+    breadcrumbs: [
+      { label: "Hub", href: "/game.html" },
+      { label: "Eventi" },
+    ],
+    backHref: "/game.html",
+    backLabel: "Torna all'hub",
+  });
+
+  root.innerHTML = `
+    <main class="page page-game layout-shell">
+      ${pageHero}
+
+      <section class="grid layout-grid">
+        <article class="card layout-span-2">
+          <h2>Prossimi eventi</h2>
+          <ul class="log-list dense" data-event-list></ul>
+        </article>
+      </section>
+    </main>
+  `;
+
+  const eventList = root.querySelector<HTMLElement>('[data-event-list]');
+
+  if (eventList) {
+    if (!mockEvents.length) {
+      eventList.innerHTML = `<li class="muted">Nessun evento disponibile.</li>`;
+    } else {
+      eventList.innerHTML = mockEvents
+        .map(
+          (item) =>
+            `<li><div><strong>${item.name}</strong> - ${item.theatre}</div><div class="muted">${item.date} | Focus: ${item.focusRole ? resolveRole(item.focusRole).name : "Any"} - Lat ${item.lat.toFixed(3)} / Lng ${item.lng.toFixed(3)}</div></li>`
+        )
+        .join("");
+    }
+  }
+};
+
+void start();

--- a/apps/pwa/src/game.ts
+++ b/apps/pwa/src/game.ts
@@ -4,200 +4,208 @@ import { buildProgressCopy, getProgressState, repMilestones, xpMilestones } from
 import { registerServiceWorker } from "./pwa/register-sw";
 import { promptServiceWorkerUpdate } from "./pwa/sw-update";
 import { formatRewards, getAvatarVisual, loadState, resolveRole, STORAGE_KEY } from "./state";
+import { requireDevAccess } from "./services/dev-gate";
 
-const root = document.querySelector<HTMLDivElement>("#app");
+const start = async () => {
+  if (!(await requireDevAccess())) return;
 
-if (!root) {
-  throw new Error("Root container missing");
-}
 
-const pageHero = renderPageHero({
-  title: "Hub di navigazione",
-  description: "Accedi a mappa, profilo, eventi e registro turni.",
-  currentPage: "game",
-  breadcrumbs: [
-    { label: "Home", href: "/" },
-    { label: "Hub" },
-  ],
-  backHref: "/",
-  backLabel: "Torna alla landing",
-  ctaRow: [
-    { id: "map", label: "Apri mappa", href: "/map.html", variant: "primary" },
-    { id: "avatar", label: "Avatar", href: "/avatar.html", variant: "ghost" },
-    { id: "profile", label: "Profilo", href: "/profile.html", variant: "ghost" },
-    { id: "turns", label: "Turni", href: "/turns.html", variant: "ghost" },
-    { id: "leaderboard", label: "Classifica", href: "/leaderboard.html", variant: "ghost" },
-  ],
-  quickActions: [{ id: "dev", label: "Dev playground", href: "/dev.html", icon: "🛠️" }],
-});
-root.innerHTML = `
-  <main class="page page-game layout-shell">
-    ${pageHero}
+  const root = document.querySelector<HTMLDivElement>("#app");
 
-    <section class="grid layout-grid">
-      <article class="card">
-        <h2>Profilo</h2>
-        <div class="profile-pane">
-          <div class="avatar-display large" data-avatar="profile">
-            <img data-avatar-img alt="Avatar ReadyPlayerMe" />
-            <span class="avatar-icon" data-avatar-label></span>
-          </div>
-          <div>
-            <p class="eyebrow" data-player-name>Profilo non configurato</p>
-            <p class="muted" data-player-role>Ruolo non impostato</p>
-            <div class="pill-row" data-role-tags></div>
-          </div>
-        </div>
-      </article>
-
-      <article class="card">
-        <h2>Statistiche</h2>
-        <ul class="stat-list">
-          <li><span>XP</span><strong data-stat="xp">0</strong></li>
-          <li><span>Cachet</span><strong data-stat="cachet">0</strong></li>  
-          <li><span>Reputazione ATCL</span><strong data-stat="rep">0</strong></li>
-        </ul>
-        <div class="progress-grid compact">
-          <div class="progress-track slim" data-track="xp">
-            <div class="progress-head">
-              <p class="muted" data-progress-copy="xp">Traguardi XP</p>      
-              <strong data-progress-value="xp">0 XP</strong>
-            </div>
-            <div class="progress-bar" role="progressbar" aria-label="Progresso XP" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-              <span class="progress-fill" data-progress-bar="xp" style="width: 0%"></span>
-            </div>
-          </div>
-          <div class="progress-track slim" data-track="rep">
-            <div class="progress-head">
-              <p class="muted" data-progress-copy="rep">Traguardi reputazione</p>
-              <strong data-progress-value="rep">0 rep</strong>
-            </div>
-            <div class="progress-bar" role="progressbar" aria-label="Progresso reputazione" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-              <span class="progress-fill accent" data-progress-bar="rep" style="width: 0%"></span>
-            </div>
-          </div>
-        </div>
-      </article>
-
-      <article class="card layout-span-2">
-        <h2>Ultimi turni</h2>
-        <ul class="log-list dense" data-turn-log></ul>
-      </article>
-    </section>
-  </main>
-`;
-
-const progressCopyXp = root.querySelector<HTMLElement>('[data-progress-copy="xp"]');
-const progressCopyRep = root.querySelector<HTMLElement>('[data-progress-copy="rep"]');
-const progressValueXp = root.querySelector<HTMLElement>('[data-progress-value="xp"]');
-const progressValueRep = root.querySelector<HTMLElement>('[data-progress-value="rep"]');
-const progressBarXp = root.querySelector<HTMLElement>('[data-progress-bar="xp"]');
-const progressBarRep = root.querySelector<HTMLElement>('[data-progress-bar="rep"]');
-const avatarDisplay = root.querySelector<HTMLElement>('[data-avatar="profile"]');
-const avatarImg = root.querySelector<HTMLImageElement>('[data-avatar-img]');
-const avatarLabel = root.querySelector<HTMLElement>('[data-avatar-label]');
-const nameNode = root.querySelector<HTMLElement>('[data-player-name]');
-const roleNode = root.querySelector<HTMLElement>('[data-player-role]');
-const roleTags = root.querySelector<HTMLElement>('[data-role-tags]');
-const statXp = root.querySelector<HTMLElement>('[data-stat="xp"]');
-const statCachet = root.querySelector<HTMLElement>('[data-stat="cachet"]');
-const statRep = root.querySelector<HTMLElement>('[data-stat="rep"]');
-const turnLog = root.querySelector<HTMLElement>('[data-turn-log]');
-const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
-let state = loadState();
-let syncBadgeTimeout: number | undefined;
-
-function showSyncBadge(message = "Stato aggiornato") {
-  if (!syncBadge) return;
-  syncBadge.textContent = message;
-  syncBadge.style.display = "inline-flex";
-  if (syncBadgeTimeout) {
-    window.clearTimeout(syncBadgeTimeout);
+  if (!root) {
+    throw new Error("Root container missing");
   }
-  syncBadgeTimeout = window.setTimeout(() => {
-    if (syncBadge) syncBadge.style.display = "none";
-  }, 2500);
-}
 
-function renderProfile() {
-  const avatarVisual = getAvatarVisual(state.profile.avatar);
-  if (avatarDisplay) {
-    avatarDisplay.style.setProperty("--avatar-color", avatarVisual.color);
-    avatarDisplay.style.setProperty("--avatar-hue", `${state.profile.avatar.hue}deg`);
-    avatarDisplay.classList.toggle("has-image", !!avatarVisual.image);
+  const pageHero = renderPageHero({
+    title: "Hub di navigazione",
+    description: "Accedi a mappa, profilo, eventi e registro turni.",
+    currentPage: "game",
+    breadcrumbs: [
+      { label: "Home", href: "/" },
+      { label: "Hub" },
+    ],
+    backHref: "/",
+    backLabel: "Torna alla landing",
+    ctaRow: [
+      { id: "map", label: "Apri mappa", href: "/map.html", variant: "primary" },
+      { id: "avatar", label: "Avatar", href: "/avatar.html", variant: "ghost" },
+      { id: "profile", label: "Profilo", href: "/profile.html", variant: "ghost" },
+      { id: "turns", label: "Turni", href: "/turns.html", variant: "ghost" },
+      { id: "leaderboard", label: "Classifica", href: "/leaderboard.html", variant: "ghost" },
+    ],
+    quickActions: [{ id: "dev", label: "Dev playground", href: "/dev.html", icon: "🛠️" }],
+  });
+  root.innerHTML = `
+    <main class="page page-game layout-shell">
+      ${pageHero}
+
+      <section class="grid layout-grid">
+        <article class="card">
+          <h2>Profilo</h2>
+          <div class="profile-pane">
+            <div class="avatar-display large" data-avatar="profile">
+              <img data-avatar-img alt="Avatar ReadyPlayerMe" />
+              <span class="avatar-icon" data-avatar-label></span>
+            </div>
+            <div>
+              <p class="eyebrow" data-player-name>Profilo non configurato</p>
+              <p class="muted" data-player-role>Ruolo non impostato</p>
+              <div class="pill-row" data-role-tags></div>
+            </div>
+          </div>
+        </article>
+
+        <article class="card">
+          <h2>Statistiche</h2>
+          <ul class="stat-list">
+            <li><span>XP</span><strong data-stat="xp">0</strong></li>
+            <li><span>Cachet</span><strong data-stat="cachet">0</strong></li>  
+            <li><span>Reputazione ATCL</span><strong data-stat="rep">0</strong></li>
+          </ul>
+          <div class="progress-grid compact">
+            <div class="progress-track slim" data-track="xp">
+              <div class="progress-head">
+                <p class="muted" data-progress-copy="xp">Traguardi XP</p>      
+                <strong data-progress-value="xp">0 XP</strong>
+              </div>
+              <div class="progress-bar" role="progressbar" aria-label="Progresso XP" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                <span class="progress-fill" data-progress-bar="xp" style="width: 0%"></span>
+              </div>
+            </div>
+            <div class="progress-track slim" data-track="rep">
+              <div class="progress-head">
+                <p class="muted" data-progress-copy="rep">Traguardi reputazione</p>
+                <strong data-progress-value="rep">0 rep</strong>
+              </div>
+              <div class="progress-bar" role="progressbar" aria-label="Progresso reputazione" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                <span class="progress-fill accent" data-progress-bar="rep" style="width: 0%"></span>
+              </div>
+            </div>
+          </div>
+        </article>
+
+        <article class="card layout-span-2">
+          <h2>Ultimi turni</h2>
+          <ul class="log-list dense" data-turn-log></ul>
+        </article>
+      </section>
+    </main>
+  `;
+
+  const progressCopyXp = root.querySelector<HTMLElement>('[data-progress-copy="xp"]');
+  const progressCopyRep = root.querySelector<HTMLElement>('[data-progress-copy="rep"]');
+  const progressValueXp = root.querySelector<HTMLElement>('[data-progress-value="xp"]');
+  const progressValueRep = root.querySelector<HTMLElement>('[data-progress-value="rep"]');
+  const progressBarXp = root.querySelector<HTMLElement>('[data-progress-bar="xp"]');
+  const progressBarRep = root.querySelector<HTMLElement>('[data-progress-bar="rep"]');
+  const avatarDisplay = root.querySelector<HTMLElement>('[data-avatar="profile"]');
+  const avatarImg = root.querySelector<HTMLImageElement>('[data-avatar-img]');
+  const avatarLabel = root.querySelector<HTMLElement>('[data-avatar-label]');
+  const nameNode = root.querySelector<HTMLElement>('[data-player-name]');
+  const roleNode = root.querySelector<HTMLElement>('[data-player-role]');
+  const roleTags = root.querySelector<HTMLElement>('[data-role-tags]');
+  const statXp = root.querySelector<HTMLElement>('[data-stat="xp"]');
+  const statCachet = root.querySelector<HTMLElement>('[data-stat="cachet"]');
+  const statRep = root.querySelector<HTMLElement>('[data-stat="rep"]');
+  const turnLog = root.querySelector<HTMLElement>('[data-turn-log]');
+  const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
+  let state = loadState();
+  let syncBadgeTimeout: number | undefined;
+
+  function showSyncBadge(message = "Stato aggiornato") {
+    if (!syncBadge) return;
+    syncBadge.textContent = message;
+    syncBadge.style.display = "inline-flex";
+    if (syncBadgeTimeout) {
+      window.clearTimeout(syncBadgeTimeout);
+    }
+    syncBadgeTimeout = window.setTimeout(() => {
+      if (syncBadge) syncBadge.style.display = "none";
+    }, 2500);
   }
-  if (avatarImg) {
-    if (avatarVisual.image) {
-      avatarImg.src = avatarVisual.image;
-      avatarImg.style.display = "block";
-    } else {
-      avatarImg.removeAttribute("src");
-      avatarImg.style.display = "none";
+
+  function renderProfile() {
+    const avatarVisual = getAvatarVisual(state.profile.avatar);
+    if (avatarDisplay) {
+      avatarDisplay.style.setProperty("--avatar-color", avatarVisual.color);
+      avatarDisplay.style.setProperty("--avatar-hue", `${state.profile.avatar.hue}deg`);
+      avatarDisplay.classList.toggle("has-image", !!avatarVisual.image);
+    }
+    if (avatarImg) {
+      if (avatarVisual.image) {
+        avatarImg.src = avatarVisual.image;
+        avatarImg.style.display = "block";
+      } else {
+        avatarImg.removeAttribute("src");
+        avatarImg.style.display = "none";
+      }
+    }
+    if (avatarLabel) avatarLabel.textContent = avatarVisual.icon;
+    const role = resolveRole(state.profile.roleId);
+    if (nameNode) nameNode.textContent = state.profile.name || "Profilo non configurato";
+    if (roleNode) roleNode.textContent = `${role.name} | Focus: ${role.focus}`;
+    if (roleTags) {
+      roleTags.innerHTML = role.stats.map((stat) => `<span class="pill ghost">${stat}</span>`).join("");
+    }
+    if (statXp) statXp.textContent = state.profile.xp.toString();
+    if (statCachet) statCachet.textContent = state.profile.cachet.toString();
+    if (statRep) statRep.textContent = state.profile.repAtcl.toString();
+  }
+
+  function renderProgress() {
+    const xpProgress = getProgressState(state.profile.xp, xpMilestones);
+    const repProgress = getProgressState(state.profile.repAtcl, repMilestones);
+    if (progressCopyXp) progressCopyXp.textContent = buildProgressCopy(xpProgress, "XP");
+    if (progressCopyRep) progressCopyRep.textContent = buildProgressCopy(repProgress, "punti rep");
+    if (progressValueXp) progressValueXp.textContent = `${state.profile.xp} XP`;
+    if (progressValueRep) progressValueRep.textContent = `${state.profile.repAtcl} rep`;
+    if (progressBarXp) {
+      progressBarXp.style.width = `${xpProgress.percent}%`;
+      progressBarXp.parentElement?.setAttribute("aria-valuenow", xpProgress.percent.toString());
+    }
+    if (progressBarRep) {
+      progressBarRep.style.width = `${repProgress.percent}%`;
+      progressBarRep.parentElement?.setAttribute("aria-valuenow", repProgress.percent.toString());
     }
   }
-  if (avatarLabel) avatarLabel.textContent = avatarVisual.icon;
-  const role = resolveRole(state.profile.roleId);
-  if (nameNode) nameNode.textContent = state.profile.name || "Profilo non configurato";
-  if (roleNode) roleNode.textContent = `${role.name} | Focus: ${role.focus}`;
-  if (roleTags) {
-    roleTags.innerHTML = role.stats.map((stat) => `<span class="pill ghost">${stat}</span>`).join("");
-  }
-  if (statXp) statXp.textContent = state.profile.xp.toString();
-  if (statCachet) statCachet.textContent = state.profile.cachet.toString();
-  if (statRep) statRep.textContent = state.profile.repAtcl.toString();
-}
 
-function renderProgress() {
-  const xpProgress = getProgressState(state.profile.xp, xpMilestones);
-  const repProgress = getProgressState(state.profile.repAtcl, repMilestones);
-  if (progressCopyXp) progressCopyXp.textContent = buildProgressCopy(xpProgress, "XP");
-  if (progressCopyRep) progressCopyRep.textContent = buildProgressCopy(repProgress, "punti rep");
-  if (progressValueXp) progressValueXp.textContent = `${state.profile.xp} XP`;
-  if (progressValueRep) progressValueRep.textContent = `${state.profile.repAtcl} rep`;
-  if (progressBarXp) {
-    progressBarXp.style.width = `${xpProgress.percent}%`;
-    progressBarXp.parentElement?.setAttribute("aria-valuenow", xpProgress.percent.toString());
+  function renderTurns() {
+    if (!turnLog) return;
+    if (!state.turns.length) {
+      turnLog.innerHTML = `<li class="muted">Nessun turno registrato.</li>`;
+    } else {
+      turnLog.innerHTML = state.turns
+        .slice(0, 6)
+        .map(
+          (turn) =>
+            `<li><div><strong>${turn.eventName}</strong> - ${turn.theatre} - ${turn.date}</div><div class="muted">${resolveRole(turn.roleId).name} | ${formatRewards(turn.rewards)}</div></li>`
+        )
+        .join("");
+    }
   }
-  if (progressBarRep) {
-    progressBarRep.style.width = `${repProgress.percent}%`;
-    progressBarRep.parentElement?.setAttribute("aria-valuenow", repProgress.percent.toString());
-  }
-}
 
-function renderTurns() {
-  if (!turnLog) return;
-  if (!state.turns.length) {
-    turnLog.innerHTML = `<li class="muted">Nessun turno registrato.</li>`;
-  } else {
-    turnLog.innerHTML = state.turns
-      .slice(0, 6)
-      .map(
-        (turn) =>
-          `<li><div><strong>${turn.eventName}</strong> - ${turn.theatre} - ${turn.date}</div><div class="muted">${resolveRole(turn.roleId).name} | ${formatRewards(turn.rewards)}</div></li>`
-      )
-      .join("");
-  }
-}
-
-renderProfile();
-renderProgress();
-renderTurns();
-
-window.addEventListener("storage", (event) => {
-  if (event.key !== STORAGE_KEY) return;
-  state = loadState();
   renderProfile();
   renderProgress();
   renderTurns();
-  showSyncBadge();
-});
 
-registerServiceWorker({
-  onReady: () => undefined,
-  onUpdate: (registration) => {
-    promptServiceWorkerUpdate(registration);
-  },
-  onError: (error) => {
-    console.error("Service worker registration failed", error);
-  },
-});
+  window.addEventListener("storage", (event) => {
+    if (event.key !== STORAGE_KEY) return;
+    state = loadState();
+    renderProfile();
+    renderProgress();
+    renderTurns();
+    showSyncBadge();
+  });
+
+  registerServiceWorker({
+    onReady: () => undefined,
+    onUpdate: (registration) => {
+      promptServiceWorkerUpdate(registration);
+    },
+    onError: (error) => {
+      console.error("Service worker registration failed", error);
+    },
+  });
+};
+
+void start();

--- a/apps/pwa/src/leaderboard.ts
+++ b/apps/pwa/src/leaderboard.ts
@@ -3,162 +3,170 @@ import { renderPageHero } from "./components/page-hero";
 import { renderLeaderboard, attachLeaderboardListeners, LeaderboardViewMode } from "./components/leaderboard";
 import { calculateLeaderboardStats, loadState, STORAGE_KEY, LeaderboardEntry, RoleId } from "./state";
 import { supabase, isSupabaseConfigured } from "./services/supabase";
+import { requireDevAccess } from "./services/dev-gate";
 
-const root = document.querySelector<HTMLDivElement>("#app");
+const start = async () => {
+  if (!(await requireDevAccess())) return;
 
-if (!root) {
-  throw new Error("Root container missing");
-}
 
-const pageHero = renderPageHero({
-  title: "Classifica",
-  description: "Le migliori performance dei tecnici teatrali ATCL.",
-  currentPage: "leaderboard",
-  breadcrumbs: [
-    { label: "Hub", href: "/game.html" },
-    { label: "Classifica" },
-  ],
-  backHref: "/game.html",
-  backLabel: "Torna all'hub",
-});
+  const root = document.querySelector<HTMLDivElement>("#app");
 
-let currentViewMode: LeaderboardViewMode = "xp";
-let leaderboardEntries: LeaderboardEntry[] = [];
-let leaderboardStats = calculateLeaderboardStats(leaderboardEntries);
-let isLoading = false;
-let loadError: string | null = null;
-let currentUserId: string | undefined;
+  if (!root) {
+    throw new Error("Root container missing");
+  }
 
-type LeaderboardRow = {
-  id: string;
-  name: string;
-  role_id: string | null;
-  xp_total: number | null;
-  cachet: number | null;
-  reputation: number | null;
-  profile_image: string | null;
-  last_activity_at: string | null;
-  turns_count: number | null;
+  const pageHero = renderPageHero({
+    title: "Classifica",
+    description: "Le migliori performance dei tecnici teatrali ATCL.",
+    currentPage: "leaderboard",
+    breadcrumbs: [
+      { label: "Hub", href: "/game.html" },
+      { label: "Classifica" },
+    ],
+    backHref: "/game.html",
+    backLabel: "Torna all'hub",
+  });
+
+  let currentViewMode: LeaderboardViewMode = "xp";
+  let leaderboardEntries: LeaderboardEntry[] = [];
+  let leaderboardStats = calculateLeaderboardStats(leaderboardEntries);
+  let isLoading = false;
+  let loadError: string | null = null;
+  let currentUserId: string | undefined;
+
+  type LeaderboardRow = {
+    id: string;
+    name: string;
+    role_id: string | null;
+    xp_total: number | null;
+    cachet: number | null;
+    reputation: number | null;
+    profile_image: string | null;
+    last_activity_at: string | null;
+    turns_count: number | null;
+  };
+
+  function renderLeaderboardPage() {
+    if (!root) return;
+    
+    const sortedEntries = sortEntriesByMode(leaderboardEntries, currentViewMode);
+    
+    root.innerHTML = `
+      <main class="page page-game layout-shell">
+        ${pageHero}
+
+        <section class="card">
+          ${isLoading ? '<p class="muted">Caricamento classifica...</p>' : ""}
+          ${loadError ? `<p class="muted">${loadError}</p>` : ""}
+          ${!isLoading && !loadError ? renderLeaderboard({
+              entries: sortedEntries,
+              stats: leaderboardStats,
+              currentUserId,
+              viewMode: currentViewMode,
+              onViewModeChange: handleViewModeChange,
+            }) : ""}
+        </section>
+      </main>
+    `;
+
+    attachLeaderboardListeners(root, handleViewModeChange);
+  }
+
+  function sortEntriesByMode(entries: LeaderboardEntry[], mode: LeaderboardViewMode): LeaderboardEntry[] {
+    const sorted = [...entries];
+    
+    switch (mode) {
+      case "xp":
+        return sorted.sort((a, b) => b.xpTotal - a.xpTotal);
+      case "reputation":
+        return sorted.sort((a, b) => b.reputation - a.reputation);
+      case "cachet":
+        return sorted.sort((a, b) => b.cachet - a.cachet);
+      default:
+        return sorted;
+    }
+  }
+
+  async function loadLeaderboard() {
+    isLoading = true;
+    loadError = null;
+    renderLeaderboardPage();
+
+    if (!isSupabaseConfigured || !supabase) {
+      isLoading = false;
+      loadError = "Supabase non configurato (mancano VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY).";
+      renderLeaderboardPage();
+      return;
+    }
+
+    try {
+      const { data: authData } = await supabase.auth.getUser();
+      currentUserId = authData.user?.id;
+
+      const { data, error } = await supabase.rpc("get_leaderboard", { p_limit: 100 });
+      if (error) throw error;
+
+      const rows = (data as LeaderboardRow[]) ?? [];
+      leaderboardEntries = rows.map((row) => {
+        const roleCandidate = row.role_id ?? "attore";
+        const roleId: RoleId = (roleCandidate === "attore" || roleCandidate === "luci" || roleCandidate === "fonico" || roleCandidate === "attrezzista" || roleCandidate === "palco")
+          ? (roleCandidate as RoleId)
+          : "attore";
+
+        const lastActivityAt = row.last_activity_at ? Date.parse(row.last_activity_at) : undefined;
+        return {
+          id: row.id,
+          name: row.name ?? "Player",
+          roleId,
+          xpTotal: row.xp_total ?? 0,
+          cachet: row.cachet ?? 0,
+          reputation: row.reputation ?? 0,
+          turnsCount: row.turns_count ?? 0,
+          lastActivityAt,
+          profileImage: row.profile_image ?? undefined,
+        };
+      });
+
+      leaderboardStats = calculateLeaderboardStats(leaderboardEntries);
+      isLoading = false;
+      renderLeaderboardPage();
+    } catch (error) {
+      isLoading = false;
+      loadError = error instanceof Error ? error.message : "Errore durante il caricamento della classifica.";
+      renderLeaderboardPage();
+    }
+  }
+
+  function handleViewModeChange(mode: LeaderboardViewMode) {
+    currentViewMode = mode;
+    
+    const url = new URL(window.location.href);
+    url.searchParams.set("mode", mode);
+    window.history.replaceState({}, "", url.toString());
+    
+    renderLeaderboardPage();
+  }
+
+  function showSyncBadge(message = "Stato aggiornato") {
+    const syncBadge = document.querySelector<HTMLElement>('[data-sync-badge]');
+    if (!syncBadge) return;
+    
+    syncBadge.textContent = message;
+    syncBadge.style.display = "inline-flex";
+    
+    setTimeout(() => {
+      if (syncBadge) syncBadge.style.display = "none";
+    }, 2500);
+  }
+
+  window.addEventListener("storage", (event) => {
+    if (event.key !== STORAGE_KEY) return;
+    loadState();
+    showSyncBadge();
+  });
+
+  renderLeaderboardPage();
+  loadLeaderboard();
 };
 
-function renderLeaderboardPage() {
-  if (!root) return;
-  
-  const sortedEntries = sortEntriesByMode(leaderboardEntries, currentViewMode);
-  
-  root.innerHTML = `
-    <main class="page page-game layout-shell">
-      ${pageHero}
-
-      <section class="card">
-        ${isLoading ? '<p class="muted">Caricamento classifica...</p>' : ""}
-        ${loadError ? `<p class="muted">${loadError}</p>` : ""}
-        ${!isLoading && !loadError ? renderLeaderboard({
-            entries: sortedEntries,
-            stats: leaderboardStats,
-            currentUserId,
-            viewMode: currentViewMode,
-            onViewModeChange: handleViewModeChange,
-          }) : ""}
-      </section>
-    </main>
-  `;
-
-  attachLeaderboardListeners(root, handleViewModeChange);
-}
-
-function sortEntriesByMode(entries: LeaderboardEntry[], mode: LeaderboardViewMode): LeaderboardEntry[] {
-  const sorted = [...entries];
-  
-  switch (mode) {
-    case "xp":
-      return sorted.sort((a, b) => b.xpTotal - a.xpTotal);
-    case "reputation":
-      return sorted.sort((a, b) => b.reputation - a.reputation);
-    case "cachet":
-      return sorted.sort((a, b) => b.cachet - a.cachet);
-    default:
-      return sorted;
-  }
-}
-
-async function loadLeaderboard() {
-  isLoading = true;
-  loadError = null;
-  renderLeaderboardPage();
-
-  if (!isSupabaseConfigured || !supabase) {
-    isLoading = false;
-    loadError = "Supabase non configurato (mancano VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY).";
-    renderLeaderboardPage();
-    return;
-  }
-
-  try {
-    const { data: authData } = await supabase.auth.getUser();
-    currentUserId = authData.user?.id;
-
-    const { data, error } = await supabase.rpc("get_leaderboard", { p_limit: 100 });
-    if (error) throw error;
-
-    const rows = (data as LeaderboardRow[]) ?? [];
-    leaderboardEntries = rows.map((row) => {
-      const roleCandidate = row.role_id ?? "attore";
-      const roleId: RoleId = (roleCandidate === "attore" || roleCandidate === "luci" || roleCandidate === "fonico" || roleCandidate === "attrezzista" || roleCandidate === "palco")
-        ? (roleCandidate as RoleId)
-        : "attore";
-
-      const lastActivityAt = row.last_activity_at ? Date.parse(row.last_activity_at) : undefined;
-      return {
-        id: row.id,
-        name: row.name ?? "Player",
-        roleId,
-        xpTotal: row.xp_total ?? 0,
-        cachet: row.cachet ?? 0,
-        reputation: row.reputation ?? 0,
-        turnsCount: row.turns_count ?? 0,
-        lastActivityAt,
-        profileImage: row.profile_image ?? undefined,
-      };
-    });
-
-    leaderboardStats = calculateLeaderboardStats(leaderboardEntries);
-    isLoading = false;
-    renderLeaderboardPage();
-  } catch (error) {
-    isLoading = false;
-    loadError = error instanceof Error ? error.message : "Errore durante il caricamento della classifica.";
-    renderLeaderboardPage();
-  }
-}
-
-function handleViewModeChange(mode: LeaderboardViewMode) {
-  currentViewMode = mode;
-  
-  const url = new URL(window.location.href);
-  url.searchParams.set("mode", mode);
-  window.history.replaceState({}, "", url.toString());
-  
-  renderLeaderboardPage();
-}
-
-function showSyncBadge(message = "Stato aggiornato") {
-  const syncBadge = document.querySelector<HTMLElement>('[data-sync-badge]');
-  if (!syncBadge) return;
-  
-  syncBadge.textContent = message;
-  syncBadge.style.display = "inline-flex";
-  
-  setTimeout(() => {
-    if (syncBadge) syncBadge.style.display = "none";
-  }, 2500);
-}
-
-window.addEventListener("storage", (event) => {
-  if (event.key !== STORAGE_KEY) return;
-  loadState();
-  showSyncBadge();
-});
-
-renderLeaderboardPage();
-loadLeaderboard();
+void start();

--- a/apps/pwa/src/main.ts
+++ b/apps/pwa/src/main.ts
@@ -2,74 +2,81 @@ import "../../../shared/styles/main.css";
 import { renderPageHero } from "./components/page-hero";
 import { renderPermissionsCard, attachPermissionsListeners } from "./features/permissions-card";
 import { renderStatusCard, attachStatusListeners } from "./features/status-card";
+import { requireDevAccess } from "./services/dev-gate";
 
-const root = document.querySelector<HTMLDivElement>("#app");
+const start = async () => {
+  if (!(await requireDevAccess())) return;
 
-if (!root) {
-  throw new Error("Root container missing");
-}
+  const root = document.querySelector<HTMLDivElement>("#app");
 
-const hero = renderPageHero({
-  title: "Progressive Web App base",
-  description:
-    "Shell installabile e offline-ready per costruire il loop di gioco. I moduli demo (profilo, attivita simulate e turni) ora vivono nel playground dev.",
-  currentPage: "home",
-  breadcrumbs: [{ label: "Home" }],
-  quickActions: [
-    { id: "hero", label: "Hero", href: "#hero", icon: "⬆️" },
-    { id: "permissions", label: "Permessi", href: "#permissions", icon: "✅" },
-    { id: "dev", label: "Dev playground", href: "/dev.html", icon: "🛠️" },
-    { id: "game", label: "Hub", href: "/game.html", icon: "🎮" },
-  ],
-  ctaRow: [
-    { id: "open-dev", label: "Apri dev playground", href: "/dev.html", variant: "primary", icon: "🛠️" },
-    { id: "refresh", label: "Reload per update", kind: "button", dataAction: "refresh", variant: "ghost" },
-    { id: "open-game", label: "Apri interfaccia base", href: "/game.html", variant: "ghost", icon: "🎮" },
-  ],
-});
+  if (!root) {
+    throw new Error("Root container missing");
+  }
 
-root.innerHTML = `
-  <main class="page">
-    <section class="layout-stack" id="hero">
-      ${hero}
-      <div class="badges">
-        <span class="badge">Installable</span>
-        <span class="badge">Offline friendly</span>
-        <span class="badge">Vite + TypeScript</span>
-      </div>
-    </section>
+  const hero = renderPageHero({
+    title: "Progressive Web App base",
+    description:
+      "Shell installabile e offline-ready per costruire il loop di gioco. I moduli demo (profilo, attivita simulate e turni) ora vivono nel playground dev.",
+    currentPage: "home",
+    breadcrumbs: [{ label: "Home" }],
+    quickActions: [
+      { id: "hero", label: "Hero", href: "#hero", icon: "⬆️" },
+      { id: "permissions", label: "Permessi", href: "#permissions", icon: "✅" },
+      { id: "dev", label: "Dev playground", href: "/dev.html", icon: "🛠️" },
+      { id: "game", label: "Hub", href: "/game.html", icon: "🎮" },
+    ],
+    ctaRow: [
+      { id: "open-dev", label: "Apri dev playground", href: "/dev.html", variant: "primary", icon: "🛠️" },
+      { id: "refresh", label: "Reload per update", kind: "button", dataAction: "refresh", variant: "ghost" },
+      { id: "open-game", label: "Apri interfaccia base", href: "/game.html", variant: "ghost", icon: "🎮" },
+    ],
+  });
 
-    <section class="grid layout-grid">
-      <article class="card">
-        <h2>App shell</h2>
-        <p>
-          Skeleton single-page: aggiungi scene e HUD in <code>src/</code>, tieni asset statici in <code>public/</code>, aggiorna il service worker quando cambi il core.
-        </p>
-        <ul class="list">
-          <li><strong>Routing:</strong> SPA via Vite dev server</li>
-          <li><strong>Install:</strong> manifest + service worker</li>
-          <li><strong>Assets:</strong> cached on first use</li>
-        </ul>
-      </article>
-
-      <article class="card">
-        <h2>Build + Dev</h2>
-        <p>
-          Usa <code>npm run dev</code> per lo sviluppo, <code>npm run build</code> per il bundle e <code>npm run preview</code> per la smoke sul build.
-        </p>
-        <div class="pill-row">
-          <span class="pill">Hot reload</span>
-          <span class="pill">ESM</span>
-          <span class="pill">Typed</span>
+  root.innerHTML = `
+    <main class="page">
+      <section class="layout-stack" id="hero">
+        ${hero}
+        <div class="badges">
+          <span class="badge">Installable</span>
+          <span class="badge">Offline friendly</span>
+          <span class="badge">Vite + TypeScript</span>
         </div>
-      </article>
+      </section>
 
-      ${renderStatusCard()}
+      <section class="grid layout-grid">
+        <article class="card">
+          <h2>App shell</h2>
+          <p>
+            Skeleton single-page: aggiungi scene e HUD in <code>src/</code>, tieni asset statici in <code>public/</code>, aggiorna il service worker quando cambi il core.
+          </p>
+          <ul class="list">
+            <li><strong>Routing:</strong> SPA via Vite dev server</li>
+            <li><strong>Install:</strong> manifest + service worker</li>
+            <li><strong>Assets:</strong> cached on first use</li>
+          </ul>
+        </article>
 
-      ${renderPermissionsCard()}
-    </section>
-  </main>
-`;
+        <article class="card">
+          <h2>Build + Dev</h2>
+          <p>
+            Usa <code>npm run dev</code> per lo sviluppo, <code>npm run build</code> per il bundle e <code>npm run preview</code> per la smoke sul build.
+          </p>
+          <div class="pill-row">
+            <span class="pill">Hot reload</span>
+            <span class="pill">ESM</span>
+            <span class="pill">Typed</span>
+          </div>
+        </article>
 
-attachStatusListeners(root, '[data-action="refresh"]');
-attachPermissionsListeners(root);
+        ${renderStatusCard()}
+
+        ${renderPermissionsCard()}
+      </section>
+    </main>
+  `;
+
+  attachStatusListeners(root, '[data-action="refresh"]');
+  attachPermissionsListeners(root);
+};
+
+void start();

--- a/apps/pwa/src/map.ts
+++ b/apps/pwa/src/map.ts
@@ -21,810 +21,817 @@ import {
   SaveStateResult,
   STORAGE_KEY,
 } from "./state";
+import { requireDevAccess } from "./services/dev-gate";
 
-type DecoratedEvent = (typeof mockEvents)[number] & { distanceKm: number };
-type DrawerSection = "events" | "turns" | "profile";
+const start = async () => {
+  if (!(await requireDevAccess())) return;
 
-const defaultCenter = [41.9028, 12.4964] as const; // Roma
-const DEFAULT_DISTANCE_KM = 220;
-const MAX_STORED_TURNS = 10;
+  type DecoratedEvent = (typeof mockEvents)[number] & { distanceKm: number };
+  type DrawerSection = "events" | "turns" | "profile";
 
-const root = document.querySelector<HTMLDivElement>("#app");
+  const defaultCenter = [41.9028, 12.4964] as const; // Roma
+  const DEFAULT_DISTANCE_KM = 220;
+  const MAX_STORED_TURNS = 10;
 
-if (!root) {
-  throw new Error("Root container missing");
-}
+  const root = document.querySelector<HTMLDivElement>("#app");
 
-const topStatsMarkup = [
-  renderStatPill({ label: "XP", value: 0, size: "sm", icon: "⭐", valueAttributes: { "data-top-stat": "xp" } }),
-  renderStatPill({ label: "Cachet", value: 0, size: "sm", icon: "💰", valueAttributes: { "data-top-stat": "cachet" } }),
-  renderStatPill({ label: "Rep", value: 0, size: "sm", icon: "📣", valueAttributes: { "data-top-stat": "rep" } }),
-].join("");
-
-const drawerTabsMarkup = [
-  renderChip({
-    label: "Eventi",
-    size: "sm",
-    variant: "ghost",
-    state: "active",
-    dataAttributes: { "drawer-tab": "events", "tab-id": "tab-events" },
-  }),
-  renderChip({ label: "Turni", size: "sm", variant: "ghost", dataAttributes: { "drawer-tab": "turns", "tab-id": "tab-turns" } }),
-  renderChip({
-    label: "Profilo",
-    size: "sm",
-    variant: "ghost",
-    dataAttributes: { "drawer-tab": "profile", "tab-id": "tab-profile" },
-  }),
-].join("");
-
-root.innerHTML = `
-  <main class="map-app">
-    <div id="map" class="map-canvas" aria-label="Mappa eventi"></div>
-
-    <header class="map-topbar">
-      <div class="app-brand">
-        <span class="brand-mark">TdP</span>
-        <div>
-          <p class="eyebrow">Turni di Palco</p>
-          <p class="muted tiny">Mappa eventi</p>
-        </div>
-      </div>
-      <div class="top-actions">
-        <div class="profile-chip" data-profile-chip>
-          <div class="avatar-display mini" data-avatar="profile-chip">
-            <img data-avatar-img-chip alt="Avatar ReadyPlayerMe" />
-            <span class="avatar-icon" data-avatar-label-chip></span>
-          </div>
-          <div class="profile-chip-text">
-            <p class="chip-title" data-chip-name>Profilo</p>
-            <p class="muted tiny" data-chip-role>Ruolo non impostato</p>
-          </div>
-        </div>
-        <div class="top-stats">${topStatsMarkup}</div>
-        <span class="badge" data-sync-badge style="display:none">Stato aggiornato</span>
-        <a class="button ghost" href="/avatar.html">Avatar</a>
-        <a class="button ghost" href="/">Landing</a>
-        <a class="button ghost" href="/profile.html">Profilo</a>
-        <button class="button primary" type="button" data-action="sync-state">Sincronizza</button>
-      </div>
-    </header>
-
-    <div class="map-actions">
-      <div class="pill-row">
-        <span class="pill ghost" data-profile-state>Carica i dati dal profilo principale.</span>
-        <span class="pill" data-role-label>Ruolo non impostato</span>
-      </div>
-      <div class="map-controls">
-        <button class="button ghost small" type="button" data-action="quick-train">Allenamento</button>
-        <button class="button ghost small" type="button" data-action="quick-scene">Scena</button>
-        <button class="button ghost small" type="button" data-action="quick-audio">Audio</button>
-      </div>
-    </div>
-
-    <section class="map-drawer">
-      <div class="drawer-header">
-        <div class="drawer-tabs" role="tablist" aria-label="Sezioni mappa" data-tablist="drawer">${drawerTabsMarkup}</div>
-        <div class="stat-board compact">
-          <div class="stat-chip">
-            <span>XP</span>
-            <strong data-stat="xp">0</strong>
-          </div>
-          <div class="stat-chip">
-            <span>Cachet</span>
-            <strong data-stat="cachet">0</strong>
-          </div>
-          <div class="stat-chip">
-            <span>Rep</span>
-            <strong data-stat="rep">0</strong>
-          </div>
-        </div>
-      </div>
-      <div class="drawer-body">
-        <div class="drawer-section" data-section="profile" id="panel-profile" role="tabpanel" aria-labelledby="tab-profile">
-          <div class="pill-row" data-role-tags></div>
-          <div class="result-box slim" data-quick-result>Mappa pronta.</div>
-        </div>
-        <div class="drawer-section" data-section="events" id="panel-events" role="tabpanel" aria-labelledby="tab-events">
-          <div class="drawer-filters" role="group" aria-label="Filtri eventi">
-            <label class="field inline">
-              <span>Ruolo focus</span>
-              <select data-filter-role aria-label="Filtra eventi per ruolo">
-                <option value="all">Tutti i ruoli</option>
-                ${roles.map((role) => `<option value="${role.id}">${role.name}</option>`).join("")}
-              </select>
-            </label>
-            <label class="field inline">
-              <span>Data massima</span>
-              <input type="date" data-filter-date aria-label="Filtra per data" />
-            </label>
-            <label class="field inline">
-              <span>Distanza max: <strong data-distance-value>${DEFAULT_DISTANCE_KM}</strong> km</span>
-              <input type="range" min="30" max="420" step="10" value="${DEFAULT_DISTANCE_KM}" data-filter-distance aria-label="Filtra per distanza" />
-            </label>
-          </div>
-          <div class="pill-row focus-row" data-focus-hints></div>
-          <div class="inline-feedback" data-loading-indicator hidden aria-live="polite">Caricamento eventi...</div>
-          <div class="compact-note" data-compact-note role="status" aria-live="polite" hidden>Layout compatto: usa i tab o apri la mappa a tutto schermo per leggere i dettagli.</div>
-          <div class="event-detail" data-event-detail>
-            <div data-event-content>
-              <p class="muted">Seleziona un evento per vedere i dettagli.</p>
-            </div>
-            <div class="detail-actions">
-              <button class="button primary" type="button" data-action="register-turn" disabled>Registra turno</button>
-              <div class="result-box slim" data-event-feedback>In attesa di selezione.</div>
-            </div>
-          </div>
-          <p class="muted tiny" data-filter-summary>Prossimi eventi mock</p>
-          <ul class="log-list dense" data-event-list></ul>
-        </div>
-        <div class="drawer-section" data-section="turns" id="panel-turns" role="tabpanel" aria-labelledby="tab-turns">
-          <p class="muted tiny">Registro recente</p>
-          <ul class="log-list dense" data-turn-log></ul>
-        </div>
-      </div>
-    </section>
-  </main>
-`;
-
-const statXp = root.querySelector<HTMLElement>('[data-stat="xp"]');
-const statCachet = root.querySelector<HTMLElement>('[data-stat="cachet"]');
-const statRep = root.querySelector<HTMLElement>('[data-stat="rep"]');
-const roleTags = root.querySelector<HTMLElement>('[data-role-tags]');
-const profileState = root.querySelector<HTMLElement>('[data-profile-state]');
-const quickResult = root.querySelector<HTMLElement>('[data-quick-result]');
-const eventList = root.querySelector<HTMLElement>('[data-event-list]');
-const turnLog = root.querySelector<HTMLElement>('[data-turn-log]');
-const roleLabel = root.querySelector<HTMLElement>('[data-role-label]');
-const mapContainer = root.querySelector<HTMLDivElement>("#map");
-const avatarChip = root.querySelector<HTMLElement>('[data-avatar="profile-chip"]');
-const avatarLabelChip = root.querySelector<HTMLElement>('[data-avatar-label-chip]');
-const avatarChipImg = root.querySelector<HTMLImageElement>('[data-avatar-img-chip]');
-const chipName = root.querySelector<HTMLElement>('[data-chip-name]');
-const chipRole = root.querySelector<HTMLElement>('[data-chip-role]');
-const topStatXp = root.querySelector<HTMLElement>('[data-top-stat="xp"]');
-const topStatCachet = root.querySelector<HTMLElement>('[data-top-stat="cachet"]');
-const topStatRep = root.querySelector<HTMLElement>('[data-top-stat="rep"]');
-const drawerTabs = Array.from(root.querySelectorAll<HTMLButtonElement>("[data-drawer-tab]"));
-const drawerSections = Array.from(root.querySelectorAll<HTMLElement>("[data-section]"));
-const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
-const drawerTablist = root.querySelector<HTMLElement>('[data-tablist="drawer"]');
-const filterRoleSelect = root.querySelector<HTMLSelectElement>('[data-filter-role]');
-const filterDateInput = root.querySelector<HTMLInputElement>('[data-filter-date]');
-const filterDistanceInput = root.querySelector<HTMLInputElement>('[data-filter-distance]');
-const distanceValue = root.querySelector<HTMLElement>('[data-distance-value]');
-const filterSummary = root.querySelector<HTMLElement>('[data-filter-summary]');
-const focusHints = root.querySelector<HTMLElement>('[data-focus-hints]');
-const eventContent = root.querySelector<HTMLElement>('[data-event-content]');
-const eventFeedback = root.querySelector<HTMLElement>('[data-event-feedback]');
-const loadingIndicator = root.querySelector<HTMLElement>('[data-loading-indicator]');
-const compactNote = root.querySelector<HTMLElement>('[data-compact-note]');
-const registerTurnButton = root.querySelector<HTMLButtonElement>('[data-action="register-turn"]');
-
-let state = loadState();
-let map: LeafletMap | null = null;
-let markerLayer: LayerGroup | null = null;
-let syncBadgeTimeout: number | undefined;
-const markerMap = new Map<string, L.Marker>();
-let filteredEvents: DecoratedEvent[] = [];
-let selectedEventId: string | null = null;
-const eventFilters: { role: RoleId | "all"; date: string; distance: number } = {
-  role: "all",
-  date: "",
-  distance: DEFAULT_DISTANCE_KM,
-};
-const markerIcon = L.icon({
-  iconUrl: markerIconPng,
-  shadowUrl: markerShadowPng,
-  iconAnchor: [12, 41],
-  popupAnchor: [1, -28],
-  tooltipAnchor: [12, -16],
-});
-
-function showSyncBadge(message = "Stato aggiornato") {
-  if (!syncBadge) return;
-  syncBadge.textContent = message;
-  syncBadge.style.display = "inline-flex";
-  if (syncBadgeTimeout) {
-    window.clearTimeout(syncBadgeTimeout);
+  if (!root) {
+    throw new Error("Root container missing");
   }
-  syncBadgeTimeout = window.setTimeout(() => {
-    if (syncBadge) {
-      syncBadge.style.display = "none";
+
+  const topStatsMarkup = [
+    renderStatPill({ label: "XP", value: 0, size: "sm", icon: "⭐", valueAttributes: { "data-top-stat": "xp" } }),
+    renderStatPill({ label: "Cachet", value: 0, size: "sm", icon: "💰", valueAttributes: { "data-top-stat": "cachet" } }),
+    renderStatPill({ label: "Rep", value: 0, size: "sm", icon: "📣", valueAttributes: { "data-top-stat": "rep" } }),
+  ].join("");
+
+  const drawerTabsMarkup = [
+    renderChip({
+      label: "Eventi",
+      size: "sm",
+      variant: "ghost",
+      state: "active",
+      dataAttributes: { "drawer-tab": "events", "tab-id": "tab-events" },
+    }),
+    renderChip({ label: "Turni", size: "sm", variant: "ghost", dataAttributes: { "drawer-tab": "turns", "tab-id": "tab-turns" } }),
+    renderChip({
+      label: "Profilo",
+      size: "sm",
+      variant: "ghost",
+      dataAttributes: { "drawer-tab": "profile", "tab-id": "tab-profile" },
+    }),
+  ].join("");
+
+  root.innerHTML = `
+    <main class="map-app">
+      <div id="map" class="map-canvas" aria-label="Mappa eventi"></div>
+
+      <header class="map-topbar">
+        <div class="app-brand">
+          <span class="brand-mark">TdP</span>
+          <div>
+            <p class="eyebrow">Turni di Palco</p>
+            <p class="muted tiny">Mappa eventi</p>
+          </div>
+        </div>
+        <div class="top-actions">
+          <div class="profile-chip" data-profile-chip>
+            <div class="avatar-display mini" data-avatar="profile-chip">
+              <img data-avatar-img-chip alt="Avatar ReadyPlayerMe" />
+              <span class="avatar-icon" data-avatar-label-chip></span>
+            </div>
+            <div class="profile-chip-text">
+              <p class="chip-title" data-chip-name>Profilo</p>
+              <p class="muted tiny" data-chip-role>Ruolo non impostato</p>
+            </div>
+          </div>
+          <div class="top-stats">${topStatsMarkup}</div>
+          <span class="badge" data-sync-badge style="display:none">Stato aggiornato</span>
+          <a class="button ghost" href="/avatar.html">Avatar</a>
+          <a class="button ghost" href="/">Landing</a>
+          <a class="button ghost" href="/profile.html">Profilo</a>
+          <button class="button primary" type="button" data-action="sync-state">Sincronizza</button>
+        </div>
+      </header>
+
+      <div class="map-actions">
+        <div class="pill-row">
+          <span class="pill ghost" data-profile-state>Carica i dati dal profilo principale.</span>
+          <span class="pill" data-role-label>Ruolo non impostato</span>
+        </div>
+        <div class="map-controls">
+          <button class="button ghost small" type="button" data-action="quick-train">Allenamento</button>
+          <button class="button ghost small" type="button" data-action="quick-scene">Scena</button>
+          <button class="button ghost small" type="button" data-action="quick-audio">Audio</button>
+        </div>
+      </div>
+
+      <section class="map-drawer">
+        <div class="drawer-header">
+          <div class="drawer-tabs" role="tablist" aria-label="Sezioni mappa" data-tablist="drawer">${drawerTabsMarkup}</div>
+          <div class="stat-board compact">
+            <div class="stat-chip">
+              <span>XP</span>
+              <strong data-stat="xp">0</strong>
+            </div>
+            <div class="stat-chip">
+              <span>Cachet</span>
+              <strong data-stat="cachet">0</strong>
+            </div>
+            <div class="stat-chip">
+              <span>Rep</span>
+              <strong data-stat="rep">0</strong>
+            </div>
+          </div>
+        </div>
+        <div class="drawer-body">
+          <div class="drawer-section" data-section="profile" id="panel-profile" role="tabpanel" aria-labelledby="tab-profile">
+            <div class="pill-row" data-role-tags></div>
+            <div class="result-box slim" data-quick-result>Mappa pronta.</div>
+          </div>
+          <div class="drawer-section" data-section="events" id="panel-events" role="tabpanel" aria-labelledby="tab-events">
+            <div class="drawer-filters" role="group" aria-label="Filtri eventi">
+              <label class="field inline">
+                <span>Ruolo focus</span>
+                <select data-filter-role aria-label="Filtra eventi per ruolo">
+                  <option value="all">Tutti i ruoli</option>
+                  ${roles.map((role) => `<option value="${role.id}">${role.name}</option>`).join("")}
+                </select>
+              </label>
+              <label class="field inline">
+                <span>Data massima</span>
+                <input type="date" data-filter-date aria-label="Filtra per data" />
+              </label>
+              <label class="field inline">
+                <span>Distanza max: <strong data-distance-value>${DEFAULT_DISTANCE_KM}</strong> km</span>
+                <input type="range" min="30" max="420" step="10" value="${DEFAULT_DISTANCE_KM}" data-filter-distance aria-label="Filtra per distanza" />
+              </label>
+            </div>
+            <div class="pill-row focus-row" data-focus-hints></div>
+            <div class="inline-feedback" data-loading-indicator hidden aria-live="polite">Caricamento eventi...</div>
+            <div class="compact-note" data-compact-note role="status" aria-live="polite" hidden>Layout compatto: usa i tab o apri la mappa a tutto schermo per leggere i dettagli.</div>
+            <div class="event-detail" data-event-detail>
+              <div data-event-content>
+                <p class="muted">Seleziona un evento per vedere i dettagli.</p>
+              </div>
+              <div class="detail-actions">
+                <button class="button primary" type="button" data-action="register-turn" disabled>Registra turno</button>
+                <div class="result-box slim" data-event-feedback>In attesa di selezione.</div>
+              </div>
+            </div>
+            <p class="muted tiny" data-filter-summary>Prossimi eventi mock</p>
+            <ul class="log-list dense" data-event-list></ul>
+          </div>
+          <div class="drawer-section" data-section="turns" id="panel-turns" role="tabpanel" aria-labelledby="tab-turns">
+            <p class="muted tiny">Registro recente</p>
+            <ul class="log-list dense" data-turn-log></ul>
+          </div>
+        </div>
+      </section>
+    </main>
+  `;
+
+  const statXp = root.querySelector<HTMLElement>('[data-stat="xp"]');
+  const statCachet = root.querySelector<HTMLElement>('[data-stat="cachet"]');
+  const statRep = root.querySelector<HTMLElement>('[data-stat="rep"]');
+  const roleTags = root.querySelector<HTMLElement>('[data-role-tags]');
+  const profileState = root.querySelector<HTMLElement>('[data-profile-state]');
+  const quickResult = root.querySelector<HTMLElement>('[data-quick-result]');
+  const eventList = root.querySelector<HTMLElement>('[data-event-list]');
+  const turnLog = root.querySelector<HTMLElement>('[data-turn-log]');
+  const roleLabel = root.querySelector<HTMLElement>('[data-role-label]');
+  const mapContainer = root.querySelector<HTMLDivElement>("#map");
+  const avatarChip = root.querySelector<HTMLElement>('[data-avatar="profile-chip"]');
+  const avatarLabelChip = root.querySelector<HTMLElement>('[data-avatar-label-chip]');
+  const avatarChipImg = root.querySelector<HTMLImageElement>('[data-avatar-img-chip]');
+  const chipName = root.querySelector<HTMLElement>('[data-chip-name]');
+  const chipRole = root.querySelector<HTMLElement>('[data-chip-role]');
+  const topStatXp = root.querySelector<HTMLElement>('[data-top-stat="xp"]');
+  const topStatCachet = root.querySelector<HTMLElement>('[data-top-stat="cachet"]');
+  const topStatRep = root.querySelector<HTMLElement>('[data-top-stat="rep"]');
+  const drawerTabs = Array.from(root.querySelectorAll<HTMLButtonElement>("[data-drawer-tab]"));
+  const drawerSections = Array.from(root.querySelectorAll<HTMLElement>("[data-section]"));
+  const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
+  const drawerTablist = root.querySelector<HTMLElement>('[data-tablist="drawer"]');
+  const filterRoleSelect = root.querySelector<HTMLSelectElement>('[data-filter-role]');
+  const filterDateInput = root.querySelector<HTMLInputElement>('[data-filter-date]');
+  const filterDistanceInput = root.querySelector<HTMLInputElement>('[data-filter-distance]');
+  const distanceValue = root.querySelector<HTMLElement>('[data-distance-value]');
+  const filterSummary = root.querySelector<HTMLElement>('[data-filter-summary]');
+  const focusHints = root.querySelector<HTMLElement>('[data-focus-hints]');
+  const eventContent = root.querySelector<HTMLElement>('[data-event-content]');
+  const eventFeedback = root.querySelector<HTMLElement>('[data-event-feedback]');
+  const loadingIndicator = root.querySelector<HTMLElement>('[data-loading-indicator]');
+  const compactNote = root.querySelector<HTMLElement>('[data-compact-note]');
+  const registerTurnButton = root.querySelector<HTMLButtonElement>('[data-action="register-turn"]');
+
+  let state = loadState();
+  let map: LeafletMap | null = null;
+  let markerLayer: LayerGroup | null = null;
+  let syncBadgeTimeout: number | undefined;
+  const markerMap = new Map<string, L.Marker>();
+  let filteredEvents: DecoratedEvent[] = [];
+  let selectedEventId: string | null = null;
+  const eventFilters: { role: RoleId | "all"; date: string; distance: number } = {
+    role: "all",
+    date: "",
+    distance: DEFAULT_DISTANCE_KM,
+  };
+  const markerIcon = L.icon({
+    iconUrl: markerIconPng,
+    shadowUrl: markerShadowPng,
+    iconAnchor: [12, 41],
+    popupAnchor: [1, -28],
+    tooltipAnchor: [12, -16],
+  });
+
+  function showSyncBadge(message = "Stato aggiornato") {
+    if (!syncBadge) return;
+    syncBadge.textContent = message;
+    syncBadge.style.display = "inline-flex";
+    if (syncBadgeTimeout) {
+      window.clearTimeout(syncBadgeTimeout);
     }
-  }, 2500);
-}
-
-function persistState(nextState: typeof state, feedback?: HTMLElement | null): SaveStateResult {
-  const result = saveState(nextState);
-  state = result.state;
-  if (!result.ok && feedback) {
-    feedback.dataset.state = "warn";
-    feedback.textContent = "Salvataggio locale non riuscito, manteniamo una copia in memoria.";
+    syncBadgeTimeout = window.setTimeout(() => {
+      if (syncBadge) {
+        syncBadge.style.display = "none";
+      }
+    }, 2500);
   }
-  return result;
-}
 
-function toRadians(value: number) {
-  return (value * Math.PI) / 180;
-}
-
-function computeDistanceKm(lat: number, lng: number) {
-  const [centerLat, centerLng] = defaultCenter;
-  const earthRadiusKm = 6371;
-  const dLat = toRadians(lat - centerLat);
-  const dLng = toRadians(lng - centerLng);
-  const a =
-    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-    Math.cos(toRadians(centerLat)) * Math.cos(toRadians(lat)) * Math.sin(dLng / 2) * Math.sin(dLng / 2);
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-  return Math.max(0, Math.round(earthRadiusKm * c));
-}
-
-function setEventLoading(isLoading: boolean) {
-  if (eventList) eventList.setAttribute("aria-busy", String(isLoading));
-  if (loadingIndicator) loadingIndicator.hidden = !isLoading;
-}
-
-function updateDistanceLabel(value: number) {
-  if (distanceValue) distanceValue.textContent = value.toString();
-}
-
-function updateViewportNote() {
-  if (compactNote) {
-    compactNote.hidden = window.innerWidth >= 720;
+  function persistState(nextState: typeof state, feedback?: HTMLElement | null): SaveStateResult {
+    const result = saveState(nextState);
+    state = result.state;
+    if (!result.ok && feedback) {
+      feedback.dataset.state = "warn";
+      feedback.textContent = "Salvataggio locale non riuscito, manteniamo una copia in memoria.";
+    }
+    return result;
   }
-}
 
-function renderProfile() {
-  const profile = state.profile;
-  const avatarVisual = getAvatarVisual(profile.avatar);
-  if (statXp) statXp.textContent = profile.xp.toString();
-  if (statCachet) statCachet.textContent = profile.cachet.toString();
-  if (statRep) statRep.textContent = profile.repAtcl.toString();
-  if (topStatXp) topStatXp.textContent = profile.xp.toString();
-  if (topStatCachet) topStatCachet.textContent = profile.cachet.toString();
-  if (topStatRep) topStatRep.textContent = profile.repAtcl.toString();
-  if (avatarChip) {
-    avatarChip.style.setProperty("--avatar-color", avatarVisual.color);
-    avatarChip.style.setProperty("--avatar-hue", `${profile.avatar.hue}deg`);
-    avatarChip.classList.toggle("has-image", !!avatarVisual.image);
-    if (avatarLabelChip) avatarLabelChip.textContent = avatarVisual.icon;
-    if (avatarChipImg) {
-      if (avatarVisual.image) {
-        avatarChipImg.src = avatarVisual.image;
-        avatarChipImg.style.display = "block";
-      } else {
-        avatarChipImg.removeAttribute("src");
-        avatarChipImg.style.display = "none";
+  function toRadians(value: number) {
+    return (value * Math.PI) / 180;
+  }
+
+  function computeDistanceKm(lat: number, lng: number) {
+    const [centerLat, centerLng] = defaultCenter;
+    const earthRadiusKm = 6371;
+    const dLat = toRadians(lat - centerLat);
+    const dLng = toRadians(lng - centerLng);
+    const a =
+      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+      Math.cos(toRadians(centerLat)) * Math.cos(toRadians(lat)) * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    return Math.max(0, Math.round(earthRadiusKm * c));
+  }
+
+  function setEventLoading(isLoading: boolean) {
+    if (eventList) eventList.setAttribute("aria-busy", String(isLoading));
+    if (loadingIndicator) loadingIndicator.hidden = !isLoading;
+  }
+
+  function updateDistanceLabel(value: number) {
+    if (distanceValue) distanceValue.textContent = value.toString();
+  }
+
+  function updateViewportNote() {
+    if (compactNote) {
+      compactNote.hidden = window.innerWidth >= 720;
+    }
+  }
+
+  function renderProfile() {
+    const profile = state.profile;
+    const avatarVisual = getAvatarVisual(profile.avatar);
+    if (statXp) statXp.textContent = profile.xp.toString();
+    if (statCachet) statCachet.textContent = profile.cachet.toString();
+    if (statRep) statRep.textContent = profile.repAtcl.toString();
+    if (topStatXp) topStatXp.textContent = profile.xp.toString();
+    if (topStatCachet) topStatCachet.textContent = profile.cachet.toString();
+    if (topStatRep) topStatRep.textContent = profile.repAtcl.toString();
+    if (avatarChip) {
+      avatarChip.style.setProperty("--avatar-color", avatarVisual.color);
+      avatarChip.style.setProperty("--avatar-hue", `${profile.avatar.hue}deg`);
+      avatarChip.classList.toggle("has-image", !!avatarVisual.image);
+      if (avatarLabelChip) avatarLabelChip.textContent = avatarVisual.icon;
+      if (avatarChipImg) {
+        if (avatarVisual.image) {
+          avatarChipImg.src = avatarVisual.image;
+          avatarChipImg.style.display = "block";
+        } else {
+          avatarChipImg.removeAttribute("src");
+          avatarChipImg.style.display = "none";
+        }
+      }
+    }
+    const role = resolveRole(profile.roleId);
+    const roleText = profile.name ? `${profile.name} (${role.name})` : "Profilo non configurato";
+    if (profileState) {
+      profileState.textContent = profile.name
+        ? `Profilo: ${roleText}`
+        : "Profilo non configurato: torna alla landing e salva un nome/ruolo.";
+    }
+    if (roleLabel) {
+      roleLabel.textContent = roleText;
+    }
+    if (chipName) {
+      chipName.textContent = profile.name || "Profilo";
+    }
+    if (chipRole) {
+      chipRole.textContent = role.name;
+    }
+    if (roleTags) {
+      roleTags.innerHTML = role.stats.map((stat) => `<span class="pill ghost">${stat}</span>`).join("");
+    }
+  }
+
+  function computeTurnRewards(event: DecoratedEvent, roleId: RoleId): Rewards {
+    const bonus = event.focusRole && event.focusRole === roleId ? 8 : 0;
+    return {
+      xp: event.baseRewards.xp + bonus,
+      cachet: event.baseRewards.cachet + Math.round(bonus / 2),
+      reputation: event.baseRewards.reputation + Math.round(bonus / 4),
+    };
+  }
+
+  function renderFocusIndicators(targetEvent?: DecoratedEvent) {
+    if (!focusHints) return;
+    const activeRole = resolveRole(state.profile.roleId);
+    const focusRole = targetEvent?.focusRole ? resolveRole(targetEvent.focusRole) : null;
+    const match = focusRole?.id === activeRole.id;
+    const focusLabel = focusRole ? focusRole.name : "Multi-ruolo";
+    focusHints.innerHTML = `
+      <span class="focus-pill active">Ruolo attivo: ${activeRole.name}</span>
+      <span class="focus-pill ${match ? "match" : "ghost"}">Focus evento: ${focusLabel}${match ? " (match)" : ""}</span>
+    `;
+  }
+
+  function renderEventDetail(event?: DecoratedEvent) {
+    if (!eventContent || !eventFeedback || !registerTurnButton) return;
+    if (!event) {
+      eventContent.innerHTML = `<p class="muted">Seleziona un evento per vedere i dettagli.</p>`;
+      registerTurnButton.disabled = true;
+      registerTurnButton.removeAttribute("data-event-id");
+      eventFeedback.dataset.state = "info";
+      eventFeedback.textContent = "In attesa di selezione.";
+      renderFocusIndicators();
+      return;
+    }
+    const focusRole = event.focusRole ? resolveRole(event.focusRole) : null;
+    const match = focusRole?.id === state.profile.roleId;
+    const rewards = computeTurnRewards(event, state.profile.roleId);
+    eventContent.innerHTML = `
+      <div class="detail-head">
+        <div>
+          <p class="eyebrow">${event.id}</p>
+          <h3>${event.name}</h3>
+          <p class="muted tiny">${event.theatre} • ${event.date}</p>
+        </div>
+        <span class="focus-pill ${match ? "match" : "ghost"}">${focusRole ? focusRole.name : "Multi-ruolo"}</span>
+      </div>
+      <div class="detail-meta">
+        <span class="pill ghost">~${event.distanceKm} km</span>
+        <span class="pill ghost">${formatRewards(rewards)}</span>
+      </div>
+    `;
+    registerTurnButton.disabled = false;
+    registerTurnButton.dataset.eventId = event.id;
+    registerTurnButton.textContent = "Registra turno";
+    eventFeedback.dataset.state = "info";
+    eventFeedback.textContent = "Pronto a registrare questo evento.";
+    renderFocusIndicators(event);
+  }
+
+  function setEventFeedback(state: "info" | "ok" | "warn" | "error", message: string) {
+    if (!eventFeedback) return;
+    eventFeedback.dataset.state = state;
+    eventFeedback.textContent = message;
+  }
+
+  function updateFilterSummary(list: DecoratedEvent[]) {
+    if (!filterSummary) return;
+    const count = list.length;
+    const label = count === 1 ? "evento" : "eventi";
+    filterSummary.textContent = `${count} ${label} filtrati • scorciatoie: Alt+1 Eventi, Alt+2 Turni, Alt+3 Profilo`;
+  }
+
+  function getFilteredEvents(): DecoratedEvent[] {
+    const decorated = mockEvents.map((event) => ({
+      ...event,
+      distanceKm: computeDistanceKm(event.lat, event.lng),
+    })) as DecoratedEvent[];
+    return decorated
+      .filter((event) => (eventFilters.role === "all" ? true : event.focusRole === eventFilters.role))
+      .filter((event) => {
+        if (!eventFilters.date) return true;
+        const eventDate = new Date(event.date).getTime();
+        const filterDate = new Date(eventFilters.date).getTime();
+        return Number.isFinite(eventDate) && Number.isFinite(filterDate) ? eventDate <= filterDate : true;
+      })
+      .filter((event) => event.distanceKm <= eventFilters.distance)
+      .sort((a, b) => a.date.localeCompare(b.date));
+  }
+
+  function renderEventList(events: DecoratedEvent[]) {
+    if (!eventList) return;
+    if (!events.length) {
+      eventList.innerHTML = `<li class="muted">Nessun evento trovato con questi filtri.</li>`;
+      return;
+    }
+    eventList.innerHTML = events
+      .map((item) => {
+        const isSelected = item.id === selectedEventId;
+        const focusRole = item.focusRole ? resolveRole(item.focusRole) : null;
+        const isMatch = focusRole?.id === state.profile.roleId;
+        const rewards = computeTurnRewards(item, state.profile.roleId);
+        return `<li>
+          <button class="event-card${isSelected ? " active" : ""}" type="button" data-event-id="${item.id}" aria-pressed="${isSelected}">
+            <div class="event-card__header">
+              <div>
+                <strong>${item.name}</strong>
+                <p class="muted tiny">${item.theatre} • ${item.date}</p>
+              </div>
+              <span class="focus-pill ${isMatch ? "match" : "ghost"}">${focusRole ? focusRole.name : "Multi-ruolo"}</span>
+            </div>
+            <div class="event-card__meta">
+              <span class="pill ghost">~${item.distanceKm} km</span>
+              <span class="pill ghost">${formatRewards(rewards)}</span>
+            </div>
+          </button>
+        </li>`;
+      })
+      .join("");
+  }
+
+  function updateSelectedListItem() {
+    if (!eventList) return;
+    const items = Array.from(eventList.querySelectorAll<HTMLElement>("[data-event-id]"));
+    items.forEach((item) => {
+      const isActive = item.dataset.eventId === selectedEventId;
+      item.classList.toggle("active", isActive);
+      item.setAttribute("aria-pressed", String(isActive));
+    });
+  }
+
+  function focusEventOnMap(event: DecoratedEvent, openPopup = true) {
+    const marker = markerMap.get(event.id);
+    if (map && marker) {
+      map.flyTo([event.lat, event.lng], Math.max(map.getZoom(), 10));
+      if (openPopup) {
+        marker.openPopup();
       }
     }
   }
-  const role = resolveRole(profile.roleId);
-  const roleText = profile.name ? `${profile.name} (${role.name})` : "Profilo non configurato";
-  if (profileState) {
-    profileState.textContent = profile.name
-      ? `Profilo: ${roleText}`
-      : "Profilo non configurato: torna alla landing e salva un nome/ruolo.";
-  }
-  if (roleLabel) {
-    roleLabel.textContent = roleText;
-  }
-  if (chipName) {
-    chipName.textContent = profile.name || "Profilo";
-  }
-  if (chipRole) {
-    chipRole.textContent = role.name;
-  }
-  if (roleTags) {
-    roleTags.innerHTML = role.stats.map((stat) => `<span class="pill ghost">${stat}</span>`).join("");
-  }
-}
 
-function computeTurnRewards(event: DecoratedEvent, roleId: RoleId): Rewards {
-  const bonus = event.focusRole && event.focusRole === roleId ? 8 : 0;
-  return {
-    xp: event.baseRewards.xp + bonus,
-    cachet: event.baseRewards.cachet + Math.round(bonus / 2),
-    reputation: event.baseRewards.reputation + Math.round(bonus / 4),
-  };
-}
-
-function renderFocusIndicators(targetEvent?: DecoratedEvent) {
-  if (!focusHints) return;
-  const activeRole = resolveRole(state.profile.roleId);
-  const focusRole = targetEvent?.focusRole ? resolveRole(targetEvent.focusRole) : null;
-  const match = focusRole?.id === activeRole.id;
-  const focusLabel = focusRole ? focusRole.name : "Multi-ruolo";
-  focusHints.innerHTML = `
-    <span class="focus-pill active">Ruolo attivo: ${activeRole.name}</span>
-    <span class="focus-pill ${match ? "match" : "ghost"}">Focus evento: ${focusLabel}${match ? " (match)" : ""}</span>
-  `;
-}
-
-function renderEventDetail(event?: DecoratedEvent) {
-  if (!eventContent || !eventFeedback || !registerTurnButton) return;
-  if (!event) {
-    eventContent.innerHTML = `<p class="muted">Seleziona un evento per vedere i dettagli.</p>`;
-    registerTurnButton.disabled = true;
-    registerTurnButton.removeAttribute("data-event-id");
-    eventFeedback.dataset.state = "info";
-    eventFeedback.textContent = "In attesa di selezione.";
-    renderFocusIndicators();
-    return;
-  }
-  const focusRole = event.focusRole ? resolveRole(event.focusRole) : null;
-  const match = focusRole?.id === state.profile.roleId;
-  const rewards = computeTurnRewards(event, state.profile.roleId);
-  eventContent.innerHTML = `
-    <div class="detail-head">
-      <div>
-        <p class="eyebrow">${event.id}</p>
-        <h3>${event.name}</h3>
-        <p class="muted tiny">${event.theatre} • ${event.date}</p>
-      </div>
-      <span class="focus-pill ${match ? "match" : "ghost"}">${focusRole ? focusRole.name : "Multi-ruolo"}</span>
-    </div>
-    <div class="detail-meta">
-      <span class="pill ghost">~${event.distanceKm} km</span>
-      <span class="pill ghost">${formatRewards(rewards)}</span>
-    </div>
-  `;
-  registerTurnButton.disabled = false;
-  registerTurnButton.dataset.eventId = event.id;
-  registerTurnButton.textContent = "Registra turno";
-  eventFeedback.dataset.state = "info";
-  eventFeedback.textContent = "Pronto a registrare questo evento.";
-  renderFocusIndicators(event);
-}
-
-function setEventFeedback(state: "info" | "ok" | "warn" | "error", message: string) {
-  if (!eventFeedback) return;
-  eventFeedback.dataset.state = state;
-  eventFeedback.textContent = message;
-}
-
-function updateFilterSummary(list: DecoratedEvent[]) {
-  if (!filterSummary) return;
-  const count = list.length;
-  const label = count === 1 ? "evento" : "eventi";
-  filterSummary.textContent = `${count} ${label} filtrati • scorciatoie: Alt+1 Eventi, Alt+2 Turni, Alt+3 Profilo`;
-}
-
-function getFilteredEvents(): DecoratedEvent[] {
-  const decorated = mockEvents.map((event) => ({
-    ...event,
-    distanceKm: computeDistanceKm(event.lat, event.lng),
-  })) as DecoratedEvent[];
-  return decorated
-    .filter((event) => (eventFilters.role === "all" ? true : event.focusRole === eventFilters.role))
-    .filter((event) => {
-      if (!eventFilters.date) return true;
-      const eventDate = new Date(event.date).getTime();
-      const filterDate = new Date(eventFilters.date).getTime();
-      return Number.isFinite(eventDate) && Number.isFinite(filterDate) ? eventDate <= filterDate : true;
-    })
-    .filter((event) => event.distanceKm <= eventFilters.distance)
-    .sort((a, b) => a.date.localeCompare(b.date));
-}
-
-function renderEventList(events: DecoratedEvent[]) {
-  if (!eventList) return;
-  if (!events.length) {
-    eventList.innerHTML = `<li class="muted">Nessun evento trovato con questi filtri.</li>`;
-    return;
-  }
-  eventList.innerHTML = events
-    .map((item) => {
-      const isSelected = item.id === selectedEventId;
-      const focusRole = item.focusRole ? resolveRole(item.focusRole) : null;
-      const isMatch = focusRole?.id === state.profile.roleId;
-      const rewards = computeTurnRewards(item, state.profile.roleId);
-      return `<li>
-        <button class="event-card${isSelected ? " active" : ""}" type="button" data-event-id="${item.id}" aria-pressed="${isSelected}">
-          <div class="event-card__header">
-            <div>
-              <strong>${item.name}</strong>
-              <p class="muted tiny">${item.theatre} • ${item.date}</p>
-            </div>
-            <span class="focus-pill ${isMatch ? "match" : "ghost"}">${focusRole ? focusRole.name : "Multi-ruolo"}</span>
-          </div>
-          <div class="event-card__meta">
-            <span class="pill ghost">~${item.distanceKm} km</span>
-            <span class="pill ghost">${formatRewards(rewards)}</span>
-          </div>
-        </button>
-      </li>`;
-    })
-    .join("");
-}
-
-function updateSelectedListItem() {
-  if (!eventList) return;
-  const items = Array.from(eventList.querySelectorAll<HTMLElement>("[data-event-id]"));
-  items.forEach((item) => {
-    const isActive = item.dataset.eventId === selectedEventId;
-    item.classList.toggle("active", isActive);
-    item.setAttribute("aria-pressed", String(isActive));
-  });
-}
-
-function focusEventOnMap(event: DecoratedEvent, openPopup = true) {
-  const marker = markerMap.get(event.id);
-  if (map && marker) {
-    map.flyTo([event.lat, event.lng], Math.max(map.getZoom(), 10));
-    if (openPopup) {
-      marker.openPopup();
+  function selectEvent(eventId: string, focusMap = true) {
+    const target = filteredEvents.find((event) => event.id === eventId);
+    if (!target) return;
+    selectedEventId = target.id;
+    updateSelectedListItem();
+    renderEventDetail(target);
+    if (focusMap) {
+      focusEventOnMap(target);
     }
   }
-}
 
-function selectEvent(eventId: string, focusMap = true) {
-  const target = filteredEvents.find((event) => event.id === eventId);
-  if (!target) return;
-  selectedEventId = target.id;
-  updateSelectedListItem();
-  renderEventDetail(target);
-  if (focusMap) {
-    focusEventOnMap(target);
+  function renderMapMarkers(events: DecoratedEvent[]) {
+    if (!map || !markerLayer) return;
+    markerLayer.clearLayers();
+    markerMap.clear();
+    if (!events.length) return;
+    const bounds: L.LatLngExpression[] = [];
+    events.forEach((event) => {
+      const marker = L.marker([event.lat, event.lng], { icon: markerIcon }).bindPopup(
+        `<strong>${event.name}</strong><br/>${event.theatre}<br/>${event.date}<br/>Focus: ${event.focusRole ? resolveRole(event.focusRole).name : "Any"
+        }`
+      );
+      marker.on("click", () => selectEvent(event.id, false));
+      markerLayer.addLayer(marker);
+      markerMap.set(event.id, marker);
+      bounds.push([event.lat, event.lng]);
+    });
+    if (bounds.length > 1) {
+      map.fitBounds(bounds, { padding: [30, 30] });
+    } else {
+      map.setView(bounds[0] as L.LatLngExpression, 11);
+    }
+    if (selectedEventId && markerMap.has(selectedEventId)) {
+      markerMap.get(selectedEventId)?.openPopup();
+    }
   }
-}
 
-function renderMapMarkers(events: DecoratedEvent[]) {
-  if (!map || !markerLayer) return;
-  markerLayer.clearLayers();
-  markerMap.clear();
-  if (!events.length) return;
-  const bounds: L.LatLngExpression[] = [];
-  events.forEach((event) => {
-    const marker = L.marker([event.lat, event.lng], { icon: markerIcon }).bindPopup(
-      `<strong>${event.name}</strong><br/>${event.theatre}<br/>${event.date}<br/>Focus: ${event.focusRole ? resolveRole(event.focusRole).name : "Any"
-      }`
-    );
-    marker.on("click", () => selectEvent(event.id, false));
-    markerLayer.addLayer(marker);
-    markerMap.set(event.id, marker);
-    bounds.push([event.lat, event.lng]);
-  });
-  if (bounds.length > 1) {
-    map.fitBounds(bounds, { padding: [30, 30] });
-  } else {
-    map.setView(bounds[0] as L.LatLngExpression, 11);
-  }
-  if (selectedEventId && markerMap.has(selectedEventId)) {
-    markerMap.get(selectedEventId)?.openPopup();
-  }
-}
-
-function applyFilters(options?: { forceSelection?: boolean }) {
-  setEventLoading(true);
-  window.setTimeout(() => {
-    filteredEvents = getFilteredEvents();
-    if (!filteredEvents.length) {
+  function applyFilters(options?: { forceSelection?: boolean }) {
+    setEventLoading(true);
+    window.setTimeout(() => {
+      filteredEvents = getFilteredEvents();
+      if (!filteredEvents.length) {
+        renderEventList(filteredEvents);
+        renderEventDetail(undefined);
+        renderFocusIndicators();
+        renderMapMarkers(filteredEvents);
+        updateFilterSummary(filteredEvents);
+        setEventLoading(false);
+        return;
+      }
+      if (options?.forceSelection || !selectedEventId || !filteredEvents.some((event) => event.id === selectedEventId)) {
+        selectedEventId = filteredEvents[0].id;
+      }
       renderEventList(filteredEvents);
-      renderEventDetail(undefined);
-      renderFocusIndicators();
+      updateSelectedListItem();
       renderMapMarkers(filteredEvents);
+      const target = filteredEvents.find((event) => event.id === selectedEventId);
+      renderEventDetail(target);
+      if (target) {
+        focusEventOnMap(target, false);
+      }
       updateFilterSummary(filteredEvents);
       setEventLoading(false);
+    }, 120);
+  }
+
+  function renderTurns() {
+    if (!turnLog) return;
+    if (!state.turns.length) {
+      turnLog.innerHTML = `<li class="muted">Nessun turno registrato ancora.</li>`;
       return;
     }
-    if (options?.forceSelection || !selectedEventId || !filteredEvents.some((event) => event.id === selectedEventId)) {
-      selectedEventId = filteredEvents[0].id;
-    }
-    renderEventList(filteredEvents);
-    updateSelectedListItem();
-    renderMapMarkers(filteredEvents);
+    turnLog.innerHTML = state.turns
+      .slice(0, 6)
+      .map(
+        (turn) =>
+          `<li><div><strong>${turn.eventName}</strong> - ${turn.theatre} - ${turn.date}</div><div class="muted">${resolveRole(turn.roleId).name} | ${formatRewards(turn.rewards)}</div></li>`
+      )
+      .join("");
+  }
+
+  function handleRegisterTurn() {
     const target = filteredEvents.find((event) => event.id === selectedEventId);
+    if (!target) {
+      setEventFeedback("warn", "Seleziona un evento prima di registrare.");
+      return;
+    }
+    const rewards = computeTurnRewards(target, state.profile.roleId);
+    const record: TurnRecord = {
+      id: `turn-${Date.now()}`,
+      eventId: target.id,
+      eventName: target.name,
+      theatre: target.theatre,
+      date: target.date,
+      roleId: state.profile.roleId,
+      rewards,
+    };
+    state = {
+      ...state,
+      profile: {
+        ...state.profile,
+        xp: state.profile.xp + rewards.xp,
+        cachet: state.profile.cachet + rewards.cachet,
+        repAtcl: state.profile.repAtcl + rewards.reputation,
+      },
+      turns: [record, ...state.turns].slice(0, MAX_STORED_TURNS),
+    };
+    const saveResult = persistState(state, eventFeedback);
+    renderProfile();
+    renderTurns();
     renderEventDetail(target);
-    if (target) {
-      focusEventOnMap(target, false);
+    setEventFeedback(
+      saveResult.ok ? "ok" : "warn",
+      `${saveResult.ok ? "Turno registrato" : "Turno registrato (solo memoria)"}: ${target.name} (${formatRewards(rewards)})`
+    );
+  }
+
+  function initMap() {
+    if (!mapContainer || map) return;
+    map = L.map(mapContainer, { zoomControl: true }).setView(defaultCenter, 7);
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      maxZoom: 19,
+      attribution: "OpenStreetMap contributors",
+    }).addTo(map);
+    markerLayer = L.layerGroup().addTo(map);
+  }
+
+  function setDrawer(sectionId: DrawerSection) {
+    drawerTabs.forEach((tab) => {
+      const isActive = tab.dataset.drawerTab === sectionId;
+      tab.classList.toggle("active", isActive);
+      tab.dataset.state = isActive ? "active" : "default";
+      tab.setAttribute("aria-selected", String(isActive));
+      tab.tabIndex = isActive ? 0 : -1;
+    });
+    drawerSections.forEach((section) => {
+      const isActive = section.dataset.section === sectionId;
+      section.classList.toggle("active", isActive);
+      section.toggleAttribute("hidden", !isActive);
+      section.setAttribute("aria-hidden", String(!isActive));
+    });
+  }
+
+  function setupTabsAccessibility() {
+    drawerTabs.forEach((tab) => {
+      tab.setAttribute("role", "tab");
+      const tabId = tab.dataset.tabId;
+      if (tabId) {
+        tab.id = tabId;
+      }
+      const section = drawerSections.find((panel) => panel.dataset.section === tab.dataset.drawerTab);
+      if (section) {
+        const sectionId = section.id || `panel-${tab.dataset.drawerTab}`;
+        section.id = sectionId;
+        tab.setAttribute("aria-controls", sectionId);
+        section.setAttribute("aria-labelledby", tab.id);
+      }
+    });
+    drawerSections.forEach((section) => {
+      section.setAttribute("role", "tabpanel");
+    });
+    if (drawerTablist) {
+      drawerTablist.setAttribute("role", "tablist");
+      drawerTablist.setAttribute("aria-orientation", "horizontal");
     }
-    updateFilterSummary(filteredEvents);
-    setEventLoading(false);
-  }, 120);
-}
-
-function renderTurns() {
-  if (!turnLog) return;
-  if (!state.turns.length) {
-    turnLog.innerHTML = `<li class="muted">Nessun turno registrato ancora.</li>`;
-    return;
   }
-  turnLog.innerHTML = state.turns
-    .slice(0, 6)
-    .map(
-      (turn) =>
-        `<li><div><strong>${turn.eventName}</strong> - ${turn.theatre} - ${turn.date}</div><div class="muted">${resolveRole(turn.roleId).name} | ${formatRewards(turn.rewards)}</div></li>`
-    )
-    .join("");
-}
 
-function handleRegisterTurn() {
-  const target = filteredEvents.find((event) => event.id === selectedEventId);
-  if (!target) {
-    setEventFeedback("warn", "Seleziona un evento prima di registrare.");
-    return;
-  }
-  const rewards = computeTurnRewards(target, state.profile.roleId);
-  const record: TurnRecord = {
-    id: `turn-${Date.now()}`,
-    eventId: target.id,
-    eventName: target.name,
-    theatre: target.theatre,
-    date: target.date,
-    roleId: state.profile.roleId,
-    rewards,
-  };
-  state = {
-    ...state,
-    profile: {
-      ...state.profile,
-      xp: state.profile.xp + rewards.xp,
-      cachet: state.profile.cachet + rewards.cachet,
-      repAtcl: state.profile.repAtcl + rewards.reputation,
-    },
-    turns: [record, ...state.turns].slice(0, MAX_STORED_TURNS),
-  };
-  const saveResult = persistState(state, eventFeedback);
-  renderProfile();
-  renderTurns();
-  renderEventDetail(target);
-  setEventFeedback(
-    saveResult.ok ? "ok" : "warn",
-    `${saveResult.ok ? "Turno registrato" : "Turno registrato (solo memoria)"}: ${target.name} (${formatRewards(rewards)})`
-  );
-}
-
-function initMap() {
-  if (!mapContainer || map) return;
-  map = L.map(mapContainer, { zoomControl: true }).setView(defaultCenter, 7);
-  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-    maxZoom: 19,
-    attribution: "OpenStreetMap contributors",
-  }).addTo(map);
-  markerLayer = L.layerGroup().addTo(map);
-}
-
-function setDrawer(sectionId: DrawerSection) {
-  drawerTabs.forEach((tab) => {
-    const isActive = tab.dataset.drawerTab === sectionId;
-    tab.classList.toggle("active", isActive);
-    tab.dataset.state = isActive ? "active" : "default";
-    tab.setAttribute("aria-selected", String(isActive));
-    tab.tabIndex = isActive ? 0 : -1;
-  });
-  drawerSections.forEach((section) => {
-    const isActive = section.dataset.section === sectionId;
-    section.classList.toggle("active", isActive);
-    section.toggleAttribute("hidden", !isActive);
-    section.setAttribute("aria-hidden", String(!isActive));
-  });
-}
-
-function setupTabsAccessibility() {
-  drawerTabs.forEach((tab) => {
-    tab.setAttribute("role", "tab");
-    const tabId = tab.dataset.tabId;
-    if (tabId) {
-      tab.id = tabId;
-    }
-    const section = drawerSections.find((panel) => panel.dataset.section === tab.dataset.drawerTab);
-    if (section) {
-      const sectionId = section.id || `panel-${tab.dataset.drawerTab}`;
-      section.id = sectionId;
-      tab.setAttribute("aria-controls", sectionId);
-      section.setAttribute("aria-labelledby", tab.id);
-    }
-  });
-  drawerSections.forEach((section) => {
-    section.setAttribute("role", "tabpanel");
-  });
-  if (drawerTablist) {
-    drawerTablist.setAttribute("role", "tablist");
-    drawerTablist.setAttribute("aria-orientation", "horizontal");
-  }
-}
-
-function focusTab(direction: 1 | -1) {
-  const currentIndex = drawerTabs.findIndex((tab) => tab.dataset.state === "active");
-  const nextIndex = (currentIndex + direction + drawerTabs.length) % drawerTabs.length;
-  const nextTab = drawerTabs[nextIndex];
-  const target = nextTab?.dataset.drawerTab as DrawerSection | undefined;
-  if (target) {
-    setDrawer(target);
-    nextTab.focus();
-  }
-}
-
-function handleTabKeydown(event: KeyboardEvent) {
-  if (event.key === "ArrowRight") {
-    event.preventDefault();
-    focusTab(1);
-  }
-  if (event.key === "ArrowLeft") {
-    event.preventDefault();
-    focusTab(-1);
-  }
-  if (event.key === "Home") {
-    event.preventDefault();
-    const first = drawerTabs[0];
-    const target = first?.dataset.drawerTab as DrawerSection | undefined;
+  function focusTab(direction: 1 | -1) {
+    const currentIndex = drawerTabs.findIndex((tab) => tab.dataset.state === "active");
+    const nextIndex = (currentIndex + direction + drawerTabs.length) % drawerTabs.length;
+    const nextTab = drawerTabs[nextIndex];
+    const target = nextTab?.dataset.drawerTab as DrawerSection | undefined;
     if (target) {
       setDrawer(target);
-      first.focus();
+      nextTab.focus();
     }
   }
-  if (event.key === "End") {
-    event.preventDefault();
-    const last = drawerTabs[drawerTabs.length - 1];
-    const target = last?.dataset.drawerTab as DrawerSection | undefined;
-    if (target) {
-      setDrawer(target);
-      last.focus();
+
+  function handleTabKeydown(event: KeyboardEvent) {
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      focusTab(1);
+    }
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      focusTab(-1);
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      const first = drawerTabs[0];
+      const target = first?.dataset.drawerTab as DrawerSection | undefined;
+      if (target) {
+        setDrawer(target);
+        first.focus();
+      }
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      const last = drawerTabs[drawerTabs.length - 1];
+      const target = last?.dataset.drawerTab as DrawerSection | undefined;
+      if (target) {
+        setDrawer(target);
+        last.focus();
+      }
     }
   }
-}
 
-function handleTabShortcut(section: DrawerSection) {
-  setDrawer(section);
-  const targetTab = drawerTabs.find((tab) => tab.dataset.drawerTab === section);
-  targetTab?.focus();
-}
-
-function applyQuick(rewards: Rewards, label: string) {
-  state = {
-    ...state,
-    profile: {
-      ...state.profile,
-      xp: state.profile.xp + rewards.xp,
-      cachet: state.profile.cachet + rewards.cachet,
-      repAtcl: state.profile.repAtcl + rewards.reputation,
-    },
-  };
-  const result = persistState(state, quickResult || profileState);
-  renderProfile();
-  if (quickResult) {
-    quickResult.dataset.state = result.ok ? "ok" : "warn";
-    quickResult.textContent = result.ok ? `${label}: ${formatRewards(rewards)}` : `${label}: salvato solo in memoria.`;
+  function handleTabShortcut(section: DrawerSection) {
+    setDrawer(section);
+    const targetTab = drawerTabs.find((tab) => tab.dataset.drawerTab === section);
+    targetTab?.focus();
   }
-}
 
-function handleQuick(action: "train" | "scene" | "audio") {
-  const role = resolveRole(state.profile.roleId);
-  if (action === "train") {
-    applyQuick({ xp: 12, cachet: 6, reputation: 4 }, "Allenamento completato");
-  } else if (action === "scene") {
-    const bonus = role.id === "attrezzista" || role.id === "palco" ? 4 : 0;
-    applyQuick({ xp: 10 + bonus, cachet: 8, reputation: 6 }, "Gestione scena");
-  } else {
-    const bonus = role.id === "fonico" ? 5 : 0;
-    applyQuick({ xp: 9 + bonus, cachet: 7, reputation: 5 }, "Check audio");
+  function applyQuick(rewards: Rewards, label: string) {
+    state = {
+      ...state,
+      profile: {
+        ...state.profile,
+        xp: state.profile.xp + rewards.xp,
+        cachet: state.profile.cachet + rewards.cachet,
+        repAtcl: state.profile.repAtcl + rewards.reputation,
+      },
+    };
+    const result = persistState(state, quickResult || profileState);
+    renderProfile();
+    if (quickResult) {
+      quickResult.dataset.state = result.ok ? "ok" : "warn";
+      quickResult.textContent = result.ok ? `${label}: ${formatRewards(rewards)}` : `${label}: salvato solo in memoria.`;
+    }
   }
-}
 
-renderProfile();
-renderTurns();
-initMap();
-setupTabsAccessibility();
-updateDistanceLabel(eventFilters.distance);
-applyFilters({ forceSelection: true });
-setDrawer("events");
-updateViewportNote();
+  function handleQuick(action: "train" | "scene" | "audio") {
+    const role = resolveRole(state.profile.roleId);
+    if (action === "train") {
+      applyQuick({ xp: 12, cachet: 6, reputation: 4 }, "Allenamento completato");
+    } else if (action === "scene") {
+      const bonus = role.id === "attrezzista" || role.id === "palco" ? 4 : 0;
+      applyQuick({ xp: 10 + bonus, cachet: 8, reputation: 6 }, "Gestione scena");
+    } else {
+      const bonus = role.id === "fonico" ? 5 : 0;
+      applyQuick({ xp: 9 + bonus, cachet: 7, reputation: 5 }, "Check audio");
+    }
+  }
 
-root.querySelector<HTMLButtonElement>('[data-action="sync-state"]')?.addEventListener("click", () => {
-  state = loadState();
   renderProfile();
   renderTurns();
+  initMap();
+  setupTabsAccessibility();
+  updateDistanceLabel(eventFilters.distance);
   applyFilters({ forceSelection: true });
-  setEventFeedback("info", "Stato ricaricato dal profilo principale.");
-  if (quickResult) {
-    quickResult.dataset.state = "info";
-    quickResult.textContent = "Stato ricaricato dal profilo principale.";
-  }
-  showSyncBadge("Stato aggiornato");
-});
-
-root.querySelector<HTMLButtonElement>('[data-action="quick-train"]')?.addEventListener("click", () => {
-  handleQuick("train");
-  renderMapMarkers(filteredEvents);
-});
-
-root.querySelector<HTMLButtonElement>('[data-action="quick-scene"]')?.addEventListener("click", () => {
-  handleQuick("scene");
-  renderMapMarkers(filteredEvents);
-});
-
-root.querySelector<HTMLButtonElement>('[data-action="quick-audio"]')?.addEventListener("click", () => {
-  handleQuick("audio");
-  renderMapMarkers(filteredEvents);
-});
-
-drawerTabs.forEach((tab) => {
-  tab.addEventListener("click", () => {
-    const target = tab.dataset.drawerTab as DrawerSection | undefined;
-    if (target) handleTabShortcut(target);
-  });
-});
-
-drawerTablist?.addEventListener("keydown", handleTabKeydown);
-
-filterRoleSelect?.addEventListener("change", () => {
-  const value = filterRoleSelect.value as RoleId | "all";
-  eventFilters.role = value;
-  applyFilters({ forceSelection: true });
-});
-
-filterDateInput?.addEventListener("change", () => {
-  eventFilters.date = filterDateInput.value;
-  applyFilters();
-});
-
-filterDistanceInput?.addEventListener("input", () => {
-  const nextValue = Number(filterDistanceInput.value) || DEFAULT_DISTANCE_KM;
-  eventFilters.distance = nextValue;
-  updateDistanceLabel(nextValue);
-  applyFilters();
-});
-
-eventList?.addEventListener("click", (event) => {
-  const target = (event.target as HTMLElement | null)?.closest<HTMLButtonElement>("[data-event-id]");
-  if (!target) return;
-  const eventId = target.dataset.eventId;
-  if (eventId) {
-    selectEvent(eventId);
-  }
-});
-
-registerTurnButton?.addEventListener("click", handleRegisterTurn);
-
-window.addEventListener("keydown", (event) => {
-  const targetTag = (event.target as HTMLElement | null)?.tagName;
-  if (targetTag && ["INPUT", "TEXTAREA", "SELECT"].includes(targetTag)) return;
-  if (event.altKey && !event.ctrlKey && !event.metaKey) {
-    if (event.key === "1") {
-      event.preventDefault();
-      handleTabShortcut("events");
-    }
-    if (event.key === "2") {
-      event.preventDefault();
-      handleTabShortcut("turns");
-    }
-    if (event.key === "3") {
-      event.preventDefault();
-      handleTabShortcut("profile");
-    }
-  }
-});
-
-window.setTimeout(() => {
-  map?.invalidateSize();
-}, 200);
-window.addEventListener("resize", () => {
-  map?.invalidateSize();
+  setDrawer("events");
   updateViewportNote();
-});
 
-window.addEventListener("storage", (event) => {
-  if (event.key !== STORAGE_KEY) return;
-  state = loadState();
-  renderProfile();
-  renderTurns();
-  applyFilters({ forceSelection: true });
-  showSyncBadge();
-  setEventFeedback("info", "Sincronizzato da un'altra scheda.");
-  if (quickResult) {
-    quickResult.dataset.state = "info";
-    quickResult.textContent = "Sincronizzato da un'altra scheda.";
-  }
-});
+  root.querySelector<HTMLButtonElement>('[data-action="sync-state"]')?.addEventListener("click", () => {
+    state = loadState();
+    renderProfile();
+    renderTurns();
+    applyFilters({ forceSelection: true });
+    setEventFeedback("info", "Stato ricaricato dal profilo principale.");
+    if (quickResult) {
+      quickResult.dataset.state = "info";
+      quickResult.textContent = "Stato ricaricato dal profilo principale.";
+    }
+    showSyncBadge("Stato aggiornato");
+  });
 
-registerServiceWorker({
-  onReady: () => undefined,
-  onUpdate: (registration) => {
-    promptServiceWorkerUpdate(registration);
-  },
-  onError: (error) => {
-    console.error("Service worker registration failed", error);
-  },
-});
+  root.querySelector<HTMLButtonElement>('[data-action="quick-train"]')?.addEventListener("click", () => {
+    handleQuick("train");
+    renderMapMarkers(filteredEvents);
+  });
+
+  root.querySelector<HTMLButtonElement>('[data-action="quick-scene"]')?.addEventListener("click", () => {
+    handleQuick("scene");
+    renderMapMarkers(filteredEvents);
+  });
+
+  root.querySelector<HTMLButtonElement>('[data-action="quick-audio"]')?.addEventListener("click", () => {
+    handleQuick("audio");
+    renderMapMarkers(filteredEvents);
+  });
+
+  drawerTabs.forEach((tab) => {
+    tab.addEventListener("click", () => {
+      const target = tab.dataset.drawerTab as DrawerSection | undefined;
+      if (target) handleTabShortcut(target);
+    });
+  });
+
+  drawerTablist?.addEventListener("keydown", handleTabKeydown);
+
+  filterRoleSelect?.addEventListener("change", () => {
+    const value = filterRoleSelect.value as RoleId | "all";
+    eventFilters.role = value;
+    applyFilters({ forceSelection: true });
+  });
+
+  filterDateInput?.addEventListener("change", () => {
+    eventFilters.date = filterDateInput.value;
+    applyFilters();
+  });
+
+  filterDistanceInput?.addEventListener("input", () => {
+    const nextValue = Number(filterDistanceInput.value) || DEFAULT_DISTANCE_KM;
+    eventFilters.distance = nextValue;
+    updateDistanceLabel(nextValue);
+    applyFilters();
+  });
+
+  eventList?.addEventListener("click", (event) => {
+    const target = (event.target as HTMLElement | null)?.closest<HTMLButtonElement>("[data-event-id]");
+    if (!target) return;
+    const eventId = target.dataset.eventId;
+    if (eventId) {
+      selectEvent(eventId);
+    }
+  });
+
+  registerTurnButton?.addEventListener("click", handleRegisterTurn);
+
+  window.addEventListener("keydown", (event) => {
+    const targetTag = (event.target as HTMLElement | null)?.tagName;
+    if (targetTag && ["INPUT", "TEXTAREA", "SELECT"].includes(targetTag)) return;
+    if (event.altKey && !event.ctrlKey && !event.metaKey) {
+      if (event.key === "1") {
+        event.preventDefault();
+        handleTabShortcut("events");
+      }
+      if (event.key === "2") {
+        event.preventDefault();
+        handleTabShortcut("turns");
+      }
+      if (event.key === "3") {
+        event.preventDefault();
+        handleTabShortcut("profile");
+      }
+    }
+  });
+
+  window.setTimeout(() => {
+    map?.invalidateSize();
+  }, 200);
+  window.addEventListener("resize", () => {
+    map?.invalidateSize();
+    updateViewportNote();
+  });
+
+  window.addEventListener("storage", (event) => {
+    if (event.key !== STORAGE_KEY) return;
+    state = loadState();
+    renderProfile();
+    renderTurns();
+    applyFilters({ forceSelection: true });
+    showSyncBadge();
+    setEventFeedback("info", "Sincronizzato da un'altra scheda.");
+    if (quickResult) {
+      quickResult.dataset.state = "info";
+      quickResult.textContent = "Sincronizzato da un'altra scheda.";
+    }
+  });
+
+  registerServiceWorker({
+    onReady: () => undefined,
+    onUpdate: (registration) => {
+      promptServiceWorkerUpdate(registration);
+    },
+    onError: (error) => {
+      console.error("Service worker registration failed", error);
+    },
+  });
+};
+
+void start();

--- a/apps/pwa/src/profile.ts
+++ b/apps/pwa/src/profile.ts
@@ -2,231 +2,239 @@ import "../../../shared/styles/main.css";
 import { renderPageHero } from "./components/page-hero";
 import { buildProgressCopy, getEarnedMilestones, getProgressState, repMilestones, xpMilestones } from "./progression";
 import { formatRewards, getAvatarVisual, loadState, resolveRole, STORAGE_KEY } from "./state";
+import { requireDevAccess } from "./services/dev-gate";
 
-const root = document.querySelector<HTMLDivElement>("#app");
+const start = async () => {
+  if (!(await requireDevAccess())) return;
 
-if (!root) {
-  throw new Error("Root container missing");
-}
 
-const pageHero = renderPageHero({
-  title: "Profilo",
-  description: "Stato giocatore, avatar e riepilogo recente.",
-  currentPage: "profile",
-  breadcrumbs: [
-    { label: "Hub", href: "/game.html" },
-    { label: "Profilo" },
-  ],
-  backHref: "/game.html",
-  backLabel: "Torna all'hub",
-});
+  const root = document.querySelector<HTMLDivElement>("#app");
 
-root.innerHTML = `
-  <main class="page page-game layout-shell">
-    ${pageHero}
-
-    <section class="grid layout-grid">
-      <article class="card layout-span-2">
-        <h2>Stato giocatore</h2>
-        <div class="profile-pane">
-          <div class="avatar-display large" data-avatar="profile">
-            <img data-avatar-img alt="Avatar ReadyPlayerMe" />
-            <span class="avatar-icon" data-avatar-label></span>
-          </div>
-          <div>
-            <p class="eyebrow">Profilo</p>
-            <h3 data-player-name>Profilo non configurato</h3>
-            <p class="muted" data-player-role>Ruolo non impostato</p>
-            <div class="pill-row" data-role-tags></div>
-          </div>
-        </div>
-        <div class="stat-board">
-          <div class="stat-chip"><span>XP</span><strong data-stat="xp">0</strong></div>
-          <div class="stat-chip"><span>Cachet</span><strong data-stat="cachet">0</strong></div>
-          <div class="stat-chip"><span>Rep</span><strong data-stat="rep">0</strong></div>
-        </div>
-        <div class="progress-grid">
-          <div class="progress-track" data-track="xp">
-            <div class="progress-head">
-              <div>
-                <p class="eyebrow">Percorso XP</p>
-                <p class="muted" data-progress-copy="xp">Accumula esperienza nei turni registrati.</p>
-              </div>
-              <strong data-progress-value="xp">0 XP</strong>
-            </div>
-            <div class="progress-bar" role="progressbar" aria-label="Progresso XP" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-              <span class="progress-fill" data-progress-bar="xp" style="width: 0%"></span>
-            </div>
-          </div>
-          <div class="progress-track" data-track="rep">
-            <div class="progress-head">
-              <div>
-                <p class="eyebrow">Reputazione</p>
-                <p class="muted" data-progress-copy="rep">Fa crescere la reputazione ATCL per sbloccare badge.</p>
-              </div>
-              <strong data-progress-value="rep">0 rep</strong>
-            </div>
-            <div class="progress-bar" role="progressbar" aria-label="Progresso reputazione" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-              <span class="progress-fill accent" data-progress-bar="rep" style="width: 0%"></span>
-            </div>
-          </div>
-        </div>
-        <div class="badge-panel">
-          <p class="eyebrow">Badge sbloccati</p>
-          <div class="badge-grid" data-badge-list></div>
-          <p class="muted" data-badge-note>Completa milestone XP o reputazione per guadagnare badge.</p>
-        </div>
-      </article>
-
-      <article class="card">
-        <h2>Ultimi turni</h2>
-        <ul class="log-list" data-turn-log></ul>
-      </article>
-    </section>
-  </main>
-`;
-
-const avatarDisplay = root.querySelector<HTMLElement>('[data-avatar="profile"]');
-const avatarLabel = root.querySelector<HTMLElement>('[data-avatar-label]');
-const avatarImg = root.querySelector<HTMLImageElement>('[data-avatar-img]');
-const nameNode = root.querySelector<HTMLElement>("[data-player-name]");
-const roleNode = root.querySelector<HTMLElement>("[data-player-role]");
-const roleTags = root.querySelector<HTMLElement>("[data-role-tags]");
-const statXp = root.querySelector<HTMLElement>('[data-stat="xp"]');
-const statCachet = root.querySelector<HTMLElement>('[data-stat="cachet"]');
-const statRep = root.querySelector<HTMLElement>('[data-stat="rep"]');
-const progressCopyXp = root.querySelector<HTMLElement>('[data-progress-copy="xp"]');
-const progressCopyRep = root.querySelector<HTMLElement>('[data-progress-copy="rep"]');
-const progressValueXp = root.querySelector<HTMLElement>('[data-progress-value="xp"]');
-const progressValueRep = root.querySelector<HTMLElement>('[data-progress-value="rep"]');
-const progressBarXp = root.querySelector<HTMLElement>('[data-progress-bar="xp"]');
-const progressBarRep = root.querySelector<HTMLElement>('[data-progress-bar="rep"]');
-const badgeList = root.querySelector<HTMLElement>('[data-badge-list]');
-const badgeNote = root.querySelector<HTMLElement>('[data-badge-note]');
-const turnLog = root.querySelector<HTMLElement>('[data-turn-log]');
-const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
-
-let state = loadState();
-let syncBadgeTimeout: number | undefined;
-
-function showSyncBadge(message = "Stato aggiornato") {
-  if (!syncBadge) return;
-  syncBadge.textContent = message;
-  syncBadge.style.display = "inline-flex";
-  if (syncBadgeTimeout) {
-    window.clearTimeout(syncBadgeTimeout);
-  }
-  syncBadgeTimeout = window.setTimeout(() => {
-    if (syncBadge) syncBadge.style.display = "none";
-  }, 2500);
-}
-
-function renderProfile() {
-  const avatarVisual = getAvatarVisual(state.profile.avatar);
-  if (avatarDisplay) {
-    avatarDisplay.style.setProperty("--avatar-color", avatarVisual.color);
-    avatarDisplay.style.setProperty("--avatar-hue", `${state.profile.avatar.hue}deg`);
-    avatarDisplay.classList.toggle("has-image", !!avatarVisual.image);
-  }
-  if (avatarImg) {
-    if (avatarVisual.image) {
-      avatarImg.src = avatarVisual.image;
-      avatarImg.style.display = "block";
-    } else {
-      avatarImg.removeAttribute("src");
-      avatarImg.style.display = "none";
-    }
-  }
-  if (avatarLabel) {
-    avatarLabel.textContent = avatarVisual.icon;
+  if (!root) {
+    throw new Error("Root container missing");
   }
 
-  if (nameNode) {
-    nameNode.textContent = state.profile.name || "Profilo non configurato";
-  }
-  const role = resolveRole(state.profile.roleId);
-  if (roleNode) {
-    roleNode.textContent = `${role.name} - Focus: ${role.focus}`;
-  }
-  if (roleTags) {
-    roleTags.innerHTML = role.stats.map((stat) => `<span class="pill ghost">${stat}</span>`).join("");
-  }
-  if (statXp) statXp.textContent = state.profile.xp.toString();
-  if (statCachet) statCachet.textContent = state.profile.cachet.toString();
-  if (statRep) statRep.textContent = state.profile.repAtcl.toString();
-
-  if (turnLog) {
-    if (!state.turns.length) {
-      turnLog.innerHTML = `<li class="muted">Nessun turno registrato.</li>`;
-    } else {
-      turnLog.innerHTML = state.turns
-        .slice(0, 8)
-        .map(
-          (turn) =>
-            `<li><div><strong>${turn.eventName}</strong> - ${turn.theatre} - ${turn.date}</div><div class="muted">${resolveRole(turn.roleId).name} | ${formatRewards(turn.rewards)}</div></li>`
-        )
-        .join("");
-    }
-  }
-}
-
-renderProfile();
-
-function renderProgressAndBadges() {
-  const xpProgress = getProgressState(state.profile.xp, xpMilestones);
-  const repProgress = getProgressState(state.profile.repAtcl, repMilestones);
-
-  if (progressValueXp) progressValueXp.textContent = `${state.profile.xp} XP`;
-  if (progressValueRep) progressValueRep.textContent = `${state.profile.repAtcl} rep`;
-  if (progressCopyXp) progressCopyXp.textContent = buildProgressCopy(xpProgress, "XP");
-  if (progressCopyRep) progressCopyRep.textContent = buildProgressCopy(repProgress, "punti rep");
-
-  if (progressBarXp) {
-    progressBarXp.style.width = `${xpProgress.percent}%`;
-    progressBarXp.parentElement?.setAttribute("aria-valuenow", xpProgress.percent.toString());
-  }
-  if (progressBarRep) {
-    progressBarRep.style.width = `${repProgress.percent}%`;
-    progressBarRep.parentElement?.setAttribute("aria-valuenow", repProgress.percent.toString());
-  }
-
-  const earnedXp = getEarnedMilestones(state.profile.xp, xpMilestones);
-  const earnedRep = getEarnedMilestones(state.profile.repAtcl, repMilestones);
-  const seen = new Set<string>();
-  const repIds = new Set(repMilestones.map((item) => item.id));
-  const badges = [...earnedXp, ...earnedRep].filter((badge) => {
-    if (seen.has(badge.id)) return false;
-    seen.add(badge.id);
-    return true;
+  const pageHero = renderPageHero({
+    title: "Profilo",
+    description: "Stato giocatore, avatar e riepilogo recente.",
+    currentPage: "profile",
+    breadcrumbs: [
+      { label: "Hub", href: "/game.html" },
+      { label: "Profilo" },
+    ],
+    backHref: "/game.html",
+    backLabel: "Torna all'hub",
   });
 
-  if (badgeList) {
-    badgeList.innerHTML = badges.length
-      ? badges
+  root.innerHTML = `
+    <main class="page page-game layout-shell">
+      ${pageHero}
+
+      <section class="grid layout-grid">
+        <article class="card layout-span-2">
+          <h2>Stato giocatore</h2>
+          <div class="profile-pane">
+            <div class="avatar-display large" data-avatar="profile">
+              <img data-avatar-img alt="Avatar ReadyPlayerMe" />
+              <span class="avatar-icon" data-avatar-label></span>
+            </div>
+            <div>
+              <p class="eyebrow">Profilo</p>
+              <h3 data-player-name>Profilo non configurato</h3>
+              <p class="muted" data-player-role>Ruolo non impostato</p>
+              <div class="pill-row" data-role-tags></div>
+            </div>
+          </div>
+          <div class="stat-board">
+            <div class="stat-chip"><span>XP</span><strong data-stat="xp">0</strong></div>
+            <div class="stat-chip"><span>Cachet</span><strong data-stat="cachet">0</strong></div>
+            <div class="stat-chip"><span>Rep</span><strong data-stat="rep">0</strong></div>
+          </div>
+          <div class="progress-grid">
+            <div class="progress-track" data-track="xp">
+              <div class="progress-head">
+                <div>
+                  <p class="eyebrow">Percorso XP</p>
+                  <p class="muted" data-progress-copy="xp">Accumula esperienza nei turni registrati.</p>
+                </div>
+                <strong data-progress-value="xp">0 XP</strong>
+              </div>
+              <div class="progress-bar" role="progressbar" aria-label="Progresso XP" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                <span class="progress-fill" data-progress-bar="xp" style="width: 0%"></span>
+              </div>
+            </div>
+            <div class="progress-track" data-track="rep">
+              <div class="progress-head">
+                <div>
+                  <p class="eyebrow">Reputazione</p>
+                  <p class="muted" data-progress-copy="rep">Fa crescere la reputazione ATCL per sbloccare badge.</p>
+                </div>
+                <strong data-progress-value="rep">0 rep</strong>
+              </div>
+              <div class="progress-bar" role="progressbar" aria-label="Progresso reputazione" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                <span class="progress-fill accent" data-progress-bar="rep" style="width: 0%"></span>
+              </div>
+            </div>
+          </div>
+          <div class="badge-panel">
+            <p class="eyebrow">Badge sbloccati</p>
+            <div class="badge-grid" data-badge-list></div>
+            <p class="muted" data-badge-note>Completa milestone XP o reputazione per guadagnare badge.</p>
+          </div>
+        </article>
+
+        <article class="card">
+          <h2>Ultimi turni</h2>
+          <ul class="log-list" data-turn-log></ul>
+        </article>
+      </section>
+    </main>
+  `;
+
+  const avatarDisplay = root.querySelector<HTMLElement>('[data-avatar="profile"]');
+  const avatarLabel = root.querySelector<HTMLElement>('[data-avatar-label]');
+  const avatarImg = root.querySelector<HTMLImageElement>('[data-avatar-img]');
+  const nameNode = root.querySelector<HTMLElement>("[data-player-name]");
+  const roleNode = root.querySelector<HTMLElement>("[data-player-role]");
+  const roleTags = root.querySelector<HTMLElement>("[data-role-tags]");
+  const statXp = root.querySelector<HTMLElement>('[data-stat="xp"]');
+  const statCachet = root.querySelector<HTMLElement>('[data-stat="cachet"]');
+  const statRep = root.querySelector<HTMLElement>('[data-stat="rep"]');
+  const progressCopyXp = root.querySelector<HTMLElement>('[data-progress-copy="xp"]');
+  const progressCopyRep = root.querySelector<HTMLElement>('[data-progress-copy="rep"]');
+  const progressValueXp = root.querySelector<HTMLElement>('[data-progress-value="xp"]');
+  const progressValueRep = root.querySelector<HTMLElement>('[data-progress-value="rep"]');
+  const progressBarXp = root.querySelector<HTMLElement>('[data-progress-bar="xp"]');
+  const progressBarRep = root.querySelector<HTMLElement>('[data-progress-bar="rep"]');
+  const badgeList = root.querySelector<HTMLElement>('[data-badge-list]');
+  const badgeNote = root.querySelector<HTMLElement>('[data-badge-note]');
+  const turnLog = root.querySelector<HTMLElement>('[data-turn-log]');
+  const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
+
+  let state = loadState();
+  let syncBadgeTimeout: number | undefined;
+
+  function showSyncBadge(message = "Stato aggiornato") {
+    if (!syncBadge) return;
+    syncBadge.textContent = message;
+    syncBadge.style.display = "inline-flex";
+    if (syncBadgeTimeout) {
+      window.clearTimeout(syncBadgeTimeout);
+    }
+    syncBadgeTimeout = window.setTimeout(() => {
+      if (syncBadge) syncBadge.style.display = "none";
+    }, 2500);
+  }
+
+  function renderProfile() {
+    const avatarVisual = getAvatarVisual(state.profile.avatar);
+    if (avatarDisplay) {
+      avatarDisplay.style.setProperty("--avatar-color", avatarVisual.color);
+      avatarDisplay.style.setProperty("--avatar-hue", `${state.profile.avatar.hue}deg`);
+      avatarDisplay.classList.toggle("has-image", !!avatarVisual.image);
+    }
+    if (avatarImg) {
+      if (avatarVisual.image) {
+        avatarImg.src = avatarVisual.image;
+        avatarImg.style.display = "block";
+      } else {
+        avatarImg.removeAttribute("src");
+        avatarImg.style.display = "none";
+      }
+    }
+    if (avatarLabel) {
+      avatarLabel.textContent = avatarVisual.icon;
+    }
+
+    if (nameNode) {
+      nameNode.textContent = state.profile.name || "Profilo non configurato";
+    }
+    const role = resolveRole(state.profile.roleId);
+    if (roleNode) {
+      roleNode.textContent = `${role.name} - Focus: ${role.focus}`;
+    }
+    if (roleTags) {
+      roleTags.innerHTML = role.stats.map((stat) => `<span class="pill ghost">${stat}</span>`).join("");
+    }
+    if (statXp) statXp.textContent = state.profile.xp.toString();
+    if (statCachet) statCachet.textContent = state.profile.cachet.toString();
+    if (statRep) statRep.textContent = state.profile.repAtcl.toString();
+
+    if (turnLog) {
+      if (!state.turns.length) {
+        turnLog.innerHTML = `<li class="muted">Nessun turno registrato.</li>`;
+      } else {
+        turnLog.innerHTML = state.turns
+          .slice(0, 8)
           .map(
-            (badge) =>
-              `<span class="badge-chip">${badge.label}<small>${badge.target}${repIds.has(badge.id) ? " rep" : " XP"}</small></span>`
+            (turn) =>
+              `<li><div><strong>${turn.eventName}</strong> - ${turn.theatre} - ${turn.date}</div><div class="muted">${resolveRole(turn.roleId).name} | ${formatRewards(turn.rewards)}</div></li>`
           )
-          .join("")
-      : '<span class="badge-chip ghost">Ancora nessun badge: completa milestone XP/rep.</span>';
+          .join("");
+      }
+    }
   }
 
-  if (badgeNote) {
-    const nextTarget = xpProgress.remaining > 0 ? { progress: xpProgress, unit: "XP" } : { progress: repProgress, unit: "punti" };
-    const nextCopy =
-      xpProgress.remaining <= 0 && repProgress.remaining <= 0
-        ? "Tieni traccia dei nuovi turni per ampliare il medagliere."
-        : buildProgressCopy(nextTarget.progress, nextTarget.unit);
-    badgeNote.textContent = nextCopy;
-  }
-}
-
-renderProgressAndBadges();
-
-window.addEventListener("storage", (event) => {
-  if (event.key !== STORAGE_KEY) return;
-  state = loadState();
   renderProfile();
+
+  function renderProgressAndBadges() {
+    const xpProgress = getProgressState(state.profile.xp, xpMilestones);
+    const repProgress = getProgressState(state.profile.repAtcl, repMilestones);
+
+    if (progressValueXp) progressValueXp.textContent = `${state.profile.xp} XP`;
+    if (progressValueRep) progressValueRep.textContent = `${state.profile.repAtcl} rep`;
+    if (progressCopyXp) progressCopyXp.textContent = buildProgressCopy(xpProgress, "XP");
+    if (progressCopyRep) progressCopyRep.textContent = buildProgressCopy(repProgress, "punti rep");
+
+    if (progressBarXp) {
+      progressBarXp.style.width = `${xpProgress.percent}%`;
+      progressBarXp.parentElement?.setAttribute("aria-valuenow", xpProgress.percent.toString());
+    }
+    if (progressBarRep) {
+      progressBarRep.style.width = `${repProgress.percent}%`;
+      progressBarRep.parentElement?.setAttribute("aria-valuenow", repProgress.percent.toString());
+    }
+
+    const earnedXp = getEarnedMilestones(state.profile.xp, xpMilestones);
+    const earnedRep = getEarnedMilestones(state.profile.repAtcl, repMilestones);
+    const seen = new Set<string>();
+    const repIds = new Set(repMilestones.map((item) => item.id));
+    const badges = [...earnedXp, ...earnedRep].filter((badge) => {
+      if (seen.has(badge.id)) return false;
+      seen.add(badge.id);
+      return true;
+    });
+
+    if (badgeList) {
+      badgeList.innerHTML = badges.length
+        ? badges
+            .map(
+              (badge) =>
+                `<span class="badge-chip">${badge.label}<small>${badge.target}${repIds.has(badge.id) ? " rep" : " XP"}</small></span>`
+            )
+            .join("")
+        : '<span class="badge-chip ghost">Ancora nessun badge: completa milestone XP/rep.</span>';
+    }
+
+    if (badgeNote) {
+      const nextTarget = xpProgress.remaining > 0 ? { progress: xpProgress, unit: "XP" } : { progress: repProgress, unit: "punti" };
+      const nextCopy =
+        xpProgress.remaining <= 0 && repProgress.remaining <= 0
+          ? "Tieni traccia dei nuovi turni per ampliare il medagliere."
+          : buildProgressCopy(nextTarget.progress, nextTarget.unit);
+      badgeNote.textContent = nextCopy;
+    }
+  }
+
   renderProgressAndBadges();
-  showSyncBadge();
-});
+
+  window.addEventListener("storage", (event) => {
+    if (event.key !== STORAGE_KEY) return;
+    state = loadState();
+    renderProfile();
+    renderProgressAndBadges();
+    showSyncBadge();
+  });
+};
+
+void start();

--- a/apps/pwa/src/services/dev-gate.ts
+++ b/apps/pwa/src/services/dev-gate.ts
@@ -1,0 +1,186 @@
+import type { User } from "@supabase/supabase-js";
+import { isSupabaseConfigured, supabase } from "./supabase";
+
+type DevGateState = {
+  root: HTMLElement;
+  form: HTMLFormElement;
+  message: HTMLElement;
+  emailInput: HTMLInputElement;
+  passwordInput: HTMLInputElement;
+  submitButton: HTMLButtonElement;
+  signOutButton: HTMLButtonElement;
+};
+
+const allowedRoles = parseEnvList(import.meta.env.VITE_PWA_DEV_ROLES ?? "dev");
+const allowedEmails = parseEnvList(import.meta.env.VITE_PWA_DEV_EMAILS ?? "");
+
+function parseEnvList(value: string) {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function getUserRoles(user: User) {
+  const roles = new Set<string>();
+  const metadataList = [user.app_metadata, user.user_metadata];
+
+  metadataList.forEach((metadata) => {
+    if (!metadata) return;
+    const roleValue = metadata.role;
+    const rolesValue = metadata.roles;
+
+    if (typeof roleValue === "string") roles.add(roleValue);
+    if (Array.isArray(roleValue)) roleValue.filter((item) => typeof item === "string").forEach((item) => roles.add(item));
+
+    if (typeof rolesValue === "string") {
+      rolesValue
+        .split(",")
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .forEach((item) => roles.add(item));
+    }
+    if (Array.isArray(rolesValue)) {
+      rolesValue.filter((item) => typeof item === "string").forEach((item) => roles.add(item));
+    }
+  });
+
+  return Array.from(roles);
+}
+
+function isUserAllowed(user: User | null | undefined) {
+  if (!user) return false;
+  if (user.email && allowedEmails.includes(user.email)) return true;
+  if (!allowedRoles.length) return false;
+  const userRoles = getUserRoles(user);
+  return userRoles.some((role) => allowedRoles.includes(role));
+}
+
+function renderGate(root: HTMLElement) {
+  root.innerHTML = `
+    <main class="dev-gate">
+      <section class="dev-gate-card">
+        <div>
+          <p class="eyebrow">Area riservata</p>
+          <h1 class="heading-2">Accesso developer PWA</h1>
+          <p class="muted">Per continuare devi autenticarti con un account abilitato su Supabase.</p>
+        </div>
+        <form class="dev-gate-form" data-dev-gate-form>
+          <label class="field">
+            <span class="field-label">Email</span>
+            <input class="input" name="email" type="email" autocomplete="email" required />
+          </label>
+          <label class="field">
+            <span class="field-label">Password</span>
+            <input class="input" name="password" type="password" autocomplete="current-password" required />
+          </label>
+          <button class="button primary" type="submit" data-dev-gate-submit>Accedi</button>
+        </form>
+        <div class="dev-gate-actions">
+          <button class="button ghost" type="button" data-dev-gate-signout>Esci</button>
+          <p class="muted" data-dev-gate-roles></p>
+        </div>
+        <p class="dev-gate-message" data-dev-gate-message aria-live="polite"></p>
+      </section>
+    </main>
+  `;
+
+  const form = root.querySelector<HTMLFormElement>("[data-dev-gate-form]");
+  const message = root.querySelector<HTMLElement>("[data-dev-gate-message]");
+  const emailInput = root.querySelector<HTMLInputElement>('input[name="email"]');
+  const passwordInput = root.querySelector<HTMLInputElement>('input[name="password"]');
+  const submitButton = root.querySelector<HTMLButtonElement>("[data-dev-gate-submit]");
+  const signOutButton = root.querySelector<HTMLButtonElement>("[data-dev-gate-signout]");
+  const rolesNote = root.querySelector<HTMLElement>("[data-dev-gate-roles]");
+
+  if (!form || !message || !emailInput || !passwordInput || !submitButton || !signOutButton || !rolesNote) {
+    throw new Error("Dev gate markup missing");
+  }
+
+  const rolesCopy = allowedRoles.length
+    ? `Ruoli abilitati: ${allowedRoles.join(", ")}.`
+    : "Nessun ruolo abilitato configurato.";
+  rolesNote.textContent = rolesCopy;
+
+  return { root, form, message, emailInput, passwordInput, submitButton, signOutButton } satisfies DevGateState;
+}
+
+function setGateMessage(state: DevGateState, message: string, tone: "error" | "success" | "info" = "info") {
+  state.message.textContent = message;
+  state.message.dataset.tone = tone;
+}
+
+function setGateBusy(state: DevGateState, isBusy: boolean) {
+  state.submitButton.disabled = isBusy;
+  state.submitButton.textContent = isBusy ? "Accesso in corso..." : "Accedi";
+  state.emailInput.disabled = isBusy;
+  state.passwordInput.disabled = isBusy;
+}
+
+async function signOutIfPossible(state: DevGateState) {
+  if (!supabase) return;
+  setGateBusy(state, true);
+  await supabase.auth.signOut();
+  setGateBusy(state, false);
+  setGateMessage(state, "Sessione chiusa.", "info");
+}
+
+export async function requireDevAccess() {
+  const root = document.querySelector<HTMLElement>("#app") ?? document.body;
+
+  if (!isSupabaseConfigured || !supabase) {
+    const state = renderGate(root);
+    state.form.classList.add("is-disabled");
+    setGateMessage(state, "Supabase non configurato: accesso developer non disponibile.", "error");
+    return false;
+  }
+
+  const { data } = await supabase.auth.getUser();
+  if (isUserAllowed(data.user)) return true;
+
+  const state = renderGate(root);
+  const currentUser = data.user;
+
+  if (currentUser) {
+    setGateMessage(state, "Account autenticato ma non autorizzato.", "error");
+  }
+
+  return new Promise<boolean>((resolve) => {
+    state.form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      setGateBusy(state, true);
+      setGateMessage(state, "Verifico le credenziali...", "info");
+
+      const { error } = await supabase.auth.signInWithPassword({
+        email: state.emailInput.value.trim(),
+        password: state.passwordInput.value,
+      });
+
+      if (error) {
+        setGateBusy(state, false);
+        setGateMessage(state, error.message, "error");
+        return;
+      }
+
+      const { data: freshData } = await supabase.auth.getUser();
+      if (!isUserAllowed(freshData.user)) {
+        await supabase.auth.signOut();
+        setGateBusy(state, false);
+        setGateMessage(state, "Utente non autorizzato per la PWA.", "error");
+        return;
+      }
+
+      setGateMessage(state, "Accesso autorizzato.", "success");
+      resolve(true);
+    });
+
+    state.signOutButton.addEventListener("click", () => {
+      void signOutIfPossible(state);
+    });
+  }).then((allowed) => {
+    if (allowed) {
+      root.innerHTML = "";
+    }
+    return allowed;
+  });
+}

--- a/apps/pwa/src/style.css
+++ b/apps/pwa/src/style.css
@@ -1424,3 +1424,52 @@ code {
     justify-items: start;
   }
 }
+
+.dev-gate {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.dev-gate-card {
+  width: min(480px, 100%);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: 20px;
+  padding: 2rem;
+  display: grid;
+  gap: 1.5rem;
+  box-shadow: var(--shadow-card);
+}
+
+.dev-gate-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.dev-gate-form.is-disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.dev-gate-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.dev-gate-message {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.dev-gate-message[data-tone="error"] {
+  color: var(--color-error);
+}
+
+.dev-gate-message[data-tone="success"] {
+  color: var(--color-success);
+}

--- a/apps/pwa/src/turns.ts
+++ b/apps/pwa/src/turns.ts
@@ -1,237 +1,245 @@
 import "../../../shared/styles/main.css";
 import { renderPageHero } from "./components/page-hero";
 import { formatRewards, loadState, resolveRole, roles, STORAGE_KEY } from "./state";
+import { requireDevAccess } from "./services/dev-gate";
 
-const root = document.querySelector<HTMLDivElement>("#app");
+const start = async () => {
+  if (!(await requireDevAccess())) return;
 
-if (!root) {
-  throw new Error("Root container missing");
-}
 
-const pageHero = renderPageHero({
-  title: "Registro turni",
-  description: "Ultimi turni registrati dal prototipo.",
-  currentPage: "turns",
-  breadcrumbs: [
-    { label: "Hub", href: "/game.html" },
-    { label: "Turni" },
-  ],
-  backHref: "/game.html",
-  backLabel: "Torna all'hub",
-});
+  const root = document.querySelector<HTMLDivElement>("#app");
 
-root.innerHTML = `
-  <main class="page page-game layout-shell">
-    ${pageHero}
-
-    <section class="grid layout-grid">
-      <article class="card layout-span-2">
-        <h2>Turni</h2>
-        <div class="toolbar">
-          <div class="filter-row">
-            <label class="field inline">
-              <span>Ruolo</span>
-              <select data-filter-role></select>
-            </label>
-            <label class="field inline">
-              <span>Teatro</span>
-              <select data-filter-venue></select>
-            </label>
-            <label class="field inline">
-              <span>Ordina</span>
-              <select data-filter-sort>
-                <option value="desc">Dal piu recente</option>
-                <option value="asc">Dal piu vecchio</option>
-              </select>
-            </label>
-          </div>
-        </div>
-        <div class="stat-board">
-          <div class="stat-chip"><span>Turni filtrati</span><strong data-total-count>0</strong></div>
-          <div class="stat-chip"><span>XP filtrati</span><strong data-total-xp>0</strong></div>
-          <div class="stat-chip"><span>Cachet filtrato</span><strong data-total-cachet>0</strong></div>
-        </div>
-        <div class="chart-grid">
-          <div class="chart-card">
-            <div class="chart-head">
-              <div>
-                <p class="eyebrow">XP</p>
-                <p class="muted">Andamento cumulativo XP guadagnati</p>
-              </div>
-              <strong data-chart-total="xp">0 XP</strong>
-            </div>
-            <div class="sparkline" data-sparkline="xp"></div>
-          </div>
-          <div class="chart-card">
-            <div class="chart-head">
-              <div>
-                <p class="eyebrow">Cachet</p>
-                <p class="muted">Crescita cachet nel tempo</p>
-              </div>
-              <strong data-chart-total="cachet">0</strong>
-            </div>
-            <div class="sparkline" data-sparkline="cachet"></div>
-          </div>
-        </div>
-        <ul class="log-list dense" data-turn-list></ul>
-      </article>
-    </section>
-  </main>
-`;
-
-const turnList = root.querySelector<HTMLElement>('[data-turn-list]');
-const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
-const roleFilter = root.querySelector<HTMLSelectElement>('[data-filter-role]');
-const venueFilter = root.querySelector<HTMLSelectElement>('[data-filter-venue]');
-const sortFilter = root.querySelector<HTMLSelectElement>('[data-filter-sort]');
-const totalCount = root.querySelector<HTMLElement>('[data-total-count]');
-const totalXp = root.querySelector<HTMLElement>('[data-total-xp]');
-const totalCachet = root.querySelector<HTMLElement>('[data-total-cachet]');
-const sparklineXp = root.querySelector<HTMLElement>('[data-sparkline="xp"]');
-const sparklineCachet = root.querySelector<HTMLElement>('[data-sparkline="cachet"]');
-const chartTotalXp = root.querySelector<HTMLElement>('[data-chart-total="xp"]');
-const chartTotalCachet = root.querySelector<HTMLElement>('[data-chart-total="cachet"]');
-let state = loadState();
-let syncBadgeTimeout: number | undefined;
-
-function showSyncBadge(message = "Stato aggiornato") {
-  if (!syncBadge) return;
-  syncBadge.textContent = message;
-  syncBadge.style.display = "inline-flex";
-  if (syncBadgeTimeout) {
-    window.clearTimeout(syncBadgeTimeout);
-  }
-  syncBadgeTimeout = window.setTimeout(() => {
-    if (syncBadge) syncBadge.style.display = "none";
-  }, 2500);
-}
-
-function safeDateValue(dateStr: string) {
-  const parsed = Date.parse(dateStr);
-  return Number.isNaN(parsed) ? 0 : parsed;
-}
-
-function populateFilters() {
-  const previousRole = roleFilter?.value ?? "all";
-  const previousVenue = venueFilter?.value ?? "all";
-  const previousSort = sortFilter?.value ?? "desc";
-
-  if (roleFilter) {
-    roleFilter.innerHTML = `<option value="all">Tutti i ruoli</option>${roles.map((role) => `<option value="${role.id}">${role.name}</option>`).join("")}`;
-    roleFilter.value = Array.from(roleFilter.options).some((option) => option.value === previousRole) ? previousRole : "all";
+  if (!root) {
+    throw new Error("Root container missing");
   }
 
-  if (venueFilter) {
-    const venues = Array.from(new Set(state.turns.map((turn) => turn.theatre)));
-    venueFilter.innerHTML = `<option value="all">Tutti i teatri</option>${venues.length ? venues.map((venue) => `<option value="${venue}">${venue}</option>`).join("") : ""}`;
-    venueFilter.value = Array.from(venueFilter.options).some((option) => option.value === previousVenue) ? previousVenue : "all";
-  }
-
-  if (sortFilter) {
-    sortFilter.value = Array.from(sortFilter.options).some((option) => option.value === previousSort) ? previousSort : "desc";
-  }
-}
-
-function getFilteredTurns() {
-  const roleValue = roleFilter?.value || "all";
-  const venueValue = venueFilter?.value || "all";
-  const sortOrder = sortFilter?.value || "desc";
-  const turns = state.turns
-    .filter((turn) => (roleValue === "all" ? true : turn.roleId === roleValue))
-    .filter((turn) => (venueValue === "all" ? true : turn.theatre === venueValue))
-    .sort((a, b) => (sortOrder === "asc" ? safeDateValue(a.date) - safeDateValue(b.date) : safeDateValue(b.date) - safeDateValue(a.date)));
-  return turns;
-}
-
-function renderTotals(turns: typeof state.turns) {
-  const count = turns.length;
-  const totalXpValue = turns.reduce((acc, turn) => acc + turn.rewards.xp, 0);
-  const totalCachetValue = turns.reduce((acc, turn) => acc + turn.rewards.cachet, 0);
-  if (totalCount) totalCount.textContent = count.toString();
-  if (totalXp) totalXp.textContent = `${totalXpValue}`;
-  if (totalCachet) totalCachet.textContent = `${totalCachetValue}`;
-  if (chartTotalXp) chartTotalXp.textContent = `${totalXpValue} XP`;
-  if (chartTotalCachet) chartTotalCachet.textContent = `${totalCachetValue}`;
-}
-
-function buildSparkline(values: number[], accent = false) {
-  if (!values.length) {
-    return `<div class="muted">Nessun dato da visualizzare.</div>`;
-  }
-  const width = 280;
-  const height = 80;
-  const maxValue = Math.max(...values);
-  const step = values.length > 1 ? width / (values.length - 1) : width;
-  const stroke = accent ? "var(--color-warning)" : "var(--color-sky-300)";
-  const points = values
-    .map((value, index) => {
-      const x = Math.round(index * step);
-      const normalized = maxValue === 0 ? 0 : value / maxValue;
-      const y = Math.round(height - normalized * (height - 14) - 6);
-      return `${x},${y}`;
-    })
-    .join(" ");
-  const lastValue = values[values.length - 1];
-  const lastX = (values.length - 1) * step;
-  const lastY = height - (maxValue === 0 ? 0 : (lastValue / maxValue) * (height - 14)) - 6;
-  return `<svg viewBox="0 0 ${width} ${height}" role="img" aria-label="Andamento nel tempo">
-    <polyline fill="none" stroke="${stroke}" stroke-width="3" stroke-linecap="round" points="${points}" />
-    <circle cx="${lastX}" cy="${lastY}" r="5" fill="${stroke}" />
-  </svg>`;
-}
-
-function renderCharts(turns: typeof state.turns) {
-  const sorted = [...turns].sort((a, b) => safeDateValue(a.date) - safeDateValue(b.date));
-  let xpAccumulator = 0;
-  let cachetAccumulator = 0;
-  const xpSeries = sorted.map((turn) => {
-    xpAccumulator += turn.rewards.xp;
-    return xpAccumulator;
+  const pageHero = renderPageHero({
+    title: "Registro turni",
+    description: "Ultimi turni registrati dal prototipo.",
+    currentPage: "turns",
+    breadcrumbs: [
+      { label: "Hub", href: "/game.html" },
+      { label: "Turni" },
+    ],
+    backHref: "/game.html",
+    backLabel: "Torna all'hub",
   });
-  const cachetSeries = sorted.map((turn) => {
-    cachetAccumulator += turn.rewards.cachet;
-    return cachetAccumulator;
-  });
-  if (sparklineXp) {
-    sparklineXp.innerHTML = buildSparkline(xpSeries);
+
+  root.innerHTML = `
+    <main class="page page-game layout-shell">
+      ${pageHero}
+
+      <section class="grid layout-grid">
+        <article class="card layout-span-2">
+          <h2>Turni</h2>
+          <div class="toolbar">
+            <div class="filter-row">
+              <label class="field inline">
+                <span>Ruolo</span>
+                <select data-filter-role></select>
+              </label>
+              <label class="field inline">
+                <span>Teatro</span>
+                <select data-filter-venue></select>
+              </label>
+              <label class="field inline">
+                <span>Ordina</span>
+                <select data-filter-sort>
+                  <option value="desc">Dal piu recente</option>
+                  <option value="asc">Dal piu vecchio</option>
+                </select>
+              </label>
+            </div>
+          </div>
+          <div class="stat-board">
+            <div class="stat-chip"><span>Turni filtrati</span><strong data-total-count>0</strong></div>
+            <div class="stat-chip"><span>XP filtrati</span><strong data-total-xp>0</strong></div>
+            <div class="stat-chip"><span>Cachet filtrato</span><strong data-total-cachet>0</strong></div>
+          </div>
+          <div class="chart-grid">
+            <div class="chart-card">
+              <div class="chart-head">
+                <div>
+                  <p class="eyebrow">XP</p>
+                  <p class="muted">Andamento cumulativo XP guadagnati</p>
+                </div>
+                <strong data-chart-total="xp">0 XP</strong>
+              </div>
+              <div class="sparkline" data-sparkline="xp"></div>
+            </div>
+            <div class="chart-card">
+              <div class="chart-head">
+                <div>
+                  <p class="eyebrow">Cachet</p>
+                  <p class="muted">Crescita cachet nel tempo</p>
+                </div>
+                <strong data-chart-total="cachet">0</strong>
+              </div>
+              <div class="sparkline" data-sparkline="cachet"></div>
+            </div>
+          </div>
+          <ul class="log-list dense" data-turn-list></ul>
+        </article>
+      </section>
+    </main>
+  `;
+
+  const turnList = root.querySelector<HTMLElement>('[data-turn-list]');
+  const syncBadge = root.querySelector<HTMLElement>('[data-sync-badge]');
+  const roleFilter = root.querySelector<HTMLSelectElement>('[data-filter-role]');
+  const venueFilter = root.querySelector<HTMLSelectElement>('[data-filter-venue]');
+  const sortFilter = root.querySelector<HTMLSelectElement>('[data-filter-sort]');
+  const totalCount = root.querySelector<HTMLElement>('[data-total-count]');
+  const totalXp = root.querySelector<HTMLElement>('[data-total-xp]');
+  const totalCachet = root.querySelector<HTMLElement>('[data-total-cachet]');
+  const sparklineXp = root.querySelector<HTMLElement>('[data-sparkline="xp"]');
+  const sparklineCachet = root.querySelector<HTMLElement>('[data-sparkline="cachet"]');
+  const chartTotalXp = root.querySelector<HTMLElement>('[data-chart-total="xp"]');
+  const chartTotalCachet = root.querySelector<HTMLElement>('[data-chart-total="cachet"]');
+  let state = loadState();
+  let syncBadgeTimeout: number | undefined;
+
+  function showSyncBadge(message = "Stato aggiornato") {
+    if (!syncBadge) return;
+    syncBadge.textContent = message;
+    syncBadge.style.display = "inline-flex";
+    if (syncBadgeTimeout) {
+      window.clearTimeout(syncBadgeTimeout);
+    }
+    syncBadgeTimeout = window.setTimeout(() => {
+      if (syncBadge) syncBadge.style.display = "none";
+    }, 2500);
   }
-  if (sparklineCachet) {
-    sparklineCachet.innerHTML = buildSparkline(cachetSeries, true);
+
+  function safeDateValue(dateStr: string) {
+    const parsed = Date.parse(dateStr);
+    return Number.isNaN(parsed) ? 0 : parsed;
   }
-}
 
-function renderTurnList(turns: typeof state.turns) {
-  if (!turnList) return;
-  if (!turns.length) {
-    turnList.innerHTML = `<li class="muted">Nessun turno registrato.</li>`;
-    return;
+  function populateFilters() {
+    const previousRole = roleFilter?.value ?? "all";
+    const previousVenue = venueFilter?.value ?? "all";
+    const previousSort = sortFilter?.value ?? "desc";
+
+    if (roleFilter) {
+      roleFilter.innerHTML = `<option value="all">Tutti i ruoli</option>${roles.map((role) => `<option value="${role.id}">${role.name}</option>`).join("")}`;
+      roleFilter.value = Array.from(roleFilter.options).some((option) => option.value === previousRole) ? previousRole : "all";
+    }
+
+    if (venueFilter) {
+      const venues = Array.from(new Set(state.turns.map((turn) => turn.theatre)));
+      venueFilter.innerHTML = `<option value="all">Tutti i teatri</option>${venues.length ? venues.map((venue) => `<option value="${venue}">${venue}</option>`).join("") : ""}`;
+      venueFilter.value = Array.from(venueFilter.options).some((option) => option.value === previousVenue) ? previousVenue : "all";
+    }
+
+    if (sortFilter) {
+      sortFilter.value = Array.from(sortFilter.options).some((option) => option.value === previousSort) ? previousSort : "desc";
+    }
   }
-  turnList.innerHTML = turns
-    .map(
-      (turn) =>
-        `<li><div><strong>${turn.eventName}</strong> - ${turn.theatre} - ${turn.date}</div><div class="muted">${resolveRole(turn.roleId).name} | ${formatRewards(turn.rewards)}</div></li>`
-    )
-    .join("");
-}
 
-function renderView() {
-  const filtered = getFilteredTurns();
-  renderTotals(filtered);
-  renderCharts(filtered);
-  renderTurnList(filtered);
-}
+  function getFilteredTurns() {
+    const roleValue = roleFilter?.value || "all";
+    const venueValue = venueFilter?.value || "all";
+    const sortOrder = sortFilter?.value || "desc";
+    const turns = state.turns
+      .filter((turn) => (roleValue === "all" ? true : turn.roleId === roleValue))
+      .filter((turn) => (venueValue === "all" ? true : turn.theatre === venueValue))
+      .sort((a, b) => (sortOrder === "asc" ? safeDateValue(a.date) - safeDateValue(b.date) : safeDateValue(b.date) - safeDateValue(a.date)));
+    return turns;
+  }
 
-populateFilters();
-renderView();
+  function renderTotals(turns: typeof state.turns) {
+    const count = turns.length;
+    const totalXpValue = turns.reduce((acc, turn) => acc + turn.rewards.xp, 0);
+    const totalCachetValue = turns.reduce((acc, turn) => acc + turn.rewards.cachet, 0);
+    if (totalCount) totalCount.textContent = count.toString();
+    if (totalXp) totalXp.textContent = `${totalXpValue}`;
+    if (totalCachet) totalCachet.textContent = `${totalCachetValue}`;
+    if (chartTotalXp) chartTotalXp.textContent = `${totalXpValue} XP`;
+    if (chartTotalCachet) chartTotalCachet.textContent = `${totalCachetValue}`;
+  }
 
-roleFilter?.addEventListener("change", renderView);
-venueFilter?.addEventListener("change", renderView);
-sortFilter?.addEventListener("change", renderView);
+  function buildSparkline(values: number[], accent = false) {
+    if (!values.length) {
+      return `<div class="muted">Nessun dato da visualizzare.</div>`;
+    }
+    const width = 280;
+    const height = 80;
+    const maxValue = Math.max(...values);
+    const step = values.length > 1 ? width / (values.length - 1) : width;
+    const stroke = accent ? "var(--color-warning)" : "var(--color-sky-300)";
+    const points = values
+      .map((value, index) => {
+        const x = Math.round(index * step);
+        const normalized = maxValue === 0 ? 0 : value / maxValue;
+        const y = Math.round(height - normalized * (height - 14) - 6);
+        return `${x},${y}`;
+      })
+      .join(" ");
+    const lastValue = values[values.length - 1];
+    const lastX = (values.length - 1) * step;
+    const lastY = height - (maxValue === 0 ? 0 : (lastValue / maxValue) * (height - 14)) - 6;
+    return `<svg viewBox="0 0 ${width} ${height}" role="img" aria-label="Andamento nel tempo">
+      <polyline fill="none" stroke="${stroke}" stroke-width="3" stroke-linecap="round" points="${points}" />
+      <circle cx="${lastX}" cy="${lastY}" r="5" fill="${stroke}" />
+    </svg>`;
+  }
 
-window.addEventListener("storage", (event) => {
-  if (event.key !== STORAGE_KEY) return;
-  state = loadState();
+  function renderCharts(turns: typeof state.turns) {
+    const sorted = [...turns].sort((a, b) => safeDateValue(a.date) - safeDateValue(b.date));
+    let xpAccumulator = 0;
+    let cachetAccumulator = 0;
+    const xpSeries = sorted.map((turn) => {
+      xpAccumulator += turn.rewards.xp;
+      return xpAccumulator;
+    });
+    const cachetSeries = sorted.map((turn) => {
+      cachetAccumulator += turn.rewards.cachet;
+      return cachetAccumulator;
+    });
+    if (sparklineXp) {
+      sparklineXp.innerHTML = buildSparkline(xpSeries);
+    }
+    if (sparklineCachet) {
+      sparklineCachet.innerHTML = buildSparkline(cachetSeries, true);
+    }
+  }
+
+  function renderTurnList(turns: typeof state.turns) {
+    if (!turnList) return;
+    if (!turns.length) {
+      turnList.innerHTML = `<li class="muted">Nessun turno registrato.</li>`;
+      return;
+    }
+    turnList.innerHTML = turns
+      .map(
+        (turn) =>
+          `<li><div><strong>${turn.eventName}</strong> - ${turn.theatre} - ${turn.date}</div><div class="muted">${resolveRole(turn.roleId).name} | ${formatRewards(turn.rewards)}</div></li>`
+      )
+      .join("");
+  }
+
+  function renderView() {
+    const filtered = getFilteredTurns();
+    renderTotals(filtered);
+    renderCharts(filtered);
+    renderTurnList(filtered);
+  }
+
   populateFilters();
   renderView();
-  showSyncBadge();
-});
+
+  roleFilter?.addEventListener("change", renderView);
+  venueFilter?.addEventListener("change", renderView);
+  sortFilter?.addEventListener("change", renderView);
+
+  window.addEventListener("storage", (event) => {
+    if (event.key !== STORAGE_KEY) return;
+    state = loadState();
+    populateFilters();
+    renderView();
+    showSyncBadge();
+  });
+};
+
+void start();


### PR DESCRIPTION
### Motivation
- Restrict access to the PWA shell to authorized developer accounts by requiring a Supabase-backed login gate.  
- Allow authorization via user roles or a whitelist of emails configured through environment variables.  
- Prevent accidental public exposure of in-development PWA pages and force a service-worker cache refresh when core assets change.  

### Description
- Add a new `requireDevAccess` service implemented in `apps/pwa/src/services/dev-gate.ts` that renders a login UI and validates users against Supabase using role/email checks and `VITE_PWA_DEV_ROLES` / `VITE_PWA_DEV_EMAILS`.  
- Protect PWA entrypoints by wrapping page initialization in an async `start` that calls `requireDevAccess()` (files updated include `main.ts`, `game.ts`, `map.ts`, `avatar.ts`, `profile.ts`, `events.ts`, `dev.ts`, `turns.ts`, `leaderboard.ts`).  
- Add styling for the dev gate in `apps/pwa/src/style.css` and bump the service worker cache names in `apps/pwa/public/sw.js` to force core asset refresh.  

### Testing
- Launched the PWA dev server with `npm --prefix apps/pwa run dev` (HTTP) and the Vite server started successfully.  
- Captured a headless browser screenshot of the dev gate using a Playwright script, which produced an artifact image of the login screen.  
- Verified the app compiles and the protected pages render only after `requireDevAccess` returns (dev server compile/run observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69661226f0f08326b47a1fcf8f393491)