### PR TITLE
Add idempotent shutdown handlers to AI support server

### DIFF
--- a/tools/ai-support-server.js
+++ b/tools/ai-support-server.js
@@ -2778,6 +2778,51 @@ const server = httpsOptions
   ? https.createServer(httpsOptions, requestHandler)
   : http.createServer(requestHandler);
 
+let shutdownStarted = false;
+
+function stopTimer(timerRef) {
+  if (!timerRef) return null;
+  clearTimeout(timerRef);
+  return null;
+}
+
+function terminateChild(child) {
+  if (!child) return null;
+  if (!child.killed) {
+    try {
+      child.kill('SIGTERM');
+    } catch (error) {
+      logError(`Failed to terminate child process: ${error.message}`);
+    }
+  }
+  return null;
+}
+
+function shutdownServer(signal) {
+  if (shutdownStarted) return;
+  shutdownStarted = true;
+
+  keepAliveTimer = stopTimer(keepAliveTimer);
+  watchdogTimer = stopTimer(watchdogTimer);
+
+  codexLoginProcess = terminateChild(codexLoginProcess);
+  ghLoginProcess = terminateChild(ghLoginProcess);
+
+  if (server.listening) {
+    try {
+      server.close(() => {
+        logLine(`Server closed after ${signal ?? 'shutdown'} signal.`);
+      });
+    } catch (error) {
+      logError(`Failed to close server: ${error.message}`);
+    }
+  }
+}
+
+process.on('SIGINT', () => shutdownServer('SIGINT'));
+process.on('SIGTERM', () => shutdownServer('SIGTERM'));
+process.on('exit', () => shutdownServer('exit'));
+
 server.listen(port, host, () => {
   const protocol = httpsOptions ? 'https' : 'http';
   const baseUrl = `${protocol}://${host}:${port}`;


### PR DESCRIPTION
### Motivation
- Ensure the AI support server performs a clean shutdown to avoid orphaned timers and child processes when the process receives termination signals or exits. 
- Prevent double-cleanup and race conditions by making the shutdown routine idempotent.

### Description
- Introduce a `shutdownStarted` guard and add helper functions `stopTimer()` and `terminateChild()` to centralize cleanup of timers and child processes. 
- Add `shutdownServer(signal)` that clears `keepAliveTimer` and `watchdogTimer`, terminates `codexLoginProcess` and `ghLoginProcess`, and closes the HTTP(S) `server` if listening. 
- Hook the shutdown routine to `process.on('SIGINT')`, `process.on('SIGTERM')`, and `process.on('exit')` so cleanup runs on those signals. 
- Changes applied to `tools/ai-support-server.js` to make shutdown idempotent and robust against errors during cleanup.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983469567a88326b91c42eb74e7cc72)