### PR TITLE
Refine badge labels and schedule badge URL refresh

### DIFF
--- a/.github/workflows/render-badge-urls.yml
+++ b/.github/workflows/render-badge-urls.yml
@@ -27,7 +27,7 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_TURNI }}
         run: |
-          url="$(npm run -s badge:render -- --label 'Render Turni')"
+          url="$(npm run -s badge:render -- --label 'Turni-di-Palco')"
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
       - name: Generate Maxwell badge URL
@@ -36,7 +36,7 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_MAXWELL }}
         run: |
-          url="$(npm run -s badge:render -- --label 'Render Maxwell')"
+          url="$(npm run -s badge:render -- --label 'Maxwell-AI-Support')"
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
       - name: Publish URLs

--- a/.github/workflows/render-badge-urls.yml
+++ b/.github/workflows/render-badge-urls.yml
@@ -1,6 +1,8 @@
 name: Render Badge URLs
 
 on:
+  schedule:
+    - cron: '*/5 * * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Intent
Refine Render badge labels and make badge URL generation automatic.

## Changes
- Updated badge labels to full project names (without Render prefix).
- Added scheduled trigger to `render-badge-urls.yml` every 5 minutes.
- Kept manual trigger (`workflow_dispatch`) for on-demand runs.

## Why
- Badge text is now clearer and consistent with project names.
- Badge URLs are regenerated automatically without manual action.