### PR TITLE
Parallelize deploy status tracking and harden Render polling

### DIFF
--- a/.github/actions/wait-render-deploy/action.yml
+++ b/.github/actions/wait-render-deploy/action.yml
@@ -1,0 +1,158 @@
+name: Wait Render Deploy
+description: Poll Render deploy status for a specific service and commit
+inputs:
+  deploy_sha:
+    description: Commit SHA to match
+    required: true
+  sync_epoch:
+    description: Sync epoch used as lower bound for deploy search
+    required: true
+  render_api_key:
+    description: Render API key
+    required: true
+  render_service_id:
+    description: Render service ID
+    required: true
+  label:
+    description: Service label used in logs
+    required: true
+outputs:
+  deploy_status:
+    description: success or failure
+    value: ${{ steps.wait.outputs.deploy_status }}
+runs:
+  using: composite
+  steps:
+    - name: Wait for Render deploy
+      id: wait
+      shell: bash
+      env:
+        DEPLOY_SHA: ${{ inputs.deploy_sha }}
+        SYNC_EPOCH: ${{ inputs.sync_epoch }}
+        RENDER_API_KEY: ${{ inputs.render_api_key }}
+        RENDER_SERVICE_ID: ${{ inputs.render_service_id }}
+        LABEL: ${{ inputs.label }}
+      run: |
+        set -euo pipefail
+
+        missing=0
+        for var in DEPLOY_SHA SYNC_EPOCH RENDER_API_KEY RENDER_SERVICE_ID LABEL; do
+          if [ -z "${!var:-}" ]; then
+            echo "Missing required value: $var"
+            missing=1
+          fi
+        done
+        if [ "$missing" -eq 1 ]; then
+          echo "deploy_status=failure" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        status="pending"
+        min_epoch="$((SYNC_EPOCH - 300))"
+
+        for attempt in $(seq 1 90); do
+          if ! response="$(curl -fsS \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys?limit=20")"; then
+            echo "[$LABEL] Render API request failed (attempt $attempt/90)" >&2
+            status="failure"
+            break
+          fi
+
+          deploys_json="$(echo "$response" | jq -c '
+            [
+              .. | objects
+              | select((has("status") or has("state") or has("deployStatus")) and (has("id") or has("deployId")))
+              | {
+                  id: (.id // .deployId // ""),
+                  status: (.status // .state // .deployStatus // "unknown"),
+                  commit: (
+                    (
+                      if has("commit") then
+                        (
+                          .commit as $c
+                          | if ($c | type) == "object" then ($c.id // $c.sha // "")
+                            elif ($c | type) == "string" then $c
+                            else ""
+                            end
+                        )
+                      else
+                        ""
+                      end
+                    ) as $commit
+                    | if $commit != "" then $commit else (.commitId // .commitHash // "") end
+                  ),
+                  createdAt: (.createdAt // .created_at // .created // ""),
+                  createdEpoch: (
+                    (.createdAt // .created_at // .created // 0) as $created
+                    | if ($created | type) == "string" and $created != "" then
+                        ($created | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601? // 0)
+                      elif ($created | type) == "number" then
+                        (if $created > 20000000000 then ($created / 1000 | floor) else ($created | floor) end)
+                      else 0
+                      end
+                  )
+                }
+              | select(.id != "")
+            ]
+            | unique_by(.id)
+          ')"
+
+          recent_deploys="$(echo "$deploys_json" | jq -c --argjson min_epoch "$min_epoch" '
+            map(select(.createdEpoch >= $min_epoch))
+            | sort_by(.createdEpoch)
+            | reverse
+          ')"
+
+          deploy_match="$(echo "$recent_deploys" | jq -c --arg sha "$DEPLOY_SHA" '
+            map(
+              select(
+                (.commit // "") as $c
+                | ($c | tostring) as $cs
+                | ($cs != "" and ($cs == $sha or ($sha | startswith($cs)) or ($cs | startswith($sha[0:7]))))
+              )
+            )
+            | first // empty
+          ')"
+          if [ -n "$deploy_match" ]; then
+            deploy="$deploy_match"
+          else
+            deploy="$(echo "$recent_deploys" | jq -c 'first // empty')"
+          fi
+
+          if [ "$deploy" = "null" ] || [ -z "$deploy" ]; then
+            latest_id="$(echo "$deploys_json" | jq -r 'sort_by(.createdEpoch) | reverse | first | (.id // "none")')"
+            latest_commit="$(echo "$deploys_json" | jq -r 'sort_by(.createdEpoch) | reverse | first | (.commit // "none")')"
+            if [ "$attempt" -eq 1 ]; then
+              echo "[$LABEL] Render candidates found: $(echo "$deploys_json" | jq -r 'length')" >&2
+            fi
+            echo "[$LABEL] attempt $attempt/90: no recent deploy found for $DEPLOY_SHA (latest id: $latest_id, latest commit: $latest_commit)" >&2
+            sleep 20
+            continue
+          fi
+
+          deploy_id="$(echo "$deploy" | jq -r '.id // "none"')"
+          deploy_commit="$(echo "$deploy" | jq -r '.commit // "none"')"
+          deploy_status="$(echo "$deploy" | jq -r '.status // "unknown"')"
+          echo "[$LABEL] attempt $attempt/90: deploy_id=$deploy_id commit=$deploy_commit status=$deploy_status" >&2
+
+          case "$deploy_status" in
+            live|deployed|ready|success)
+              status="success"
+              break
+              ;;
+            *_failed|failed|error|canceled|cancelled)
+              status="failure"
+              break
+              ;;
+            *)
+              sleep 20
+              ;;
+          esac
+        done
+
+        if [ "$status" = "pending" ]; then
+          status="failure"
+        fi
+
+        echo "deploy_status=$status" >> "$GITHUB_OUTPUT"

--- a/.github/actions/wait-render-deploy/action.yml
+++ b/.github/actions/wait-render-deploy/action.yml
@@ -16,6 +16,14 @@ inputs:
   label:
     description: Service label used in logs
     required: true
+  sleep_interval:
+    description: Seconds to wait between polling attempts
+    required: false
+    default: "20"
+  debug:
+    description: Enable debug logging
+    required: false
+    default: "false"
 outputs:
   deploy_status:
     description: success or failure
@@ -32,11 +40,13 @@ runs:
         RENDER_API_KEY: ${{ inputs.render_api_key }}
         RENDER_SERVICE_ID: ${{ inputs.render_service_id }}
         LABEL: ${{ inputs.label }}
+        SLEEP_INTERVAL: ${{ inputs.sleep_interval }}
+        DEBUG: ${{ inputs.debug }}
       run: |
         set -euo pipefail
 
         missing=0
-        for var in DEPLOY_SHA SYNC_EPOCH RENDER_API_KEY RENDER_SERVICE_ID LABEL; do
+        for var in DEPLOY_SHA SYNC_EPOCH RENDER_API_KEY RENDER_SERVICE_ID LABEL SLEEP_INTERVAL; do
           if [ -z "${!var:-}" ]; then
             echo "Missing required value: $var"
             missing=1
@@ -47,14 +57,56 @@ runs:
           exit 0
         fi
 
+        if [[ ! "$DEPLOY_SHA" =~ ^[a-fA-F0-9]{7,40}$ ]]; then
+          echo "Invalid SHA format: $DEPLOY_SHA" >&2
+          echo "deploy_status=failure" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ ! "$RENDER_SERVICE_ID" =~ ^srv-[a-zA-Z0-9]+$ ]]; then
+          echo "Invalid service ID format: $RENDER_SERVICE_ID" >&2
+          echo "deploy_status=failure" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ ! "$SLEEP_INTERVAL" =~ ^[0-9]+$ ]] || [ "$SLEEP_INTERVAL" -lt 1 ]; then
+          echo "Invalid sleep interval: $SLEEP_INTERVAL" >&2
+          echo "deploy_status=failure" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        debug_flag="$(echo "$DEBUG" | tr '[:upper:]' '[:lower:]')"
+        log_debug() {
+          if [ "$debug_flag" = "true" ]; then
+            echo "[$LABEL][debug] $*" >&2
+          fi
+        }
+
         status="pending"
         min_epoch="$((SYNC_EPOCH - 300))"
+        response_file="$(mktemp)"
+        trap 'rm -f "$response_file"' EXIT
 
         for attempt in $(seq 1 90); do
-          if ! response="$(curl -fsS \
+          if ! http_code="$(curl -sS -o "$response_file" -w "%{http_code}" \
             -H "Authorization: Bearer $RENDER_API_KEY" \
             "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys?limit=20")"; then
             echo "[$LABEL] Render API request failed (attempt $attempt/90)" >&2
+            status="failure"
+            break
+          fi
+          response="$(cat "$response_file")"
+
+          if [ "$http_code" = "429" ]; then
+            sleep_time=$((attempt * SLEEP_INTERVAL))
+            echo "[$LABEL] Rate limited (attempt $attempt/90), waiting ${sleep_time}s" >&2
+            sleep "$sleep_time"
+            continue
+          fi
+
+          if [[ ! "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+            echo "[$LABEL] Render API returned HTTP $http_code (attempt $attempt/90)" >&2
+            log_debug "Response body: $response"
             status="failure"
             break
           fi
@@ -127,7 +179,7 @@ runs:
               echo "[$LABEL] Render candidates found: $(echo "$deploys_json" | jq -r 'length')" >&2
             fi
             echo "[$LABEL] attempt $attempt/90: no recent deploy found for $DEPLOY_SHA (latest id: $latest_id, latest commit: $latest_commit)" >&2
-            sleep 20
+            sleep "$SLEEP_INTERVAL"
             continue
           fi
 
@@ -141,12 +193,12 @@ runs:
               status="success"
               break
               ;;
-            *_failed|failed|error|canceled|cancelled)
+            *_failed|failed|error|canceled|cancelled|build_failed|deactivate_failed)
               status="failure"
               break
               ;;
             *)
-              sleep 20
+              sleep "$SLEEP_INTERVAL"
               ;;
           esac
         done

--- a/.github/workflows/sync-deploy-branches.yml
+++ b/.github/workflows/sync-deploy-branches.yml
@@ -10,23 +10,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  configuration:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Configure Git
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
   sync-render-preview:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      actions: write
-      deployments: write
-
+    outputs:
+      deploy_sha: ${{ steps.sync-render-branch.outputs.deploy_sha }}
+      sync_epoch: ${{ steps.sync-render-branch.outputs.sync_epoch }}
     steps:
       - name: Configure Git
         run: |
@@ -66,9 +56,17 @@ jobs:
           echo "deploy_sha=$(git rev-parse origin/main)" >> "$GITHUB_OUTPUT"
           echo "sync_epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
 
+  deploy-turni:
+    runs-on: ubuntu-latest
+    needs: sync-render-preview
+    permissions:
+      contents: read
+      actions: write
+      deployments: write
+    steps:
       - name: Create GitHub Deployment - Turni-di-Palco
         uses: chrnorm/deployment-action@v2
-        id: deployment-main
+        id: deployment-turni
         with:
           token: '${{ github.token }}'
           ref: render/preview
@@ -76,9 +74,180 @@ jobs:
           environment: render/preview - Turni-di-Palco
           description: 'Deploy Turni-di-Palco to Render preview'
 
+      - name: Mark deployment in progress - Turni-di-Palco
+        if: always() && steps.deployment-turni.outputs.deployment_id != ''
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ github.token }}'
+          deployment-id: ${{ steps.deployment-turni.outputs.deployment_id }}
+          state: 'in_progress'
+          environment-url: https://turni-di-palco.onrender.com
+
+      - name: Wait for Turni-di-Palco auto-deploy
+        id: wait-turni
+        env:
+          DEPLOY_SHA: ${{ needs.sync-render-preview.outputs.deploy_sha }}
+          SYNC_EPOCH: ${{ needs.sync-render-preview.outputs.sync_epoch }}
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID_TURNI: ${{ secrets.RENDER_SERVICE_ID_TURNI }}
+        run: |
+          set -euo pipefail
+
+          missing=0
+          for var in DEPLOY_SHA SYNC_EPOCH RENDER_API_KEY RENDER_SERVICE_ID_TURNI; do
+            if [ -z "${!var:-}" ]; then
+              echo "Missing required value: $var"
+              missing=1
+            fi
+          done
+          if [ "$missing" -eq 1 ]; then
+            echo "deploy_status=failure" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          status="pending"
+          min_epoch="$((SYNC_EPOCH - 300))"
+
+          for attempt in $(seq 1 90); do
+            if ! response="$(curl -fsS \
+              -H "Authorization: Bearer $RENDER_API_KEY" \
+              "https://api.render.com/v1/services/${RENDER_SERVICE_ID_TURNI}/deploys?limit=20")"; then
+              echo "[Turni-di-Palco] Render API request failed (attempt $attempt/90)" >&2
+              status="failure"
+              break
+            fi
+
+            deploys_json="$(echo "$response" | jq -c '
+              [
+                .. | objects
+                | select((has("status") or has("state") or has("deployStatus")) and (has("id") or has("deployId")))
+                | {
+                    id: (.id // .deployId // ""),
+                    status: (.status // .state // .deployStatus // "unknown"),
+                    commit: (
+                      (
+                        if has("commit") then
+                          (
+                            .commit as $c
+                            | if ($c | type) == "object" then ($c.id // $c.sha // "")
+                              elif ($c | type) == "string" then $c
+                              else ""
+                              end
+                          )
+                        else
+                          ""
+                        end
+                      ) as $commit
+                      | if $commit != "" then $commit else (.commitId // .commitHash // "") end
+                    ),
+                    createdAt: (.createdAt // .created_at // .created // ""),
+                    createdEpoch: (
+                      (.createdAt // .created_at // .created // 0) as $created
+                      | if ($created | type) == "string" and $created != "" then
+                          ($created | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601? // 0)
+                        elif ($created | type) == "number" then
+                          (if $created > 20000000000 then ($created / 1000 | floor) else ($created | floor) end)
+                        else 0
+                        end
+                    )
+                  }
+                | select(.id != "")
+              ]
+              | unique_by(.id)
+            ')"
+
+            recent_deploys="$(echo "$deploys_json" | jq -c --argjson min_epoch "$min_epoch" '
+              map(select(.createdEpoch >= $min_epoch))
+              | sort_by(.createdEpoch)
+              | reverse
+            ')"
+
+            deploy_match="$(echo "$recent_deploys" | jq -c --arg sha "$DEPLOY_SHA" '
+              map(
+                select(
+                  (.commit // "") as $c
+                  | ($c | tostring) as $cs
+                  | ($cs != "" and ($cs == $sha or ($sha | startswith($cs)) or ($cs | startswith($sha[0:7]))))
+                )
+              )
+              | first // empty
+            ')"
+            if [ -n "$deploy_match" ]; then
+              deploy="$deploy_match"
+            else
+              deploy="$(echo "$recent_deploys" | jq -c 'first // empty')"
+            fi
+
+            if [ "$deploy" = "null" ] || [ -z "$deploy" ]; then
+              latest_id="$(echo "$deploys_json" | jq -r 'sort_by(.createdEpoch) | reverse | first | (.id // "none")')"
+              latest_commit="$(echo "$deploys_json" | jq -r 'sort_by(.createdEpoch) | reverse | first | (.commit // "none")')"
+              if [ "$attempt" -eq 1 ]; then
+                echo "[Turni-di-Palco] Render candidates found: $(echo "$deploys_json" | jq -r 'length')" >&2
+              fi
+              echo "[Turni-di-Palco] attempt $attempt/90: no recent deploy found for $DEPLOY_SHA (latest id: $latest_id, latest commit: $latest_commit)" >&2
+              sleep 20
+              continue
+            fi
+
+            deploy_id="$(echo "$deploy" | jq -r '.id // "none"')"
+            deploy_commit="$(echo "$deploy" | jq -r '.commit // "none"')"
+            deploy_status="$(echo "$deploy" | jq -r '.status // "unknown"')"
+            echo "[Turni-di-Palco] attempt $attempt/90: deploy_id=$deploy_id commit=$deploy_commit status=$deploy_status" >&2
+
+            case "$deploy_status" in
+              live|deployed|ready|success)
+                status="success"
+                break
+                ;;
+              *_failed|failed|error|canceled|cancelled)
+                status="failure"
+                break
+                ;;
+              *)
+                sleep 20
+                ;;
+            esac
+          done
+
+          if [ "$status" = "pending" ]; then
+            status="failure"
+          fi
+
+          echo "deploy_status=$status" >> "$GITHUB_OUTPUT"
+
+      - name: Update deployment status (success) - Turni-di-Palco
+        if: always() && steps.wait-turni.outputs.deploy_status == 'success' && steps.deployment-turni.outputs.deployment_id != ''
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ github.token }}'
+          deployment-id: ${{ steps.deployment-turni.outputs.deployment_id }}
+          state: 'success'
+          environment-url: https://turni-di-palco.onrender.com
+
+      - name: Update deployment status (failure) - Turni-di-Palco
+        if: always() && steps.wait-turni.outputs.deploy_status != 'success' && steps.deployment-turni.outputs.deployment_id != ''
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ github.token }}'
+          deployment-id: ${{ steps.deployment-turni.outputs.deployment_id }}
+          state: 'failure'
+          environment-url: https://turni-di-palco.onrender.com
+
+      - name: Fail job if Turni-di-Palco deploy failed
+        if: always() && steps.wait-turni.outputs.deploy_status != 'success'
+        run: exit 1
+
+  deploy-maxwell:
+    runs-on: ubuntu-latest
+    needs: sync-render-preview
+    permissions:
+      contents: read
+      actions: write
+      deployments: write
+    steps:
       - name: Create GitHub Deployment - Maxwell-AI-Support
         uses: chrnorm/deployment-action@v2
-        id: deployment-ai
+        id: deployment-maxwell
         with:
           token: '${{ github.token }}'
           ref: render/preview
@@ -86,206 +255,165 @@ jobs:
           environment: render/preview - Maxwell-AI-Support
           description: 'Deploy Maxwell-AI-Support to Render preview'
 
-      - name: Mark deployments in progress - Render
-        if: always() && steps.deployment-main.outputs.deployment_id != ''
+      - name: Mark deployment in progress - Maxwell-AI-Support
+        if: always() && steps.deployment-maxwell.outputs.deployment_id != ''
         uses: chrnorm/deployment-status@v2
         with:
           token: '${{ github.token }}'
-          deployment-id: ${{ steps.deployment-main.outputs.deployment_id }}
-          state: 'in_progress'
-          environment-url: https://turni-di-palco.onrender.com
-
-      - name: Mark deployments in progress - Maxwell
-        if: always() && steps.deployment-ai.outputs.deployment_id != ''
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ github.token }}'
-          deployment-id: ${{ steps.deployment-ai.outputs.deployment_id }}
+          deployment-id: ${{ steps.deployment-maxwell.outputs.deployment_id }}
           state: 'in_progress'
           environment-url: https://maxwell-ai-support.onrender.com
 
-      - name: Wait for Render auto-deploys
-        id: wait-render
+      - name: Wait for Maxwell-AI-Support auto-deploy
+        id: wait-maxwell
         env:
-          DEPLOY_SHA: ${{ steps.sync-render-branch.outputs.deploy_sha }}
-          SYNC_EPOCH: ${{ steps.sync-render-branch.outputs.sync_epoch }}
+          DEPLOY_SHA: ${{ needs.sync-render-preview.outputs.deploy_sha }}
+          SYNC_EPOCH: ${{ needs.sync-render-preview.outputs.sync_epoch }}
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-          RENDER_SERVICE_ID_TURNI: ${{ secrets.RENDER_SERVICE_ID_TURNI }}
           RENDER_SERVICE_ID_MAXWELL: ${{ secrets.RENDER_SERVICE_ID_MAXWELL }}
         run: |
           set -euo pipefail
 
           missing=0
-          for var in DEPLOY_SHA SYNC_EPOCH RENDER_API_KEY RENDER_SERVICE_ID_TURNI RENDER_SERVICE_ID_MAXWELL; do
+          for var in DEPLOY_SHA SYNC_EPOCH RENDER_API_KEY RENDER_SERVICE_ID_MAXWELL; do
             if [ -z "${!var:-}" ]; then
               echo "Missing required value: $var"
               missing=1
             fi
           done
           if [ "$missing" -eq 1 ]; then
-            echo "turni_status=failure" >> "$GITHUB_OUTPUT"
-            echo "maxwell_status=failure" >> "$GITHUB_OUTPUT"
+            echo "deploy_status=failure" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          poll_render() {
-            service_id="$1"
-            label="$2"
-            status="pending"
-            min_epoch="$((SYNC_EPOCH - 300))"
+          status="pending"
+          min_epoch="$((SYNC_EPOCH - 300))"
 
-            for attempt in $(seq 1 90); do
-              if ! response="$(curl -fsS \
-                -H "Authorization: Bearer $RENDER_API_KEY" \
-                "https://api.render.com/v1/services/${service_id}/deploys?limit=20")"; then
-                echo "[$label] Render API request failed (attempt $attempt/90)" >&2
-                status="failure"
-                break
-              fi
-
-              deploys_json="$(echo "$response" | jq -c '
-                [
-                  .. | objects
-                  | select((has("status") or has("state") or has("deployStatus")) and (has("id") or has("deployId")))
-                  | {
-                      id: (.id // .deployId // ""),
-                      status: (.status // .state // .deployStatus // "unknown"),
-                      commit: (
-                        (
-                          if has("commit") then
-                            (
-                              .commit as $c
-                              | if ($c | type) == "object" then ($c.id // $c.sha // "")
-                                elif ($c | type) == "string" then $c
-                                else ""
-                                end
-                            )
-                          else
-                            ""
-                          end
-                        ) as $commit
-                        | if $commit != "" then $commit else (.commitId // .commitHash // "") end
-                      ),
-                      createdAt: (.createdAt // .created_at // .created // ""),
-                      createdEpoch: (
-                        (.createdAt // .created_at // .created // 0) as $created
-                        | if ($created | type) == "string" and $created != "" then
-                            ($created | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601? // 0)
-                          elif ($created | type) == "number" then
-                            (if $created > 20000000000 then ($created / 1000 | floor) else ($created | floor) end)
-                          else 0
-                          end
-                      )
-                    }
-                  | select(.id != "")
-                ]
-                | unique_by(.id)
-              ')"
-
-              recent_deploys="$(echo "$deploys_json" | jq -c --argjson min_epoch "$min_epoch" '
-                map(select(.createdEpoch >= $min_epoch))
-                | sort_by(.createdEpoch)
-                | reverse
-              ')"
-
-              deploy_match="$(echo "$recent_deploys" | jq -c --arg sha "$DEPLOY_SHA" '
-                map(
-                  select(
-                    (.commit // "") as $c
-                    | ($c | tostring) as $cs
-                    | ($cs != "" and ($cs == $sha or ($sha | startswith($cs)) or ($cs | startswith($sha[0:7]))))
-                  )
-                )
-                | first // empty
-              ')"
-              if [ -n "$deploy_match" ]; then
-                deploy="$deploy_match"
-              else
-                deploy="$(echo "$recent_deploys" | jq -c 'first // empty')"
-              fi
-
-              if [ "$deploy" = "null" ] || [ -z "$deploy" ]; then
-                latest_id="$(echo "$deploys_json" | jq -r 'sort_by(.createdEpoch) | reverse | first | (.id // "none")')"
-                latest_commit="$(echo "$deploys_json" | jq -r 'sort_by(.createdEpoch) | reverse | first | (.commit // "none")')"
-                if [ "$attempt" -eq 1 ]; then
-                  echo "[$label] Render candidates found: $(echo "$deploys_json" | jq -r 'length')" >&2
-                fi
-                echo "[$label] attempt $attempt/90: no recent deploy found for $DEPLOY_SHA (latest id: $latest_id, latest commit: $latest_commit)" >&2
-                sleep 20
-                continue
-              fi
-
-              deploy_id="$(echo "$deploy" | jq -r '.id // "none"')"
-              deploy_commit="$(echo "$deploy" | jq -r '.commit // "none"')"
-              deploy_status="$(echo "$deploy" | jq -r '.status // "unknown"')"
-              echo "[$label] attempt $attempt/90: deploy_id=$deploy_id commit=$deploy_commit status=$deploy_status" >&2
-
-              case "$deploy_status" in
-                live|deployed|ready|success)
-                  status="success"
-                  break
-                  ;;
-                *_failed|failed|error|canceled|cancelled)
-                  status="failure"
-                  break
-                  ;;
-                *)
-                  sleep 20
-                  ;;
-              esac
-            done
-
-            if [ "$status" = "pending" ]; then
+          for attempt in $(seq 1 90); do
+            if ! response="$(curl -fsS \
+              -H "Authorization: Bearer $RENDER_API_KEY" \
+              "https://api.render.com/v1/services/${RENDER_SERVICE_ID_MAXWELL}/deploys?limit=20")"; then
+              echo "[Maxwell-AI-Support] Render API request failed (attempt $attempt/90)" >&2
               status="failure"
+              break
             fi
 
-            echo "$status"
-          }
+            deploys_json="$(echo "$response" | jq -c '
+              [
+                .. | objects
+                | select((has("status") or has("state") or has("deployStatus")) and (has("id") or has("deployId")))
+                | {
+                    id: (.id // .deployId // ""),
+                    status: (.status // .state // .deployStatus // "unknown"),
+                    commit: (
+                      (
+                        if has("commit") then
+                          (
+                            .commit as $c
+                            | if ($c | type) == "object" then ($c.id // $c.sha // "")
+                              elif ($c | type) == "string" then $c
+                              else ""
+                              end
+                          )
+                        else
+                          ""
+                        end
+                      ) as $commit
+                      | if $commit != "" then $commit else (.commitId // .commitHash // "") end
+                    ),
+                    createdAt: (.createdAt // .created_at // .created // ""),
+                    createdEpoch: (
+                      (.createdAt // .created_at // .created // 0) as $created
+                      | if ($created | type) == "string" and $created != "" then
+                          ($created | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601? // 0)
+                        elif ($created | type) == "number" then
+                          (if $created > 20000000000 then ($created / 1000 | floor) else ($created | floor) end)
+                        else 0
+                        end
+                    )
+                  }
+                | select(.id != "")
+              ]
+              | unique_by(.id)
+            ')"
 
-          turni_status="$(poll_render "$RENDER_SERVICE_ID_TURNI" "Turni-di-Palco")"
-          maxwell_status="$(poll_render "$RENDER_SERVICE_ID_MAXWELL" "Maxwell-AI-Support")"
+            recent_deploys="$(echo "$deploys_json" | jq -c --argjson min_epoch "$min_epoch" '
+              map(select(.createdEpoch >= $min_epoch))
+              | sort_by(.createdEpoch)
+              | reverse
+            ')"
 
-          echo "turni_status=$turni_status" >> "$GITHUB_OUTPUT"
-          echo "maxwell_status=$maxwell_status" >> "$GITHUB_OUTPUT"
+            deploy_match="$(echo "$recent_deploys" | jq -c --arg sha "$DEPLOY_SHA" '
+              map(
+                select(
+                  (.commit // "") as $c
+                  | ($c | tostring) as $cs
+                  | ($cs != "" and ($cs == $sha or ($sha | startswith($cs)) or ($cs | startswith($sha[0:7]))))
+                )
+              )
+              | first // empty
+            ')"
+            if [ -n "$deploy_match" ]; then
+              deploy="$deploy_match"
+            else
+              deploy="$(echo "$recent_deploys" | jq -c 'first // empty')"
+            fi
 
-      - name: Update deployment status (success) - Turni-di-Palco
-        if: always() && steps.wait-render.outputs.turni_status == 'success' && steps.deployment-main.outputs.deployment_id != ''
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ github.token }}'
-          deployment-id: ${{ steps.deployment-main.outputs.deployment_id }}
-          state: 'success'
-          environment-url: https://turni-di-palco.onrender.com
+            if [ "$deploy" = "null" ] || [ -z "$deploy" ]; then
+              latest_id="$(echo "$deploys_json" | jq -r 'sort_by(.createdEpoch) | reverse | first | (.id // "none")')"
+              latest_commit="$(echo "$deploys_json" | jq -r 'sort_by(.createdEpoch) | reverse | first | (.commit // "none")')"
+              if [ "$attempt" -eq 1 ]; then
+                echo "[Maxwell-AI-Support] Render candidates found: $(echo "$deploys_json" | jq -r 'length')" >&2
+              fi
+              echo "[Maxwell-AI-Support] attempt $attempt/90: no recent deploy found for $DEPLOY_SHA (latest id: $latest_id, latest commit: $latest_commit)" >&2
+              sleep 20
+              continue
+            fi
+
+            deploy_id="$(echo "$deploy" | jq -r '.id // "none"')"
+            deploy_commit="$(echo "$deploy" | jq -r '.commit // "none"')"
+            deploy_status="$(echo "$deploy" | jq -r '.status // "unknown"')"
+            echo "[Maxwell-AI-Support] attempt $attempt/90: deploy_id=$deploy_id commit=$deploy_commit status=$deploy_status" >&2
+
+            case "$deploy_status" in
+              live|deployed|ready|success)
+                status="success"
+                break
+                ;;
+              *_failed|failed|error|canceled|cancelled)
+                status="failure"
+                break
+                ;;
+              *)
+                sleep 20
+                ;;
+            esac
+          done
+
+          if [ "$status" = "pending" ]; then
+            status="failure"
+          fi
+
+          echo "deploy_status=$status" >> "$GITHUB_OUTPUT"
 
       - name: Update deployment status (success) - Maxwell-AI-Support
-        if: always() && steps.wait-render.outputs.maxwell_status == 'success' && steps.deployment-ai.outputs.deployment_id != ''
+        if: always() && steps.wait-maxwell.outputs.deploy_status == 'success' && steps.deployment-maxwell.outputs.deployment_id != ''
         uses: chrnorm/deployment-status@v2
         with:
           token: '${{ github.token }}'
-          deployment-id: ${{ steps.deployment-ai.outputs.deployment_id }}
+          deployment-id: ${{ steps.deployment-maxwell.outputs.deployment_id }}
           state: 'success'
           environment-url: https://maxwell-ai-support.onrender.com
 
-      - name: Update deployment status (failure) - Turni-di-Palco
-        if: always() && steps.wait-render.outputs.turni_status != 'success' && steps.deployment-main.outputs.deployment_id != ''
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ github.token }}'
-          deployment-id: ${{ steps.deployment-main.outputs.deployment_id }}
-          state: 'failure'
-          environment-url: https://turni-di-palco.onrender.com
-
       - name: Update deployment status (failure) - Maxwell-AI-Support
-        if: always() && steps.wait-render.outputs.maxwell_status != 'success' && steps.deployment-ai.outputs.deployment_id != ''
+        if: always() && steps.wait-maxwell.outputs.deploy_status != 'success' && steps.deployment-maxwell.outputs.deployment_id != ''
         uses: chrnorm/deployment-status@v2
         with:
           token: '${{ github.token }}'
-          deployment-id: ${{ steps.deployment-ai.outputs.deployment_id }}
+          deployment-id: ${{ steps.deployment-maxwell.outputs.deployment_id }}
           state: 'failure'
           environment-url: https://maxwell-ai-support.onrender.com
 
-      - name: Fail workflow if Render deploys failed
-        if: always() && (steps.wait-render.outputs.turni_status != 'success' || steps.wait-render.outputs.maxwell_status != 'success')
+      - name: Fail job if Maxwell-AI-Support deploy failed
+        if: always() && steps.wait-maxwell.outputs.deploy_status != 'success'
         run: exit 1
-
-  

--- a/.github/workflows/sync-deploy-branches.yml
+++ b/.github/workflows/sync-deploy-branches.yml
@@ -64,6 +64,9 @@ jobs:
       actions: write
       deployments: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Create GitHub Deployment - Turni-di-Palco
         uses: chrnorm/deployment-action@v2
         id: deployment-turni
@@ -85,135 +88,13 @@ jobs:
 
       - name: Wait for Turni-di-Palco auto-deploy
         id: wait-turni
-        env:
-          DEPLOY_SHA: ${{ needs.sync-render-preview.outputs.deploy_sha }}
-          SYNC_EPOCH: ${{ needs.sync-render-preview.outputs.sync_epoch }}
-          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-          RENDER_SERVICE_ID_TURNI: ${{ secrets.RENDER_SERVICE_ID_TURNI }}
-        run: |
-          set -euo pipefail
-
-          missing=0
-          for var in DEPLOY_SHA SYNC_EPOCH RENDER_API_KEY RENDER_SERVICE_ID_TURNI; do
-            if [ -z "${!var:-}" ]; then
-              echo "Missing required value: $var"
-              missing=1
-            fi
-          done
-          if [ "$missing" -eq 1 ]; then
-            echo "deploy_status=failure" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          status="pending"
-          min_epoch="$((SYNC_EPOCH - 300))"
-
-          for attempt in $(seq 1 90); do
-            if ! response="$(curl -fsS \
-              -H "Authorization: Bearer $RENDER_API_KEY" \
-              "https://api.render.com/v1/services/${RENDER_SERVICE_ID_TURNI}/deploys?limit=20")"; then
-              echo "[Turni-di-Palco] Render API request failed (attempt $attempt/90)" >&2
-              status="failure"
-              break
-            fi
-
-            deploys_json="$(echo "$response" | jq -c '
-              [
-                .. | objects
-                | select((has("status") or has("state") or has("deployStatus")) and (has("id") or has("deployId")))
-                | {
-                    id: (.id // .deployId // ""),
-                    status: (.status // .state // .deployStatus // "unknown"),
-                    commit: (
-                      (
-                        if has("commit") then
-                          (
-                            .commit as $c
-                            | if ($c | type) == "object" then ($c.id // $c.sha // "")
-                              elif ($c | type) == "string" then $c
-                              else ""
-                              end
-                          )
-                        else
-                          ""
-                        end
-                      ) as $commit
-                      | if $commit != "" then $commit else (.commitId // .commitHash // "") end
-                    ),
-                    createdAt: (.createdAt // .created_at // .created // ""),
-                    createdEpoch: (
-                      (.createdAt // .created_at // .created // 0) as $created
-                      | if ($created | type) == "string" and $created != "" then
-                          ($created | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601? // 0)
-                        elif ($created | type) == "number" then
-                          (if $created > 20000000000 then ($created / 1000 | floor) else ($created | floor) end)
-                        else 0
-                        end
-                    )
-                  }
-                | select(.id != "")
-              ]
-              | unique_by(.id)
-            ')"
-
-            recent_deploys="$(echo "$deploys_json" | jq -c --argjson min_epoch "$min_epoch" '
-              map(select(.createdEpoch >= $min_epoch))
-              | sort_by(.createdEpoch)
-              | reverse
-            ')"
-
-            deploy_match="$(echo "$recent_deploys" | jq -c --arg sha "$DEPLOY_SHA" '
-              map(
-                select(
-                  (.commit // "") as $c
-                  | ($c | tostring) as $cs
-                  | ($cs != "" and ($cs == $sha or ($sha | startswith($cs)) or ($cs | startswith($sha[0:7]))))
-                )
-              )
-              | first // empty
-            ')"
-            if [ -n "$deploy_match" ]; then
-              deploy="$deploy_match"
-            else
-              deploy="$(echo "$recent_deploys" | jq -c 'first // empty')"
-            fi
-
-            if [ "$deploy" = "null" ] || [ -z "$deploy" ]; then
-              latest_id="$(echo "$deploys_json" | jq -r 'sort_by(.createdEpoch) | reverse | first | (.id // "none")')"
-              latest_commit="$(echo "$deploys_json" | jq -r 'sort_by(.createdEpoch) | reverse | first | (.commit // "none")')"
-              if [ "$attempt" -eq 1 ]; then
-                echo "[Turni-di-Palco] Render candidates found: $(echo "$deploys_json" | jq -r 'length')" >&2
-              fi
-              echo "[Turni-di-Palco] attempt $attempt/90: no recent deploy found for $DEPLOY_SHA (latest id: $latest_id, latest commit: $latest_commit)" >&2
-              sleep 20
-              continue
-            fi
-
-            deploy_id="$(echo "$deploy" | jq -r '.id // "none"')"
-            deploy_commit="$(echo "$deploy" | jq -r '.commit // "none"')"
-            deploy_status="$(echo "$deploy" | jq -r '.status // "unknown"')"
-            echo "[Turni-di-Palco] attempt $attempt/90: deploy_id=$deploy_id commit=$deploy_commit status=$deploy_status" >&2
-
-            case "$deploy_status" in
-              live|deployed|ready|success)
-                status="success"
-                break
-                ;;
-              *_failed|failed|error|canceled|cancelled)
-                status="failure"
-                break
-                ;;
-              *)
-                sleep 20
-                ;;
-            esac
-          done
-
-          if [ "$status" = "pending" ]; then
-            status="failure"
-          fi
-
-          echo "deploy_status=$status" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/wait-render-deploy
+        with:
+          deploy_sha: ${{ needs.sync-render-preview.outputs.deploy_sha }}
+          sync_epoch: ${{ needs.sync-render-preview.outputs.sync_epoch }}
+          render_api_key: ${{ secrets.RENDER_API_KEY }}
+          render_service_id: ${{ secrets.RENDER_SERVICE_ID_TURNI }}
+          label: Turni-di-Palco
 
       - name: Update deployment status (success) - Turni-di-Palco
         if: always() && steps.wait-turni.outputs.deploy_status == 'success' && steps.deployment-turni.outputs.deployment_id != ''
@@ -245,6 +126,9 @@ jobs:
       actions: write
       deployments: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Create GitHub Deployment - Maxwell-AI-Support
         uses: chrnorm/deployment-action@v2
         id: deployment-maxwell
@@ -266,135 +150,13 @@ jobs:
 
       - name: Wait for Maxwell-AI-Support auto-deploy
         id: wait-maxwell
-        env:
-          DEPLOY_SHA: ${{ needs.sync-render-preview.outputs.deploy_sha }}
-          SYNC_EPOCH: ${{ needs.sync-render-preview.outputs.sync_epoch }}
-          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-          RENDER_SERVICE_ID_MAXWELL: ${{ secrets.RENDER_SERVICE_ID_MAXWELL }}
-        run: |
-          set -euo pipefail
-
-          missing=0
-          for var in DEPLOY_SHA SYNC_EPOCH RENDER_API_KEY RENDER_SERVICE_ID_MAXWELL; do
-            if [ -z "${!var:-}" ]; then
-              echo "Missing required value: $var"
-              missing=1
-            fi
-          done
-          if [ "$missing" -eq 1 ]; then
-            echo "deploy_status=failure" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          status="pending"
-          min_epoch="$((SYNC_EPOCH - 300))"
-
-          for attempt in $(seq 1 90); do
-            if ! response="$(curl -fsS \
-              -H "Authorization: Bearer $RENDER_API_KEY" \
-              "https://api.render.com/v1/services/${RENDER_SERVICE_ID_MAXWELL}/deploys?limit=20")"; then
-              echo "[Maxwell-AI-Support] Render API request failed (attempt $attempt/90)" >&2
-              status="failure"
-              break
-            fi
-
-            deploys_json="$(echo "$response" | jq -c '
-              [
-                .. | objects
-                | select((has("status") or has("state") or has("deployStatus")) and (has("id") or has("deployId")))
-                | {
-                    id: (.id // .deployId // ""),
-                    status: (.status // .state // .deployStatus // "unknown"),
-                    commit: (
-                      (
-                        if has("commit") then
-                          (
-                            .commit as $c
-                            | if ($c | type) == "object" then ($c.id // $c.sha // "")
-                              elif ($c | type) == "string" then $c
-                              else ""
-                              end
-                          )
-                        else
-                          ""
-                        end
-                      ) as $commit
-                      | if $commit != "" then $commit else (.commitId // .commitHash // "") end
-                    ),
-                    createdAt: (.createdAt // .created_at // .created // ""),
-                    createdEpoch: (
-                      (.createdAt // .created_at // .created // 0) as $created
-                      | if ($created | type) == "string" and $created != "" then
-                          ($created | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601? // 0)
-                        elif ($created | type) == "number" then
-                          (if $created > 20000000000 then ($created / 1000 | floor) else ($created | floor) end)
-                        else 0
-                        end
-                    )
-                  }
-                | select(.id != "")
-              ]
-              | unique_by(.id)
-            ')"
-
-            recent_deploys="$(echo "$deploys_json" | jq -c --argjson min_epoch "$min_epoch" '
-              map(select(.createdEpoch >= $min_epoch))
-              | sort_by(.createdEpoch)
-              | reverse
-            ')"
-
-            deploy_match="$(echo "$recent_deploys" | jq -c --arg sha "$DEPLOY_SHA" '
-              map(
-                select(
-                  (.commit // "") as $c
-                  | ($c | tostring) as $cs
-                  | ($cs != "" and ($cs == $sha or ($sha | startswith($cs)) or ($cs | startswith($sha[0:7]))))
-                )
-              )
-              | first // empty
-            ')"
-            if [ -n "$deploy_match" ]; then
-              deploy="$deploy_match"
-            else
-              deploy="$(echo "$recent_deploys" | jq -c 'first // empty')"
-            fi
-
-            if [ "$deploy" = "null" ] || [ -z "$deploy" ]; then
-              latest_id="$(echo "$deploys_json" | jq -r 'sort_by(.createdEpoch) | reverse | first | (.id // "none")')"
-              latest_commit="$(echo "$deploys_json" | jq -r 'sort_by(.createdEpoch) | reverse | first | (.commit // "none")')"
-              if [ "$attempt" -eq 1 ]; then
-                echo "[Maxwell-AI-Support] Render candidates found: $(echo "$deploys_json" | jq -r 'length')" >&2
-              fi
-              echo "[Maxwell-AI-Support] attempt $attempt/90: no recent deploy found for $DEPLOY_SHA (latest id: $latest_id, latest commit: $latest_commit)" >&2
-              sleep 20
-              continue
-            fi
-
-            deploy_id="$(echo "$deploy" | jq -r '.id // "none"')"
-            deploy_commit="$(echo "$deploy" | jq -r '.commit // "none"')"
-            deploy_status="$(echo "$deploy" | jq -r '.status // "unknown"')"
-            echo "[Maxwell-AI-Support] attempt $attempt/90: deploy_id=$deploy_id commit=$deploy_commit status=$deploy_status" >&2
-
-            case "$deploy_status" in
-              live|deployed|ready|success)
-                status="success"
-                break
-                ;;
-              *_failed|failed|error|canceled|cancelled)
-                status="failure"
-                break
-                ;;
-              *)
-                sleep 20
-                ;;
-            esac
-          done
-
-          if [ "$status" = "pending" ]; then
-            status="failure"
-          fi
-
-          echo "deploy_status=$status" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/wait-render-deploy
+        with:
+          deploy_sha: ${{ needs.sync-render-preview.outputs.deploy_sha }}
+          sync_epoch: ${{ needs.sync-render-preview.outputs.sync_epoch }}
+          render_api_key: ${{ secrets.RENDER_API_KEY }}
+          render_service_id: ${{ secrets.RENDER_SERVICE_ID_MAXWELL }}
+          label: Maxwell-AI-Support
 
       - name: Update deployment status (success) - Maxwell-AI-Support
         if: always() && steps.wait-maxwell.outputs.deploy_status == 'success' && steps.deployment-maxwell.outputs.deployment_id != ''


### PR DESCRIPTION
## Intent
Rendere i deploy `render/preview` indipendenti per `Turni-di-Palco` e `Maxwell-AI-Support`, con polling Render riusabile e più robusto.

## Key changes
- Split del workflow in job paralleli:
  - `sync-render-preview`
  - `deploy-turni`
  - `deploy-maxwell`
- Ogni job deploy ora aggiorna il proprio stato (`in_progress` / `success` / `failure`) senza attendere l’altro.
- Estrazione del polling Render in una composite action locale:
  - `.github/actions/wait-render-deploy/action.yml`
- Hardening della action:
  - gestione HTTP 429 con backoff progressivo
  - validazione input (`deploy_sha`, `render_service_id`, `sleep_interval`)
  - estensione failure pattern (`build_failed`, `deactivate_failed`)
  - supporto input opzionali `sleep_interval` e `debug`
  - gestione esplicita HTTP code e debug logging controllato

## Testing
- Verifica statica della struttura workflow/action e wiring dei `uses` locali.
- Nessun test runtime eseguito localmente (workflow GitHub Actions).