### PR TITLE
Aggiunge feature flags per la PWA

### DIFF
--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -1,5 +1,5 @@
-const CORE_CACHE_NAME = "turni-di-palco-v6cc50991";
-const TILE_CACHE_NAME = "turni-di-palco-tiles-v6cc50991";
+const CORE_CACHE_NAME = "turni-di-palco-v6cc50992";
+const TILE_CACHE_NAME = "turni-di-palco-tiles-v6cc50992";
 const TILE_HOSTS = new Set([
   "tile.openstreetmap.org",
   "a.tile.openstreetmap.org",

--- a/apps/pwa/src/main.ts
+++ b/apps/pwa/src/main.ts
@@ -3,6 +3,7 @@ import { renderPageHero } from "./components/page-hero";
 import { renderPermissionsCard, attachPermissionsListeners } from "./features/permissions-card";
 import { renderStatusCard, attachStatusListeners } from "./features/status-card";
 import { requireDevAccess } from "./services/dev-gate";
+import { isFeatureEnabled } from "./services/feature-flags";
 
 const start = async () => {
   if (!(await requireDevAccess())) return;
@@ -68,15 +69,19 @@ const start = async () => {
           </div>
         </article>
 
-        ${renderStatusCard()}
+        ${isFeatureEnabled("status-card") ? renderStatusCard() : ""}
 
-        ${renderPermissionsCard()}
+        ${isFeatureEnabled("permissions-card") ? renderPermissionsCard() : ""}
       </section>
     </main>
   `;
 
-  attachStatusListeners(root, '[data-action="refresh"]');
-  attachPermissionsListeners(root);
+  if (isFeatureEnabled("status-card")) {
+    attachStatusListeners(root, '[data-action="refresh"]');
+  }
+  if (isFeatureEnabled("permissions-card")) {
+    attachPermissionsListeners(root);
+  }
 };
 
 void start();

--- a/apps/pwa/src/services/feature-flags.ts
+++ b/apps/pwa/src/services/feature-flags.ts
@@ -1,0 +1,40 @@
+export type FeatureFlag = "status-card" | "permissions-card" | "ai-support";
+
+type FeatureFlagConfig = Record<FeatureFlag, boolean>;
+
+const DEFAULT_FLAGS: FeatureFlagConfig = {
+  "status-card": true,
+  "permissions-card": true,
+  "ai-support": false,
+};
+
+function parseList(value: string | undefined) {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function resolveFeatureFlags(): FeatureFlagConfig {
+  const enabled = new Set(parseList(import.meta.env.VITE_FEATURE_FLAGS));
+  const disabled = new Set(parseList(import.meta.env.VITE_DISABLED_FEATURE_FLAGS));
+  const resolved: FeatureFlagConfig = { ...DEFAULT_FLAGS };
+
+  (Object.keys(resolved) as FeatureFlag[]).forEach((flag) => {
+    if (enabled.has(flag)) resolved[flag] = true;
+    if (disabled.has(flag)) resolved[flag] = false;
+  });
+
+  return resolved;
+}
+
+const resolvedFlags = resolveFeatureFlags();
+
+export function isFeatureEnabled(flag: FeatureFlag) {
+  return resolvedFlags[flag];
+}
+
+export function listFeatureFlags() {
+  return { ...resolvedFlags };
+}


### PR DESCRIPTION
### Motivation
- Abilitare/disabilitare parti della landing PWA (scheda status, scheda permessi e futuro supporto AI) tramite variabili d'ambiente per rollout progressivi.
- Forzare il refresh dei core asset quando si cambia la configurazione abilitando un aggiornamento del service worker aggiornando la cache key.

### Description
- Aggiunge `apps/pwa/src/services/feature-flags.ts` che espone `isFeatureEnabled` e `listFeatureFlags` e risolve flag da `VITE_FEATURE_FLAGS` e `VITE_DISABLED_FEATURE_FLAGS` con valori di default per `status-card`, `permissions-card` e `ai-support`.
- Aggiorna `apps/pwa/src/main.ts` per esporre condizionalmente le card `status` e `permissions` e per collegare i rispettivi listener solo quando i flag corrispondenti sono abilitati usando `isFeatureEnabled`.
- Aggiorna `apps/pwa/public/sw.js` incrementando le `CORE_CACHE_NAME` e `TILE_CACHE_NAME` per forzare l'aggiornamento del service worker quando cambiano gli asset core.

### Testing
- Nessun test automatizzato eseguito per questa modifica.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b6cb7ad108326b13ac2324e3d67a1)