### PR TITLE
Add security headers for Netlify and document Render header setup

### DIFF
--- a/TECHNICAL_NOTES.md
+++ b/TECHNICAL_NOTES.md
@@ -36,6 +36,14 @@
 - Service Worker: `apps/pwa/public/sw.js`
 - Il versioning della cache viene aggiornato dallo script `tools/update-cache-version.js` (invocato da `npm run build:pwa`) per forzare l’update degli asset core.
 
+## Header di sicurezza (Netlify/Render)
+
+- Netlify: gli header sono configurati in `netlify.toml` nella sezione `[[headers]]`.
+- Render: il servizio PWA attuale usa `vite preview` (startCommand in `render.yaml`), quindi gli header vanno impostati a livello di reverse proxy o server applicativo.
+  - Opzione consigliata: mettere un reverse proxy (es. Caddy/Nginx) davanti al preview server e impostare gli header lì.
+  - In alternativa: sostituire il preview server con un piccolo server (Express/Fastify) che serva `apps/pwa/dist` e imposti gli stessi header.
+  - Se si migra la PWA a “Static Site” su Render, utilizzare il supporto ai `headers` del manifest Render.
+
 ## Supabase (client)
 
 - Configurazione lato client tramite variabili d’ambiente (vedi `.env`, `apps/mobile/.env.example`, `apps/pwa/.env.example`).

--- a/TECHNICAL_NOTES.md
+++ b/TECHNICAL_NOTES.md
@@ -39,6 +39,7 @@
 ## Header di sicurezza (Netlify/Render)
 
 - Netlify: gli header sono configurati in `netlify.toml` nella sezione `[[headers]]`.
+- Nota CSP: al momento `index.html` contiene uno script inline per il redirect mobile; per questo `script-src` include temporaneamente `'unsafe-inline'` finche' il bootstrap non viene spostato in un modulo esterno.
 - Render: il servizio PWA attuale usa `vite preview` (startCommand in `render.yaml`), quindi gli header vanno impostati a livello di reverse proxy o server applicativo.
   - Opzione consigliata: mettere un reverse proxy (es. Caddy/Nginx) davanti al preview server e impostare gli header lì.
   - In alternativa: sostituire il preview server con un piccolo server (Express/Fastify) che serva `apps/pwa/dist` e imposti gli stessi header.

--- a/netlify.toml
+++ b/netlify.toml
@@ -31,7 +31,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://readyplayer.me https://*.readyplayer.me; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' https://cdn.iubenda.com; connect-src 'self' https://api.github.com https://*.supabase.co wss://*.supabase.co https://maxwell-ai-support.onrender.com; frame-src https://readyplayer.me https://*.readyplayer.me; media-src 'self' https://readyplayer.me https://*.readyplayer.me; worker-src 'self' blob:; upgrade-insecure-requests"
+    Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://readyplayer.me https://*.readyplayer.me https://*.supabase.co; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.iubenda.com; connect-src 'self' https://api.github.com https://*.supabase.co wss://*.supabase.co https://maxwell-ai-support.onrender.com; frame-src https://readyplayer.me https://*.readyplayer.me; media-src 'self' https://readyplayer.me https://*.readyplayer.me; worker-src 'self' blob:; upgrade-insecure-requests"
     Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"

--- a/netlify.toml
+++ b/netlify.toml
@@ -27,3 +27,13 @@
 
 [context.deploy-preview]
   command = "npm ci && npm run build:pwa"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://readyplayer.me https://*.readyplayer.me; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' https://cdn.iubenda.com; connect-src 'self' https://api.github.com https://*.supabase.co wss://*.supabase.co https://maxwell-ai-support.onrender.com; frame-src https://readyplayer.me https://*.readyplayer.me; media-src 'self' https://readyplayer.me https://*.readyplayer.me; worker-src 'self' blob:; upgrade-insecure-requests"
+    Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(self \"https://readyplayer.me\" \"https://*.readyplayer.me\"), microphone=(self \"https://readyplayer.me\" \"https://*.readyplayer.me\"), geolocation=(self), fullscreen=(self)"
+    X-Frame-Options = "SAMEORIGIN"


### PR DESCRIPTION
### Motivation
- Enforce stronger security for the PWA by adding HTTP response headers (CSP, HSTS, etc.) to the Netlify configuration and provide guidance for applying the same headers when deploying on Render.

### Description
- Added a `[[headers]]` section to `netlify.toml` that sets a restrictive `Content-Security-Policy` including `connect-src` entries for GitHub API, Supabase, and the AI support endpoint, plus allowances for OpenStreetMap tiles and ReadyPlayer.Me assets. 
- Also configured `Strict-Transport-Security`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` for camera/microphone/geolocation/fullscreen, and `X-Frame-Options: SAMEORIGIN` in `netlify.toml`.
- Documented deployment options for Render in `TECHNICAL_NOTES.md`, recommending a reverse proxy (Caddy/Nginx) or a small custom server (Express/Fastify) to inject the same headers when the app is served via `vite preview` or migrated to a static site.

### Testing
- No automated tests were executed for these configuration and documentation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698206953cb08326a9620f6e0f5608b5)