### PR TITLE
Harden Supabase RLS policies and add PWA security inventory

### DIFF
--- a/supabase/SECURITY_POLICIES.md
+++ b/supabase/SECURITY_POLICIES.md
@@ -1,0 +1,54 @@
+# Supabase security inventory (PWA)
+
+## PWA data access inventory
+
+### RPC used by the PWA
+- `public.get_leaderboard(p_limit int)` (used by `apps/pwa/src/leaderboard.ts`).
+
+### Tables read by the RPC
+- `public.profiles` (leaderboard profile fields).
+- `public.turns` (aggregate count per profile).
+
+### Other client-exposed tables/views (not referenced in PWA code)
+- `public.roles`, `public.events`, `public.activities` (catalog data).
+- `public.badges`, `public.user_badges` (badge data).
+- `public.my_turn_stats`, `public.my_badges` (views granted to `authenticated`).
+
+## RLS status check
+
+RLS is enabled on every game table exposed to the client:
+- `public.roles`
+- `public.events`
+- `public.activities`
+- `public.profiles`
+- `public.turns`
+- `public.activity_completions`
+- `public.badges`
+- `public.user_badges`
+
+## Policy summary (minimum access)
+
+All policies are now explicitly scoped to the `authenticated` role:
+- Read-only catalog tables (`roles`, `events`, `activities`, `badges`) allow `select` to `authenticated`.
+- Ownership tables (`profiles`, `turns`, `activity_completions`, `user_badges`) allow `select/insert/update/delete` only for rows where `auth.uid()` matches the owner.
+- RPCs (`get_leaderboard`, `reset_my_progress`, `evaluate_my_badges`, `mark_my_badges_seen`) are granted only to `authenticated`.
+
+## Anonymous access verification (manual)
+
+Run these checks in a Supabase SQL editor or `psql` session as the `anon` role:
+
+```sql
+-- Expect: permission denied or RLS violation
+select * from public.profiles limit 1;
+select * from public.turns limit 1;
+
+-- Expect: permission denied (RPC execution blocked)
+select public.get_leaderboard(10);
+
+-- Expect: permission denied
+select * from public.badges limit 1;
+```
+
+### Expected outcome
+- Anonymous users cannot read or write any rows from protected tables.
+- Anonymous users cannot execute RPCs (leaderboard or progress reset).

--- a/supabase/migrations/20260108_rls_policy_hardening.sql
+++ b/supabase/migrations/20260108_rls_policy_hardening.sql
@@ -1,0 +1,75 @@
+alter policy "roles read" on public.roles
+  to authenticated
+  using (true);
+
+alter policy "events read" on public.events
+  to authenticated
+  using (true);
+
+alter policy "activities read" on public.activities
+  to authenticated
+  using (true);
+
+alter policy "profiles select own" on public.profiles
+  to authenticated
+  using (auth.uid() = id);
+
+alter policy "profiles insert own" on public.profiles
+  to authenticated
+  with check (auth.uid() = id);
+
+alter policy "profiles update own" on public.profiles
+  to authenticated
+  using (auth.uid() = id)
+  with check (auth.uid() = id);
+
+alter policy "turns select own" on public.turns
+  to authenticated
+  using (auth.uid() = user_id);
+
+alter policy "turns insert own" on public.turns
+  to authenticated
+  with check (auth.uid() = user_id);
+
+alter policy "turns update own" on public.turns
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+alter policy "turns delete own" on public.turns
+  to authenticated
+  using (auth.uid() = user_id);
+
+alter policy "activity completions select own" on public.activity_completions
+  to authenticated
+  using (auth.uid() = user_id);
+
+alter policy "activity completions insert own" on public.activity_completions
+  to authenticated
+  with check (auth.uid() = user_id);
+
+alter policy "activity completions update own" on public.activity_completions
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+alter policy "activity completions delete own" on public.activity_completions
+  to authenticated
+  using (auth.uid() = user_id);
+
+alter policy "badges read" on public.badges
+  to authenticated
+  using (true);
+
+alter policy "user badges select own" on public.user_badges
+  to authenticated
+  using (auth.uid() = user_id);
+
+alter policy "user badges update own" on public.user_badges
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+revoke select on public.badges from anon;
+
+grant select on public.badges to authenticated;

--- a/supabase/migrations/20260113_rls_policy_hardening.sql
+++ b/supabase/migrations/20260113_rls_policy_hardening.sql
@@ -12,50 +12,50 @@ alter policy "activities read" on public.activities
 
 alter policy "profiles select own" on public.profiles
   to authenticated
-  using (auth.uid() = id);
+  using ((select auth.uid()) = id);
 
 alter policy "profiles insert own" on public.profiles
   to authenticated
-  with check (auth.uid() = id);
+  with check ((select auth.uid()) = id);
 
 alter policy "profiles update own" on public.profiles
   to authenticated
-  using (auth.uid() = id)
-  with check (auth.uid() = id);
+  using ((select auth.uid()) = id)
+  with check ((select auth.uid()) = id);
 
 alter policy "turns select own" on public.turns
   to authenticated
-  using (auth.uid() = user_id);
+  using ((select auth.uid()) = user_id);
 
 alter policy "turns insert own" on public.turns
   to authenticated
-  with check (auth.uid() = user_id);
+  with check ((select auth.uid()) = user_id);
 
 alter policy "turns update own" on public.turns
   to authenticated
-  using (auth.uid() = user_id)
-  with check (auth.uid() = user_id);
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
 
 alter policy "turns delete own" on public.turns
   to authenticated
-  using (auth.uid() = user_id);
+  using ((select auth.uid()) = user_id);
 
 alter policy "activity completions select own" on public.activity_completions
   to authenticated
-  using (auth.uid() = user_id);
+  using ((select auth.uid()) = user_id);
 
 alter policy "activity completions insert own" on public.activity_completions
   to authenticated
-  with check (auth.uid() = user_id);
+  with check ((select auth.uid()) = user_id);
 
 alter policy "activity completions update own" on public.activity_completions
   to authenticated
-  using (auth.uid() = user_id)
-  with check (auth.uid() = user_id);
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
 
 alter policy "activity completions delete own" on public.activity_completions
   to authenticated
-  using (auth.uid() = user_id);
+  using ((select auth.uid()) = user_id);
 
 alter policy "badges read" on public.badges
   to authenticated
@@ -63,12 +63,12 @@ alter policy "badges read" on public.badges
 
 alter policy "user badges select own" on public.user_badges
   to authenticated
-  using (auth.uid() = user_id);
+  using ((select auth.uid()) = user_id);
 
 alter policy "user badges update own" on public.user_badges
   to authenticated
-  using (auth.uid() = user_id)
-  with check (auth.uid() = user_id);
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
 
 revoke select on public.badges from anon;
 


### PR DESCRIPTION
### Motivation

- Limit client-side exposure by scoping row-level-security (RLS) policies to the `authenticated` role and removing anonymous read access where inappropriate.
- Inventory RPCs/tables used by the PWA (e.g. `public.get_leaderboard`) to ensure each exposed object has an explicit minimal policy.
- Provide a short internal checklist to verify anonymous users cannot read/execute protected data or RPCs.

### Description

- Add `supabase/migrations/20260108_rls_policy_hardening.sql` which alters existing policies to `TO authenticated` for catalog and ownership tables and enforces owner checks via `auth.uid()` for `profiles`, `turns`, `activity_completions`, and `user_badges`.
- Revoke anonymous `SELECT` on `public.badges` and explicitly `GRANT SELECT` to `authenticated` in the same migration.
- Add `supabase/SECURITY_POLICIES.md` documenting the PWA data access inventory (RPCs and tables), current RLS status, minimal policy summary, and manual SQL checks to validate anonymous access is blocked.
- Confirmed the PWA uses `public.get_leaderboard(p_limit int)` in `apps/pwa/src/leaderboard.ts` and listed tables read by that RPC in the documentation.

### Testing

- No automated tests were executed because there is no local Supabase instance available in CI for this change.
- Manual verification steps are documented in `supabase/SECURITY_POLICIES.md` (SQL snippets to run as the `anon` role and expected `permission denied` outcomes).
- The migration file is provided to be applied in a Supabase environment where the checks in the doc can be run and validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69820692fa30832694badc1594342bdc)