### PR TITLE
Enforce dev access checks server-side and add audit logging

### DIFF
--- a/apps/pwa/src/services/dev-gate.ts
+++ b/apps/pwa/src/services/dev-gate.ts
@@ -17,6 +17,7 @@ const allowedEmails = parseEnvList(import.meta.env.VITE_PWA_DEV_EMAILS ?? "");
 const publicModeValue = import.meta.env.VITE_PUBLIC_MODE;
 
 export const isPublicMode = publicModeValue === "true" || publicModeValue === "1";
+const serverAccessFunction = "dev-access";
 
 function parseEnvList(value: string) {
   return value
@@ -60,6 +61,35 @@ function isUserAllowed(user: User | null | undefined) {
   return userRoles.some((role) => allowedRoles.includes(role));
 }
 
+type DevAccessResponse = {
+  allowed: boolean;
+  reason?: string;
+};
+
+async function verifyServerAccess() {
+  if (!supabase) {
+    return { allowed: false, reason: "Supabase non configurato." };
+  }
+
+  try {
+    const { data, error } = await supabase.functions.invoke<DevAccessResponse>(serverAccessFunction, {
+      body: { path: window.location.pathname },
+    });
+
+    if (error) {
+      return { allowed: false, reason: error.message };
+    }
+
+    return {
+      allowed: Boolean(data?.allowed),
+      reason: data?.reason ?? undefined,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Errore sconosciuto.";
+    return { allowed: false, reason: message };
+  }
+}
+
 function renderGate(root: HTMLElement) {
   root.innerHTML = `
     <main class="dev-gate">
@@ -67,7 +97,9 @@ function renderGate(root: HTMLElement) {
         <div>
           <p class="eyebrow">Area riservata</p>
           <h1 class="heading-2">Accesso developer PWA</h1>
-          <p class="muted">Per continuare devi autenticarti con un account abilitato su Supabase.</p>
+          <p class="muted">
+            Per continuare devi autenticarti con un account abilitato su Supabase: le autorizzazioni sono verificate anche lato server.
+          </p>
         </div>
         <form class="dev-gate-form" data-dev-gate-form>
           <label class="field">
@@ -168,13 +200,22 @@ export async function requireDevAccess() {
   }
 
   const { data } = await supabase.auth.getUser();
-  if (isUserAllowed(data.user)) return true;
+  const currentUser = data.user;
+  let serverCheck: DevAccessResponse | null = null;
+
+  if (currentUser && isUserAllowed(currentUser)) {
+    serverCheck = await verifyServerAccess();
+    if (serverCheck.allowed) return true;
+  }
 
   const state = renderGate(root);
-  const currentUser = data.user;
 
   if (currentUser) {
-    setGateMessage(state, "Account autenticato ma non autorizzato.", "error");
+    if (!serverCheck) {
+      serverCheck = await verifyServerAccess();
+    }
+    const message = serverCheck.reason ?? "Account autenticato ma non autorizzato.";
+    setGateMessage(state, message, "error");
   }
 
   return new Promise<boolean>((resolve) => {
@@ -195,10 +236,12 @@ export async function requireDevAccess() {
       }
 
       const { data: freshData } = await supabase.auth.getUser();
-      if (!isUserAllowed(freshData.user)) {
+      const serverCheck = await verifyServerAccess();
+      if (!isUserAllowed(freshData.user) || !serverCheck.allowed) {
         await supabase.auth.signOut();
         setGateBusy(state, false);
-        setGateMessage(state, "Utente non autorizzato per la PWA.", "error");
+        const message = serverCheck.reason ?? "Utente non autorizzato per la PWA.";
+        setGateMessage(state, message, "error");
         return;
       }
 

--- a/supabase/SECURITY_POLICIES.md
+++ b/supabase/SECURITY_POLICIES.md
@@ -5,6 +5,9 @@
 ### RPC used by the PWA
 - `public.get_leaderboard(p_limit int)` (used by `apps/pwa/src/leaderboard.ts`).
 
+### Edge functions used by the PWA
+- `dev-access` (enforces dev-only authorization server-side and logs access denials).
+
 ### Tables read by the RPC
 - `public.profiles` (leaderboard profile fields).
 - `public.turns` (aggregate count per profile).
@@ -32,6 +35,7 @@ All policies are now explicitly scoped to the `authenticated` role:
 - Read-only catalog tables (`roles`, `events`, `activities`, `badges`) allow `select` to `authenticated`.
 - Ownership tables (`profiles`, `turns`, `activity_completions`, `user_badges`) allow `select/insert/update/delete` only for rows where `auth.uid()` matches the owner.
 - RPCs (`get_leaderboard`, `reset_my_progress`, `evaluate_my_badges`, `mark_my_badges_seen`) are granted only to `authenticated`.
+- `dev_access_audit` is written by the `dev-access` edge function using the service role key (RLS enabled).
 
 ## Anonymous access verification (manual)
 

--- a/supabase/functions/dev-access/index.ts
+++ b/supabase/functions/dev-access/index.ts
@@ -1,0 +1,140 @@
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+type DevAccessResponse = {
+  allowed: boolean;
+  reason?: string;
+};
+
+type DevAccessAudit = {
+  user_id: string;
+  user_email: string | null;
+  user_roles: string[];
+  path: string | null;
+  reason: string;
+};
+
+function parseEnvList(value: string | null) {
+  return (value ?? '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function getUserRoles(user: Record<string, unknown>) {
+  const roles = new Set<string>();
+  const appMetadata = user.app_metadata as Record<string, unknown> | null | undefined;
+  const userMetadata = user.user_metadata as Record<string, unknown> | null | undefined;
+  const metadataList = [appMetadata, userMetadata].filter(Boolean) as Record<string, unknown>[];
+
+  metadataList.forEach((metadata) => {
+    const roleValue = metadata.role;
+    const rolesValue = metadata.roles;
+
+    if (typeof roleValue === 'string') roles.add(roleValue);
+    if (Array.isArray(roleValue)) {
+      roleValue.filter((item) => typeof item === 'string').forEach((item) => roles.add(item));
+    }
+
+    if (typeof rolesValue === 'string') {
+      rolesValue
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .forEach((item) => roles.add(item));
+    }
+    if (Array.isArray(rolesValue)) {
+      rolesValue.filter((item) => typeof item === 'string').forEach((item) => roles.add(item));
+    }
+  });
+
+  return Array.from(roles);
+}
+
+function isUserAllowed(
+  user: { email?: string | null; app_metadata?: Record<string, unknown>; user_metadata?: Record<string, unknown> },
+  allowedEmails: string[],
+  allowedRoles: string[]
+) {
+  if (user.email && allowedEmails.includes(user.email)) return true;
+  if (!allowedRoles.length) return false;
+  const userRoles = getUserRoles(user as Record<string, unknown>);
+  return userRoles.some((role) => allowedRoles.includes(role));
+}
+
+function jsonResponse(body: DevAccessResponse, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ allowed: false, reason: 'Metodo non consentito.' }, 405);
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const anonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+
+  const allowedRoles = parseEnvList(Deno.env.get('DEV_ALLOWED_ROLES') ?? 'dev');
+  const allowedEmails = parseEnvList(Deno.env.get('DEV_ALLOWED_EMAILS') ?? '');
+
+  let payload: { path?: string } = {};
+  try {
+    payload = await req.json();
+  } catch {
+    payload = {};
+  }
+
+  const authHeader = req.headers.get('Authorization') ?? '';
+  const supabaseClient = createClient(supabaseUrl, anonKey, {
+    global: {
+      headers: { Authorization: authHeader },
+    },
+  });
+
+  const { data, error } = await supabaseClient.auth.getUser();
+  const user = data?.user ?? null;
+
+  if (error || !user) {
+    return jsonResponse({ allowed: false, reason: 'Utente non autenticato.' }, 401);
+  }
+
+  const allowed = isUserAllowed(user, allowedEmails, allowedRoles);
+  if (allowed) {
+    return jsonResponse({ allowed: true });
+  }
+
+  if (serviceRoleKey) {
+    const adminClient = createClient(supabaseUrl, serviceRoleKey);
+    const userRoles = getUserRoles(user as Record<string, unknown>);
+    const auditEntry: DevAccessAudit = {
+      user_id: user.id,
+      user_email: user.email ?? null,
+      user_roles: userRoles,
+      path: payload.path ?? null,
+      reason: 'not_allowed',
+    };
+
+    const { error: insertError } = await adminClient.from('dev_access_audit').insert(auditEntry);
+    if (insertError) {
+      console.error('Dev access audit insert failed', insertError.message);
+    }
+  } else {
+    console.warn('Missing SUPABASE_SERVICE_ROLE_KEY for dev access audit logging.');
+  }
+
+  return jsonResponse({ allowed: false, reason: 'Accesso non autorizzato.' }, 403);
+});

--- a/supabase/migrations/20260114_dev_access_audit.sql
+++ b/supabase/migrations/20260114_dev_access_audit.sql
@@ -1,0 +1,11 @@
+create table if not exists public.dev_access_audit (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  user_email text,
+  user_roles text[] not null default '{}',
+  path text,
+  reason text not null default 'not_allowed',
+  created_at timestamptz not null default now()
+);
+
+alter table public.dev_access_audit enable row level security;


### PR DESCRIPTION
### Motivation
- Ensure dev-only UI gates are backed by server-side authorization so protected routes/APIs cannot be accessed purely client-side.
- Provide minimal auditability for denied dev access attempts including user id/email/roles for traceability.
- Make the UI explicit that authorization is enforced on the backend as well.

### Description
- Update `apps/pwa/src/services/dev-gate.ts` to call a Supabase Edge Function (`dev-access`) via `supabase.functions.invoke`, add `verifyServerAccess` and surface server-side reasons in gate messages. 
- Change gate copy to state that authorizations are verified server-side and block access unless both client and server checks pass. 
- Add a Supabase Edge Function at `supabase/functions/dev-access/index.ts` that validates the authenticated user against env-configured allowed roles/emails and, on denial, inserts a minimal audit record (user id/email/roles/path/reason) using the service role key. 
- Add a migration `supabase/migrations/20260114_dev_access_audit.sql` to create `public.dev_access_audit` (RLS enabled) and update `supabase/SECURITY_POLICIES.md` to document the new function/table. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69834690aa148326bb35dce6bad21806)