### PR TITLE
Blocca creazione di nuovi documenti e documenta device-flow per Codex e GH CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ Template developed by [Heartran](https://github.com/heartran)
 
 - `apps/reactbricks`: CMS sources (da ripulire; integrare come workspace separato).
 
-- `docs/`: PDF di design/GDD; aggiungi nuovi file datati con changelog breve.
+- `docs/`: PDF di design/GDD.
+  - **Non creare nuovi documenti o file in `docs/`.**
 
 ## Build, Test, and Development Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Template developed by [Heartran](https://github.com/heartran)
 - `apps/reactbricks`: CMS sources (da ripulire; integrare come workspace separato).
 
 - `docs/`: PDF di design/GDD.
-  - **Non creare nuovi documenti o file in `docs/`.**
+  - **Non creare nuovi documenti o file in `docs/` se non esplicitamente richiesti.** Si preferiscono **sempre** le modifiche fatte su branch diversi da `main`.
 
 ## Build, Test, and Development Commands
 

--- a/docs/2025-02-18-ai-support.md
+++ b/docs/2025-02-18-ai-support.md
@@ -121,6 +121,37 @@ Se il backend non esiste, creare un handler che:
   - `AI_SUPPORT_GH_BIN` (override path del binario `gh`)
   - `GITHUB_REPO_OWNER` + `GITHUB_REPO_NAME` (fallback repo)
 
+## Autenticazione remota (senza OpenAI API key)
+
+Quando il server remoto non puo' usare una API key OpenAI, la soluzione consigliata e'
+autenticare Codex e GitHub CLI con il device flow (codice + URL) eseguito direttamente
+sul server. Il `tools/ai-support-server.js` espone un pannello `/auth` che avvia questi
+login e mostra lo stato corrente.
+
+### Codex CLI (device auth)
+
+- Avviare il login device:
+  - CLI: `codex login --device-auth`
+  - UI: visitare `http://<host>:8787/auth` e cliccare "Avvia login".
+- Copiare URL + codice di accesso presenti nei log del server.
+- Completare il login dal proprio browser locale (non serve una API key).
+- Verificare lo stato: `codex login status` oppure dal pannello `/auth`.
+
+### GitHub CLI (device auth)
+
+- Avviare il login device:
+  - CLI: `gh auth login --device`
+  - UI: visitare `http://<host>:8787/auth` e cliccare "Avvia login".
+- Copiare URL + codice di accesso presenti nei log del server.
+- Completare il login dal proprio browser locale.
+- Verificare lo stato: `gh auth status` oppure dal pannello `/auth`.
+
+### Note operative
+
+- Il device flow evita la necessita' di API key sul server remoto.
+- Se il login e' gia' attivo, il server risponde con un errore "login already running".
+- In ambienti headless, la pagina `/auth` e' utile per controllare lo stato e avviare i login.
+
 ## Gestione credenziali GitHub
 
 Token e repo devono vivere lato server (mai nel browser) e vanno passati a `createGithubIssue` (es. da env):


### PR DESCRIPTION
### Motivation
- Evitare la proliferazione di nuovi file di documentazione nella cartella `docs/` secondo la nuova policy del repository.
- Fornire istruzioni operative per autenticare il server remoto senza usare una API key OpenAI, usando il device flow per Codex e la GitHub CLI.

### Description
- Modificato `AGENTS.md` aggiornando la voce `docs/` per includere la regola `Non creare nuovi documenti o file in docs/` e rimuovere l'indicazione precedente di aggiungere nuovi PDF datati.
- Aggiornato `docs/2025-02-18-ai-support.md` con una nuova sezione `Autenticazione remota (senza OpenAI API key)` che documenta l'uso del pannello `/auth` del server e il device flow.
- Documentati i comandi e i controlli principali per il device auth: `codex login --device-auth`, `codex login status`, `gh auth login --device`, `gh auth status` e l'uso del pannello `http://<host>:8787/auth` per avviare e verificare i login.
- Aggiunte note operative su errori comuni (es. `login already running`) e sul comportamento in ambienti headless.

### Testing
- Cambiamenti solo alla documentazione, non sono stati eseguiti test automatizzati.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b739b9f58832683e367c84530ad30)