### PR TITLE
Add robust Render badges and centralize env helpers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,90 @@
-# Supabase configuration
-SUPABASE_URL=https://nskdqxntfxtwnbtunpgm.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=
-# Supabase client configuration (PWA/tools)
-VITE_SUPABASE_URL=https://nskdqxntfxtwnbtunpgm.supabase.co
-VITE_SUPABASE_ANON_KEY=
-# Dry run mode
+# =====================================
+# Core / shared
+# =====================================
+
+# Dry run mode for import/maintenance scripts (1=true, 0=false)
 DRY_RUN=1
+
+# Optional: force cache version in tools/update-cache-version.js
+SW_CACHE_VERSION=
+
+# =====================================
+# Supabase
+# =====================================
+
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# PWA client configuration
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+
+# =====================================
+# AI Support server (tools/ai-support-server.js)
+# =====================================
+
+# Port resolution priority: PORT -> AI_SUPPORT_PORT -> VITE_AI_SUPPORT_PORT
+PORT=8787
+AI_SUPPORT_PORT=
+VITE_AI_SUPPORT_PORT=
+
+# Default local host is 127.0.0.1, on Render it auto-forces 0.0.0.0
+AI_SUPPORT_HOST=
+# Set 1/true only if you intentionally want localhost binding on Render
+AI_SUPPORT_ALLOW_LOCALHOST_ON_RENDER=
+
+# Logging / output
+AI_SUPPORT_VERBOSE=true
+AI_SUPPORT_LOG_MESSAGES=false
+AI_SUPPORT_COLOR=true
+
+# Auth / API protection
+AI_SUPPORT_API_KEY=
+AI_SUPPORT_API_TOKEN=
+AI_SUPPORT_ISSUE_TOKEN=
+AI_SUPPORT_ALLOWED_ORIGINS=
+AI_SUPPORT_ADMIN_ENABLED=false
+
+# Rate limiter
+AI_SUPPORT_RATE_LIMIT_MAX=60
+AI_SUPPORT_RATE_LIMIT_WINDOW_MS=60000
+
+# HTTPS (local/dev)
+AI_SUPPORT_HTTPS=false
+SSL_CRT_FILE=
+SSL_KEY_FILE=
+
+# Optional auth storage
+AI_SUPPORT_AUTH_ENV_FILE=
+AI_SUPPORT_AUTH_ENV_WRITE=false
+AI_SUPPORT_AUTH_DIR=
+AI_SUPPORT_CREDENTIALS_FILE=
+
+# Binaries / CLI overrides
+CODEX_BIN=
+CODEX_ARGS=
+AI_SUPPORT_GH_BIN=
+
+# GitHub integration
+AI_SUPPORT_GH_REPO=
+GITHUB_REPO=
+GITHUB_REPO_OWNER=
+GITHUB_REPO_NAME=
+GH_HOST=github.com
+GH_TOKEN=
+GITHUB_TOKEN=
+
+# =====================================
+# Render badge generator (tools/render-status-badge.js)
+# =====================================
+
+RENDER_API_KEY=
+RENDER_SERVICE_ID=
+RENDER_BADGE_LABEL=
+RENDER_BADGE_STYLE=for-the-badge
+
+# =====================================
+# Watchdog
+# =====================================
+
+WATCHDOG_LOG_LEVEL=info

--- a/.github/workflows/render-badge-urls.yml
+++ b/.github/workflows/render-badge-urls.yml
@@ -1,0 +1,49 @@
+name: Render Badge URLs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Turni badge URL
+        id: turni
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_TURNI }}
+        run: |
+          url="$(npm run -s badge:render -- --label 'Render Turni')"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Generate Maxwell badge URL
+        id: maxwell
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_MAXWELL }}
+        run: |
+          url="$(npm run -s badge:render -- --label 'Render Maxwell')"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Publish URLs
+        run: |
+          {
+            echo "## Render badge URLs"
+            echo ""
+            echo "- Turni: ${{ steps.turni.outputs.url }}"
+            echo "- Maxwell: ${{ steps.maxwell.outputs.url }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![CI](https://github.com/Heartran/Turni-di-Palco/actions/workflows/ci.yml/badge.svg)](https://github.com/Heartran/Turni-di-Palco/actions/workflows/ci.yml)
 [![Update Server Repository](https://github.com/Heartran/Turni-di-Palco/actions/workflows/update-server-repository.yml/badge.svg)](https://github.com/Heartran/Turni-di-Palco/actions/workflows/update-server-repository.yml)
 [![Sync Deploy Branches](https://github.com/Heartran/Turni-di-Palco/actions/workflows/sync-deploy-branches.yml/badge.svg)](https://github.com/Heartran/Turni-di-Palco/actions/workflows/sync-deploy-branches.yml)
-[![Render Turni Deploy](https://img.shields.io/github/deployments/Heartran/Turni-di-Palco/render%2Fpreview%20-%20Turni-di-Palco?label=Render%20Turni&logo=render)](https://github.com/Heartran/Turni-di-Palco/deployments)
-[![Render Maxwell Deploy](https://img.shields.io/github/deployments/Heartran/Turni-di-Palco/render%2Fpreview%20-%20Maxwell-AI-Support?label=Render%20Maxwell&logo=render)](https://github.com/Heartran/Turni-di-Palco/deployments)
+[Render deploy status (Turni)](https://github.com/Heartran/Turni-di-Palco/deployments?environment=render%2Fpreview+-+Turni-di-Palco)
+[Render deploy status (Maxwell)](https://github.com/Heartran/Turni-di-Palco/deployments?environment=render%2Fpreview+-+Maxwell-AI-Support)
 
 Turni di Palco è una Progressive Web App pensata per gestire i turni teatrali con meccaniche di gioco (XP, livelli, ruoli) per rendere l'organizzazione piu coinvolgente.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![CI](https://github.com/Heartran/Turni-di-Palco/actions/workflows/ci.yml/badge.svg)](https://github.com/Heartran/Turni-di-Palco/actions/workflows/ci.yml)
 [![Update Server Repository](https://github.com/Heartran/Turni-di-Palco/actions/workflows/update-server-repository.yml/badge.svg)](https://github.com/Heartran/Turni-di-Palco/actions/workflows/update-server-repository.yml)
 [![Sync Deploy Branches](https://github.com/Heartran/Turni-di-Palco/actions/workflows/sync-deploy-branches.yml/badge.svg)](https://github.com/Heartran/Turni-di-Palco/actions/workflows/sync-deploy-branches.yml)
+[![Render Turni Deploy](https://img.shields.io/github/deployments/Heartran/Turni-di-Palco/render%2Fpreview%20-%20Turni-di-Palco?label=Render%20Turni&logo=render)](https://github.com/Heartran/Turni-di-Palco/deployments)
+[![Render Maxwell Deploy](https://img.shields.io/github/deployments/Heartran/Turni-di-Palco/render%2Fpreview%20-%20Maxwell-AI-Support?label=Render%20Maxwell&logo=render)](https://github.com/Heartran/Turni-di-Palco/deployments)
 
 Turni di Palco è una Progressive Web App pensata per gestire i turni teatrali con meccaniche di gioco (XP, livelli, ruoli) per rendere l'organizzazione piu coinvolgente.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CI](https://github.com/Heartran/Turni-di-Palco/actions/workflows/ci.yml/badge.svg)](https://github.com/Heartran/Turni-di-Palco/actions/workflows/ci.yml)
 [![Update Server Repository](https://github.com/Heartran/Turni-di-Palco/actions/workflows/update-server-repository.yml/badge.svg)](https://github.com/Heartran/Turni-di-Palco/actions/workflows/update-server-repository.yml)
 [![Sync Deploy Branches](https://github.com/Heartran/Turni-di-Palco/actions/workflows/sync-deploy-branches.yml/badge.svg)](https://github.com/Heartran/Turni-di-Palco/actions/workflows/sync-deploy-branches.yml)
+[![Render Badge URLs](https://github.com/Heartran/Turni-di-Palco/actions/workflows/render-badge-urls.yml/badge.svg)](https://github.com/Heartran/Turni-di-Palco/actions/workflows/render-badge-urls.yml)
 [Render deploy status (Turni)](https://github.com/Heartran/Turni-di-Palco/deployments?environment=render%2Fpreview+-+Turni-di-Palco)
 [Render deploy status (Maxwell)](https://github.com/Heartran/Turni-di-Palco/deployments?environment=render%2Fpreview+-+Maxwell-AI-Support)
 
@@ -32,6 +33,11 @@ npm install
 ## Comandi disponibili
 
 Tutti gli script vanno eseguiti dalla root con `npm run <script>`.
+
+### Badge Render
+
+- `badge:render`: genera una URL badge Shields basata sull'ultimo deploy Render (`RENDER_API_KEY` + `RENDER_SERVICE_ID`).
+- Workflow manuale `Render Badge URLs`: pubblica in summary le due URL (Turni e Maxwell) usando i secret Render del repository.
 
 ### Manutenzione
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.39.0",
         "ajv": "^8.17.1",
-        "dotenv": "^16.3.1"
+        "dotenv": "^16.3.1",
+        "render-status-badge": "^1.0.1"
       },
       "devDependencies": {
         "qrcode": "^1.5.4",
@@ -219,7 +220,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -241,7 +241,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3261,7 +3260,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
       "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3278,7 +3276,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3289,7 +3286,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3338,7 +3334,6 @@
       "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.0",
         "@typescript-eslint/types": "8.50.0",
@@ -3662,13 +3657,34 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3755,6 +3771,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3767,14 +3789,75 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
+      "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -3787,9 +3870,17 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3797,6 +3888,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -3917,7 +4024,6 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -3932,6 +4038,45 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -4176,10 +4321,28 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-libc": {
@@ -4229,7 +4392,6 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -4240,12 +4402,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/embla-carousel": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -4276,6 +4443,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.4",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
@@ -4303,7 +4479,6 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4311,7 +4486,6 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4326,7 +4500,6 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4337,7 +4510,6 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4816,6 +4988,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -4835,7 +5013,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4896,7 +5073,6 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5123,6 +5299,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -5136,6 +5321,73 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5220,6 +5472,39 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -5258,9 +5543,28 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -5271,6 +5575,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/fsevents": {
@@ -5290,7 +5612,6 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5308,7 +5629,6 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5340,7 +5660,6 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5378,7 +5697,6 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5406,7 +5724,6 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5417,7 +5734,6 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -5431,7 +5747,6 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5449,6 +5764,26 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -5523,6 +5858,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/input-otp": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
@@ -5540,6 +5881,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-extglob": {
@@ -5591,7 +5941,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -5619,7 +5968,6 @@
       "version": "25.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -6035,15 +6383,52 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6051,7 +6436,6 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -6078,7 +6462,6 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6105,6 +6488,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -6129,6 +6521,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -6139,6 +6543,18 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -6224,6 +6640,15 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6241,6 +6666,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -6320,7 +6751,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6361,6 +6791,25 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
@@ -6396,12 +6845,62 @@
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
+    "node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6428,7 +6927,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6601,6 +7099,113 @@
         "decimal.js-light": "^2.4.1"
       }
     },
+    "node_modules/render-status-badge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/render-status-badge/-/render-status-badge-1.0.1.tgz",
+      "integrity": "sha512-+Dbt5xIaq2khcCm/rFxtC1j3bKtIWiTozFRv6NZrdXvFtZtQBlB538b6jLv/F+MLOHR8bsMI+RpPzs8Aeh4TWg==",
+      "license": "ISC",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "array-flatten": "^1.1.1",
+        "axios": "^1.8.3",
+        "body-parser": "^1.20.3",
+        "bytes": "^3.1.2",
+        "call-bind-apply-helpers": "^1.0.2",
+        "call-bound": "^1.0.4",
+        "content-disposition": "^0.5.4",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.0.6",
+        "debug": "^2.6.9",
+        "depd": "^2.0.0",
+        "destroy": "^1.2.0",
+        "dotenv": "^16.4.7",
+        "dunder-proto": "^1.0.1",
+        "ee-first": "^1.1.1",
+        "encodeurl": "^2.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "express": "^4.21.2",
+        "finalhandler": "^1.3.1",
+        "forwarded": "^0.2.0",
+        "fresh": "^0.5.2",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.4.24",
+        "inherits": "^2.0.4",
+        "ipaddr.js": "^1.9.1",
+        "math-intrinsics": "^1.1.0",
+        "media-typer": "^0.3.0",
+        "merge-descriptors": "^1.0.3",
+        "methods": "^1.1.2",
+        "mime": "^1.6.0",
+        "mime-db": "^1.52.0",
+        "mime-types": "^2.1.35",
+        "ms": "^2.0.0",
+        "negotiator": "^0.6.3",
+        "object-inspect": "^1.13.4",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^0.1.12",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.13.0",
+        "range-parser": "^1.2.1",
+        "raw-body": "^2.5.2",
+        "safe-buffer": "^5.2.1",
+        "safer-buffer": "^2.1.2",
+        "send": "^0.19.0",
+        "serve-static": "^1.16.2",
+        "setprototypeof": "^1.2.0",
+        "side-channel": "^1.1.0",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2",
+        "statuses": "^2.0.1",
+        "toidentifier": "^1.0.1",
+        "type-is": "^1.6.18",
+        "unpipe": "^1.0.0",
+        "utils-merge": "^1.0.1",
+        "vary": "^1.1.2"
+      },
+      "bin": {
+        "render-status-badge": "index.js"
+      }
+    },
+    "node_modules/render-status-badge/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/render-status-badge/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/render-status-badge/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6684,9 +7289,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -6722,11 +7346,71 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
     "node_modules/shebang-command": {
@@ -6746,6 +7430,78 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -6775,6 +7531,15 @@
       "version": "0.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -6950,6 +7715,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "dev": true,
@@ -7012,11 +7786,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7030,6 +7816,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -7093,6 +7888,24 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/vaul": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
@@ -7134,7 +7947,6 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "sync:mobile": "node tools/sync-mobile.js",
     "ai:codex": "node tools/ai-codex.js",
     "ai:support": "node tools/ai-support-server.js",
+    "badge:render": "node tools/render-status-badge.js",
     "cleanup:events": "node tools/cleanup-old-events.js",
     "keep-alive": "node tools/keep-alive-reciprocal.js",
     "watchdog": "node tools/maxwell-watchdog.js"
@@ -29,8 +30,9 @@
     "qrcode-terminal": "^0.12.0"
   },
   "dependencies": {
-    "ajv": "^8.17.1",
     "@supabase/supabase-js": "^2.39.0",
-    "dotenv": "^16.3.1"
+    "ajv": "^8.17.1",
+    "dotenv": "^16.3.1",
+    "render-status-badge": "^1.0.1"
   }
 }

--- a/tools/ai-support-server.js
+++ b/tools/ai-support-server.js
@@ -5,28 +5,26 @@ const { spawn, spawnSync } = require('node:child_process');
 const os = require('node:os');
 const path = require('node:path');
 const fs = require('node:fs');
+const {
+  hasEnv,
+  readEnvBool,
+  readEnvFirst,
+  readEnvNumber,
+  stripQuotes,
+} = require('./env-utils');
 
 const repoRoot = path.resolve(__dirname, '..');
 
-const port =
-  Number(process.env.PORT) ||
-  Number(process.env.AI_SUPPORT_PORT || process.env.VITE_AI_SUPPORT_PORT) ||
-  8787;
+const port = readEnvNumber(['PORT', 'AI_SUPPORT_PORT', 'VITE_AI_SUPPORT_PORT'], 8787);
 const host = resolveHost();
 const codexBin = resolveCodexBin();
 const ghBin = resolveGhBin();
-const codexArgs = process.env.CODEX_ARGS ? process.env.CODEX_ARGS.split(' ') : [];
+const codexArgsRaw = readEnvFirst(['CODEX_ARGS'], { strip: false });
+const codexArgs = codexArgsRaw ? codexArgsRaw.split(' ') : [];
 const maxBodySize = 1_000_000;
-const verbose =
-  process.env.AI_SUPPORT_VERBOSE !== '0' &&
-  process.env.AI_SUPPORT_VERBOSE !== 'false';
-const logMessages =
-  process.env.AI_SUPPORT_LOG_MESSAGES === '1' ||
-  process.env.AI_SUPPORT_LOG_MESSAGES === 'true';
-const enableColor =
-  process.env.AI_SUPPORT_COLOR !== '0' &&
-  process.env.AI_SUPPORT_COLOR !== 'false' &&
-  process.stdout.isTTY;
+const verbose = readEnvBool(['AI_SUPPORT_VERBOSE'], true);
+const logMessages = readEnvBool(['AI_SUPPORT_LOG_MESSAGES'], false);
+const enableColor = readEnvBool(['AI_SUPPORT_COLOR'], true) && process.stdout.isTTY;
 const authStorage = resolveAuthStorage();
 const maxwellCredentials = resolveMaxwellCredentials();
 hydrateMaxwellCredentials(maxwellCredentials);
@@ -38,21 +36,15 @@ function isTruthy(value) {
 }
 
 function stripEnvValue(value) {
-  const raw = String(value ?? '').trim();
-  if (!raw) return '';
-  if (
-    (raw.startsWith('"') && raw.endsWith('"')) ||
-    (raw.startsWith("'") && raw.endsWith("'"))
-  ) {
-    return raw.slice(1, -1);
-  }
-  return raw;
+  return stripQuotes(value);
+}
+
+function isRenderEnvironment() {
+  return hasEnv(['RENDER', 'RENDER_SERVICE_ID']);
 }
 
 function resolveIssueAuthToken() {
-  return stripEnvValue(
-    process.env.AI_SUPPORT_API_TOKEN || process.env.AI_SUPPORT_ISSUE_TOKEN
-  );
+  return readEnvFirst(['AI_SUPPORT_API_TOKEN', 'AI_SUPPORT_ISSUE_TOKEN']);
 }
 
 function getRequestAuthToken(req) {
@@ -110,11 +102,10 @@ function writeEnvFileValue(filePath, key, value) {
 }
 
 function resolveAuthStorage() {
-  const envFilePath = process.env.AI_SUPPORT_AUTH_ENV_FILE
-    ? path.resolve(process.env.AI_SUPPORT_AUTH_ENV_FILE)
-    : null;
-  const writeEnvFile = isTruthy(process.env.AI_SUPPORT_AUTH_ENV_WRITE);
-  let authDir = process.env.AI_SUPPORT_AUTH_DIR || null;
+  const authEnvFile = readEnvFirst(['AI_SUPPORT_AUTH_ENV_FILE']);
+  const envFilePath = authEnvFile ? path.resolve(authEnvFile) : null;
+  const writeEnvFile = readEnvBool(['AI_SUPPORT_AUTH_ENV_WRITE'], false);
+  let authDir = readEnvFirst(['AI_SUPPORT_AUTH_DIR']) || null;
   let source = authDir ? 'env' : null;
   let envFileStatus = envFilePath ? 'missing' : 'disabled';
 
@@ -187,8 +178,9 @@ function readMaxwellCredentialsFile(filePath) {
 }
 
 function resolveMaxwellCredentialsPath() {
-  if (process.env.AI_SUPPORT_CREDENTIALS_FILE) {
-    return path.resolve(process.env.AI_SUPPORT_CREDENTIALS_FILE);
+  const credentialsFile = readEnvFirst(['AI_SUPPORT_CREDENTIALS_FILE']);
+  if (credentialsFile) {
+    return path.resolve(credentialsFile);
   }
 
   const candidates = [
@@ -205,7 +197,7 @@ function resolveMaxwellCredentialsPath() {
   ];
 
   const renderSecretDirs = [];
-  if (process.env.RENDER || process.env.RENDER_SERVICE_ID) {
+  if (isRenderEnvironment()) {
     for (const envKey of [
       'RENDER_SECRET_FILES_DIR',
       'RENDER_SECRET_DIR',
@@ -423,10 +415,10 @@ function buildGhEnv() {
   const credentialHost = readCredentialString(credentialGithub?.hostname);
   const credentialToken = readCredentialString(credentialGithub?.token);
 
-  const envToken = stripEnvValue(process.env.GH_TOKEN) || stripEnvValue(process.env.GITHUB_TOKEN);
+  const envToken = readEnvFirst(['GH_TOKEN', 'GITHUB_TOKEN']);
   const token = envToken || credentialToken;
 
-  const envHost = stripEnvValue(process.env.GH_HOST);
+  const envHost = readEnvFirst(['GH_HOST']);
   const host = envHost || credentialHost || 'github.com';
 
   if (!authStorage?.enabled && !token) return null;
@@ -474,8 +466,9 @@ function sendHtml(res, statusCode, html) {
 }
 
 function resolveCodexBin() {
-  if (process.env.CODEX_BIN) {
-    return process.env.CODEX_BIN;
+  const configuredCodexBin = readEnvFirst(['CODEX_BIN'], { strip: false });
+  if (configuredCodexBin) {
+    return configuredCodexBin;
   }
 
   if (process.platform === 'win32') {
@@ -508,8 +501,9 @@ function resolveCodexBin() {
 }
 
 function resolveGhBin() {
-  if (process.env.AI_SUPPORT_GH_BIN) {
-    return process.env.AI_SUPPORT_GH_BIN;
+  const configuredGhBin = readEnvFirst(['AI_SUPPORT_GH_BIN'], { strip: false });
+  if (configuredGhBin) {
+    return configuredGhBin;
   }
 
   if (process.platform === 'win32') {
@@ -542,20 +536,20 @@ function resolveGhBin() {
 }
 
 function resolveGithubRepo() {
-  if (process.env.AI_SUPPORT_GH_REPO) {
-    return process.env.AI_SUPPORT_GH_REPO;
+  const explicitRepo = readEnvFirst(['AI_SUPPORT_GH_REPO', 'GITHUB_REPO']);
+  if (explicitRepo) {
+    return explicitRepo;
   }
-  if (process.env.GITHUB_REPO) {
-    return process.env.GITHUB_REPO;
-  }
-  if (process.env.GITHUB_REPO_OWNER && process.env.GITHUB_REPO_NAME) {
-    return `${process.env.GITHUB_REPO_OWNER}/${process.env.GITHUB_REPO_NAME}`;
+  const owner = readEnvFirst(['GITHUB_REPO_OWNER']);
+  const name = readEnvFirst(['GITHUB_REPO_NAME']);
+  if (owner && name) {
+    return `${owner}/${name}`;
   }
   return null;
 }
 
 function resolveGithubHost() {
-  const envHost = stripEnvValue(process.env.GH_HOST);
+  const envHost = readEnvFirst(['GH_HOST']);
   if (envHost) return envHost;
   const credentialHost = readCredentialString(maxwellCredentials?.github?.hostname);
   if (credentialHost) return credentialHost;
@@ -563,8 +557,7 @@ function resolveGithubHost() {
 }
 
 function resolveGithubToken() {
-  const envToken =
-    stripEnvValue(process.env.GH_TOKEN) || stripEnvValue(process.env.GITHUB_TOKEN);
+  const envToken = readEnvFirst(['GH_TOKEN', 'GITHUB_TOKEN']);
   if (envToken) return envToken;
   return readCredentialString(maxwellCredentials?.github?.token);
 }
@@ -1016,8 +1009,7 @@ function checkCodexAuth() {
 }
 
 function checkGhAuth() {
-  const tokenFromEnv =
-    stripEnvValue(process.env.GH_TOKEN) || stripEnvValue(process.env.GITHUB_TOKEN);
+  const tokenFromEnv = readEnvFirst(['GH_TOKEN', 'GITHUB_TOKEN']);
   const tokenFromFile =
     maxwellCredentials?.status === 'loaded'
       ? readCredentialString(maxwellCredentials?.github?.token)
@@ -1092,7 +1084,7 @@ function formatStatus(status) {
 }
 
 function parseAllowedOrigins() {
-  const raw = process.env.AI_SUPPORT_ALLOWED_ORIGINS;
+  const raw = readEnvFirst(['AI_SUPPORT_ALLOWED_ORIGINS'], { strip: false });
   if (!raw) return [];
   return raw
     .split(',')
@@ -1108,17 +1100,17 @@ function resolveCorsOrigin(origin, allowedOrigins) {
 }
 
 function resolveApiKey() {
-  return stripEnvValue(process.env.AI_SUPPORT_API_KEY) || '';
+  return readEnvFirst(['AI_SUPPORT_API_KEY']);
 }
 
 function isAdminEnabled() {
   if (process.env.AI_SUPPORT_ADMIN_ENABLED === undefined) return false;
-  return isTruthy(process.env.AI_SUPPORT_ADMIN_ENABLED);
+  return readEnvBool(['AI_SUPPORT_ADMIN_ENABLED'], false);
 }
 
 function createRateLimiter() {
-  const limit = Number(process.env.AI_SUPPORT_RATE_LIMIT_MAX) || 60;
-  const windowMs = Number(process.env.AI_SUPPORT_RATE_LIMIT_WINDOW_MS) || 60_000;
+  const limit = readEnvNumber(['AI_SUPPORT_RATE_LIMIT_MAX'], 60);
+  const windowMs = readEnvNumber(['AI_SUPPORT_RATE_LIMIT_WINDOW_MS'], 60_000);
   const store = new Map();
 
   const consume = (key) => {
@@ -1143,14 +1135,14 @@ function createRateLimiter() {
 const rateLimiter = createRateLimiter();
 
 function resolveHttpsOptions() {
-  const httpsEnv = process.env.AI_SUPPORT_HTTPS;
+  const httpsEnv = readEnvFirst(['AI_SUPPORT_HTTPS']).toLowerCase();
   if (httpsEnv === 'false' || httpsEnv === '0') {
     return null;
   }
 
   const flag = httpsEnv === 'true' || httpsEnv === '1';
-  const certPath = process.env.SSL_CRT_FILE;
-  const keyPath = process.env.SSL_KEY_FILE;
+  const certPath = readEnvFirst(['SSL_CRT_FILE']);
+  const keyPath = readEnvFirst(['SSL_KEY_FILE']);
 
   if (certPath && keyPath && fs.existsSync(certPath) && fs.existsSync(keyPath)) {
     return {
@@ -1188,11 +1180,12 @@ function resolveHttpsOptions() {
 }
 
 function resolveHost() {
-  const configuredHost = process.env.AI_SUPPORT_HOST;
-  const runningOnRender = Boolean(process.env.RENDER || process.env.RENDER_SERVICE_ID);
-  const allowLocalhostOnRender =
-    process.env.AI_SUPPORT_ALLOW_LOCALHOST_ON_RENDER === '1' ||
-    process.env.AI_SUPPORT_ALLOW_LOCALHOST_ON_RENDER === 'true';
+  const configuredHost = readEnvFirst(['AI_SUPPORT_HOST'], { strip: false });
+  const runningOnRender = isRenderEnvironment();
+  const allowLocalhostOnRender = readEnvBool(
+    ['AI_SUPPORT_ALLOW_LOCALHOST_ON_RENDER'],
+    false
+  );
 
   if (configuredHost) {
     const normalizedHost = configuredHost.trim().toLowerCase();

--- a/tools/env-utils.js
+++ b/tools/env-utils.js
@@ -1,0 +1,50 @@
+function stripQuotes(value) {
+  const raw = String(value ?? '').trim();
+  if (!raw) return '';
+  if (
+    (raw.startsWith('"') && raw.endsWith('"')) ||
+    (raw.startsWith("'") && raw.endsWith("'"))
+  ) {
+    return raw.slice(1, -1);
+  }
+  return raw;
+}
+
+function readEnvFirst(names, options = {}) {
+  const { strip = true } = options;
+  for (const name of names) {
+    const value = process.env[name];
+    if (value === undefined || value === null) continue;
+    const normalized = strip ? stripQuotes(value) : String(value);
+    if (!normalized) continue;
+    return normalized;
+  }
+  return '';
+}
+
+function readEnvBool(names, defaultValue = false) {
+  const raw = readEnvFirst(names).toLowerCase();
+  if (!raw) return defaultValue;
+  if (raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on') return true;
+  if (raw === '0' || raw === 'false' || raw === 'no' || raw === 'off') return false;
+  return defaultValue;
+}
+
+function readEnvNumber(names, defaultValue) {
+  const raw = readEnvFirst(names);
+  if (!raw) return defaultValue;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : defaultValue;
+}
+
+function hasEnv(names) {
+  return Boolean(readEnvFirst(names));
+}
+
+module.exports = {
+  hasEnv,
+  readEnvBool,
+  readEnvFirst,
+  readEnvNumber,
+  stripQuotes,
+};

--- a/tools/render-status-badge.js
+++ b/tools/render-status-badge.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 require('dotenv').config();
+const { readEnvFirst } = require('./env-utils');
 
 const API_BASE = 'https://api.render.com/v1';
 
@@ -101,10 +102,10 @@ async function fetchLatestDeployStatus(apiKey, serviceId) {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const apiKey = process.env.RENDER_API_KEY;
-  const serviceId = args['service-id'] || process.env.RENDER_SERVICE_ID;
-  const label = args.label || process.env.RENDER_BADGE_LABEL || 'Render';
-  const style = args.style || process.env.RENDER_BADGE_STYLE || 'for-the-badge';
+  const apiKey = readEnvFirst(['RENDER_API_KEY']);
+  const serviceId = args['service-id'] || readEnvFirst(['RENDER_SERVICE_ID']);
+  const label = args.label || readEnvFirst(['RENDER_BADGE_LABEL']) || 'Render';
+  const style = args.style || readEnvFirst(['RENDER_BADGE_STYLE']) || 'for-the-badge';
   const logo = args.logo || 'render';
 
   if (!apiKey) {

--- a/tools/render-status-badge.js
+++ b/tools/render-status-badge.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+require('dotenv').config();
+
+const API_BASE = 'https://api.render.com/v1';
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) continue;
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith('--')) {
+      args[key] = next;
+      i += 1;
+    } else {
+      args[key] = 'true';
+    }
+  }
+  return args;
+}
+
+function encodeBadgeValue(value) {
+  return encodeURIComponent(value).replace(/-/g, '--');
+}
+
+function resolveLatestDeploy(payload) {
+  if (Array.isArray(payload) && payload.length > 0) {
+    return payload[0];
+  }
+  if (payload && Array.isArray(payload.deploys) && payload.deploys.length > 0) {
+    return payload.deploys[0];
+  }
+  if (payload && payload.deploy) {
+    return payload.deploy;
+  }
+  return null;
+}
+
+function resolveStatus(deploy) {
+  if (!deploy || typeof deploy !== 'object') return 'unknown';
+  const status = deploy.status || deploy.state || deploy.deployStatus || deploy.deploy?.status;
+  return typeof status === 'string' && status.trim() ? status.trim().toLowerCase() : 'unknown';
+}
+
+function mapStatus(status) {
+  const successStatuses = new Set(['live', 'deployed', 'ready', 'success', 'succeeded']);
+  const inProgressStatuses = new Set([
+    'created',
+    'queued',
+    'pending',
+    'in_progress',
+    'build_in_progress',
+    'update_in_progress',
+    'deploying',
+  ]);
+  const failedStatuses = new Set([
+    'failed',
+    'error',
+    'build_failed',
+    'update_failed',
+    'deactivate_failed',
+  ]);
+  const cancelledStatuses = new Set(['canceled', 'cancelled']);
+
+  if (successStatuses.has(status)) {
+    return { text: 'Live', color: 'brightgreen' };
+  }
+  if (inProgressStatuses.has(status)) {
+    return { text: 'Deploying', color: 'blue' };
+  }
+  if (failedStatuses.has(status)) {
+    return { text: 'Failed', color: 'red' };
+  }
+  if (cancelledStatuses.has(status)) {
+    return { text: 'Canceled', color: 'lightgrey' };
+  }
+  if (status === 'deactivated') {
+    return { text: 'Inactive', color: 'lightgrey' };
+  }
+  return { text: 'Unknown', color: 'lightgrey' };
+}
+
+async function fetchLatestDeployStatus(apiKey, serviceId) {
+  const response = await fetch(`${API_BASE}/services/${serviceId}/deploys?limit=1`, {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Render API ${response.status}: ${body.slice(0, 300)}`);
+  }
+
+  const payload = await response.json();
+  const deploy = resolveLatestDeploy(payload);
+  return resolveStatus(deploy);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const apiKey = process.env.RENDER_API_KEY;
+  const serviceId = args['service-id'] || process.env.RENDER_SERVICE_ID;
+  const label = args.label || process.env.RENDER_BADGE_LABEL || 'Render';
+  const style = args.style || process.env.RENDER_BADGE_STYLE || 'for-the-badge';
+  const logo = args.logo || 'render';
+
+  if (!apiKey) {
+    console.error('Missing RENDER_API_KEY');
+    process.exit(1);
+  }
+  if (!serviceId) {
+    console.error('Missing service id. Set RENDER_SERVICE_ID or pass --service-id.');
+    process.exit(1);
+  }
+
+  let status = 'unknown';
+  try {
+    status = await fetchLatestDeployStatus(apiKey, serviceId);
+  } catch (error) {
+    console.error(`Error fetching deploy status: ${error.message}`);
+  }
+
+  const mapped = mapStatus(status);
+  const badgeUrl = `https://img.shields.io/badge/${encodeBadgeValue(label)}-${encodeBadgeValue(mapped.text)}-${mapped.color}?logo=${encodeURIComponent(
+    logo
+  )}&style=${encodeURIComponent(style)}`;
+  process.stdout.write(`${badgeUrl}\n`);
+}
+
+main();


### PR DESCRIPTION
## Intent
Add robust Render badge generation and reduce env-variable duplication in tooling.

## Key changes
- Added local script: `tools/render-status-badge.js` with current Render API compatibility.
- Added npm script: `badge:render`.
- Added workflow: `.github/workflows/render-badge-urls.yml` to generate Turni/Maxwell badge URLs in step summary.
- Added shared env helper: `tools/env-utils.js`.
- Refactored `tools/ai-support-server.js` and badge script to use centralized env readers.
- Rewrote `.env.example` to reflect current toolchain and envs.

## Notes
- Kept behavior compatible while reducing duplicated env parsing logic.
- No changes in deploy architecture.