### PR TITLE
Decode unicode-escaped event names in turn records

### DIFF
--- a/apps/pwa/src/state.ts
+++ b/apps/pwa/src/state.ts
@@ -165,12 +165,17 @@ function sanitizeRewards(raw: Partial<Rewards> | undefined): Rewards {
   };
 }
 
+function decodeUnicodeEscapes(value: string) {
+  if (!value.includes("\\u")) return value;
+  return value.replace(/\\u([0-9a-fA-F]{4})/g, (_, codePoint: string) => String.fromCharCode(Number.parseInt(codePoint, 16)));
+}
+
 function sanitizeTurn(raw: unknown, fallbackRole: RoleId): TurnRecord | null {
   if (!raw || typeof raw !== "object") return null;
   const turn = raw as Partial<TurnRecord>;
   const id = typeof turn.id === "string" ? turn.id : "";
   const eventId = typeof turn.eventId === "string" ? turn.eventId : "";
-  const eventName = typeof turn.eventName === "string" ? turn.eventName : "";
+  const eventName = typeof turn.eventName === "string" ? decodeUnicodeEscapes(turn.eventName) : "";
   const theatre = typeof turn.theatre === "string" ? turn.theatre : "";
   const date = typeof turn.date === "string" ? turn.date : "";
   if (!id || !eventId || !eventName || !theatre || !date) return null;


### PR DESCRIPTION
### Motivation
- Turn event names saved with unicode-escaped sequences were displayed literally in the Turni/ATCL views, so they need to be decoded when loading persisted turns.

### Description
- Add `decodeUnicodeEscapes` and apply it to `eventName` during sanitization in `apps/pwa/src/state.ts` so `\uXXXX` sequences are converted to proper characters.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69673f0f6f8c8326a00bfa08dd0deb92)