### PR TITLE
Fix Maxwell Render port binding on loopback host

### DIFF
--- a/tools/ai-support-server.js
+++ b/tools/ai-support-server.js
@@ -1188,10 +1188,30 @@ function resolveHttpsOptions() {
 }
 
 function resolveHost() {
-  if (process.env.AI_SUPPORT_HOST) {
-    return process.env.AI_SUPPORT_HOST;
+  const configuredHost = process.env.AI_SUPPORT_HOST;
+  const runningOnRender = Boolean(process.env.RENDER || process.env.RENDER_SERVICE_ID);
+  const allowLocalhostOnRender =
+    process.env.AI_SUPPORT_ALLOW_LOCALHOST_ON_RENDER === '1' ||
+    process.env.AI_SUPPORT_ALLOW_LOCALHOST_ON_RENDER === 'true';
+
+  if (configuredHost) {
+    const normalizedHost = configuredHost.trim().toLowerCase();
+    const isLoopbackHost =
+      normalizedHost === '127.0.0.1' ||
+      normalizedHost === 'localhost' ||
+      normalizedHost === '::1';
+
+    if (runningOnRender && isLoopbackHost && !allowLocalhostOnRender) {
+      logLine(
+        `AI_SUPPORT_HOST=${configuredHost} ignored on Render; forcing 0.0.0.0 for port binding`
+      );
+      return '0.0.0.0';
+    }
+
+    return configuredHost;
   }
-  if (process.env.RENDER || process.env.RENDER_SERVICE_ID) {
+
+  if (runningOnRender) {
     return '0.0.0.0';
   }
   return '127.0.0.1';


### PR DESCRIPTION
## Intent
Fix Maxwell deploy failures on Render caused by loopback host binding.

## What changed
- Updated `resolveHost()` in `tools/ai-support-server.js` to force `0.0.0.0` on Render when `AI_SUPPORT_HOST` is set to loopback (`127.0.0.1`, `localhost`, `::1`).
- Added explicit override `AI_SUPPORT_ALLOW_LOCALHOST_ON_RENDER=1|true` to allow loopback on Render only when intentionally requested.
- Added log message when a loopback host is ignored on Render.

## Why
Render reported `Port scan timeout reached, no open ports detected` for Maxwell. This ensures the service binds to a public interface in Render environments.

## Testing
- Root-cause verified via Render MCP logs/deploy status.
- Static verification of host resolution path.