### PR TITLE
AI support: use CORS health check, expose explicit status and add fallback UI

### DIFF
--- a/TECHNICAL_NOTES.md
+++ b/TECHNICAL_NOTES.md
@@ -23,6 +23,7 @@
 ## AI support (mobile)
 
 - Client calls `POST /api/ai/chat` (proxy in `apps/mobile/vite.config.ts`).
+- Availability check uses `GET /health` (proxy in `apps/mobile/vite.config.ts`).
 - Local server: `tools/ai-support-server.js` uses `codex exec`.
 - Optional env:
   - `AI_SUPPORT_PORT` (server port, default 8787)
@@ -34,6 +35,9 @@
   - `AI_SUPPORT_ADMIN_ENABLED` (admin endpoints `/auth` + `/auth/command`; default false)
   - `VITE_AI_SUPPORT_ENDPOINT` (client endpoint override)
   - `VITE_AI_SUPPORT_ISSUE_ENDPOINT` (issue endpoint override)
+- CORS: if the health endpoint is reached cross-origin, the server must reply with
+  `Access-Control-Allow-Origin` matching the calling origin (or `*`) so the browser can
+  read the response in `mode: "cors"`. In dev, prefer the same-origin `/health` proxy.
 
 ## PWA, cache e aggiornamenti
 

--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -100,7 +100,7 @@ export function AccountSettings({
   });
   const [notificationPermission, setNotificationPermission] = useState<NotificationPermissionState>(() => getPermission());
   const [supportStatus, setSupportStatus] = useState<
-    'checking' | 'available' | 'unavailable'
+    'checking' | 'available' | 'unavailable' | 'unknown'
   >('checking');
 
   const notificationStatusLabel = (() => {
@@ -161,9 +161,9 @@ export function AccountSettings({
     let mounted = true;
 
     const checkSupport = async () => {
-      const available = await checkAiSupportAvailability();
+      const availability = await checkAiSupportAvailability();
       if (!mounted) return;
-      setSupportStatus(available ? 'available' : 'unavailable');
+      setSupportStatus(availability);
     };
 
     checkSupport();
@@ -361,6 +361,7 @@ export function AccountSettings({
     typeof navigator !== 'undefined' && !!navigator.geolocation;
   const supportUnavailable = supportStatus === 'unavailable';
   const supportChecking = supportStatus === 'checking';
+  const supportUnknown = supportStatus === 'unknown';
 
   return (
     <Screen
@@ -591,6 +592,11 @@ export function AccountSettings({
           {supportUnavailable ? (
             <p className="text-[14px] leading-[20px] text-[#ff4d4f]">
               Supporto AI attualmente non disponibile.
+            </p>
+          ) : null}
+          {supportUnknown ? (
+            <p className="text-[14px] leading-[20px] text-[#f4bf4f]">
+              Stato del supporto non verificabile. Puoi comunque provare ad aprire la chat.
             </p>
           ) : null}
 

--- a/apps/mobile/src/services/ai.ts
+++ b/apps/mobile/src/services/ai.ts
@@ -36,6 +36,11 @@ type AiSupportAvailabilityOptions = {
   timeoutMs?: number;
 };
 
+export type AiSupportAvailabilityStatus =
+  | 'available'
+  | 'unavailable'
+  | 'unknown';
+
 const SUPPORT_PROMPT =
   "Sei Maxwell, assistente di supporto per l'app Turni di Palco. " +
   "Sei super disponibile, positivo e un po' divertente. " +
@@ -120,16 +125,6 @@ function resolveHealthEndpoint(endpoint: string) {
   return endpoint;
 }
 
-function isCrossOriginTarget(target: string) {
-  if (typeof window === 'undefined') return false;
-  try {
-    const url = new URL(target, window.location.href);
-    return url.origin !== window.location.origin;
-  } catch {
-    return false;
-  }
-}
-
 function extractReply(payload: AiSupportResponse | string | null) {
   if (!payload) return null;
   if (typeof payload === 'string') return payload;
@@ -182,7 +177,6 @@ export async function checkAiSupportAvailability({
   timeoutMs = 2500,
 }: AiSupportAvailabilityOptions = {}) {
   const target = resolveHealthEndpoint(resolveEndpoint(endpoint));
-  const crossOrigin = isCrossOriginTarget(target);
   const controller = new AbortController();
   const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
 
@@ -190,11 +184,11 @@ export async function checkAiSupportAvailability({
     const response = await fetch(target, {
       method: 'GET',
       signal: controller.signal,
-      mode: crossOrigin ? 'no-cors' : 'cors',
+      mode: 'cors',
     });
-    return response.ok || (crossOrigin && response.type === 'opaque');
+    return response.ok ? 'available' : 'unavailable';
   } catch {
-    return false;
+    return 'unknown';
   } finally {
     window.clearTimeout(timeout);
   }

--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -111,6 +111,10 @@ export default defineConfig(({ mode }) => {
           target: `http://localhost:${aiSupportPort}`,
           changeOrigin: true,
         },
+        '/health': {
+          target: `http://localhost:${aiSupportPort}`,
+          changeOrigin: true,
+        },
       },
     },
     preview: {

--- a/tools/ai-support-server.js
+++ b/tools/ai-support-server.js
@@ -2261,11 +2261,13 @@ const requestHandler = (req, res) => {
     if (!res.getHeader('Access-Control-Allow-Origin')) {
       // Keep /health readable by external probes even without explicit allowed origins.
       res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     }
     logLine(
       `${requestId} GET /health\n  client=${clientIp}\n  status=${formatStatus(200)}\n  duration=${Date.now() - start}ms`
     );
-    sendJson(res, 200, { status: 'ok' });
+    sendJson(res, 200, { status: 'ok', service: 'ai-support', uptime: process.uptime() });
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Avoid relying on opaque `no-cors` responses to detect AI support availability and treat only explicit HTTP success as available. 
- Ensure the dev client can call a real `/health` endpoint via a same-origin proxy or a CORS-enabled server response. 
- Provide a graceful UI fallback when health cannot be verified (cross-origin / network unknown).

### Description
- Updated the mobile health check to remove `no-cors`, use `mode: 'cors'` and return an explicit availability type (`'available' | 'unavailable' | 'unknown'`) in `apps/mobile/src/services/ai.ts`.
- Added an "unknown" support state to the Account Settings screen and a user-facing message, wiring `checkAiSupportAvailability` to set the new state in `apps/mobile/src/components/screens/AccountSettings.tsx`.
- Added a same-origin dev proxy for the health endpoint in `apps/mobile/vite.config.ts` (proxy `/health` → AI support server) and documented required CORS behavior in `TECHNICAL_NOTES.md`.
- Made the AI support server return a richer health payload and ensured CORS headers for `/health` probes in `tools/ai-support-server.js`.

### Testing
- Started the mobile dev server with `npm --workspace apps/mobile run dev` and confirmed Vite served the app (local URL printed). — succeeded.
- Ran a Playwright script to load the mobile UI and capture `Account Settings`; the run produced `artifacts/account-settings.png` showing the new "health unknown" message when the probe could not be verified. — succeeded.
- Performed a few `curl` probes against local endpoints during verification which showed expected TLS/HTTP variations in the dev environment; these were exploratory and are noted but not part of automated test coverage. — informational.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983468f45648326aa57b2f5701546e0)