### PR TITLE
Fix Maxwell chat input anchoring

### DIFF
--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -355,9 +355,9 @@ export function SupportChat({ userName, onBack }: SupportChatProps) {
     <Screen
       withBottomNavPadding={false}
       className="relative items-start justify-start"
-      contentClassName="relative w-full flex-1 px-6 pt-8 pb-[calc(env(safe-area-inset-bottom,_0px)+20px)] space-y-0 box-border"
+      contentClassName="relative w-full flex flex-1 flex-col min-h-0 px-6 pt-8 pb-[calc(env(safe-area-inset-bottom,_0px)+20px)] box-border"
     >
-      <div className="flex h-full w-full flex-col gap-4">
+      <div className="flex h-full w-full flex-1 flex-col gap-4 min-h-0">
         <button
           type="button"
           onClick={onBack}
@@ -424,7 +424,7 @@ export function SupportChat({ userName, onBack }: SupportChatProps) {
           </div>
         ) : null}
 
-        <div className="flex-1 overflow-y-auto pr-1 space-y-3">
+        <div className="flex-1 min-h-0 overflow-y-auto pr-1 space-y-3">
           {messages.map((message) => (
             <div
               key={message.id}


### PR DESCRIPTION
### Motivation
- Prevent the support chat text input from moving with the message list so the input stays anchored while messages scroll.

### Description
- Modify `apps/mobile/src/components/screens/SupportChat.tsx` to make the screen content a proper flex column by adding `flex flex-col min-h-0` to `contentClassName` on `Screen`.
- Give the main container `flex-1` and `min-h-0` to allow the message list to size correctly and avoid pushing the input bar.
- Add `min-h-0` to the messages container (`div` with `overflow-y-auto`) so it can scroll independently from the input area.
- Commit message: `Fix chat input layout`.

### Testing
- No automated tests were executed for this UI-only change; validation was done via code inspection and layout adjustments in the modified component.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698201b70868832694fb8f1db19a2aa6)