### PR TITLE
Hardening mobile routing and watchdog

### DIFF
--- a/TECHNICAL_NOTES.md
+++ b/TECHNICAL_NOTES.md
@@ -6,6 +6,7 @@
 - `apps/mobile`: Mobile UI (React/Vite). Build copiato in `apps/pwa/public/mobile/` tramite script di sync.
 - `shared/`: stili e utilità condivise.
 - `tools/`: script di automazione build/copy/cache.
+  - `tools/serve-dist.js` risolve le richieste `/mobile/*` su `apps/pwa/dist/public/mobile/*` in produzione.
 
 ## Build & run (sviluppo)
 

--- a/TECHNICAL_NOTES.md
+++ b/TECHNICAL_NOTES.md
@@ -3,10 +3,10 @@
 ## Struttura repo (high level)
 
 - `apps/pwa`: PWA Vite multipage (entry HTML nella root del package). Asset statici in `apps/pwa/public/` (incl. `public/sw.js` e `public/mobile/`).
-- `apps/mobile`: Mobile UI (React/Vite). Build copiato in `apps/pwa/public/mobile/` tramite script di sync.
+- `apps/mobile`: Mobile UI (React/Vite). Build in `apps/mobile/build`, copiato in `apps/pwa/public/mobile/` tramite script di sync (`build:mobile`, `sync:mobile`).
 - `shared/`: stili e utilità condivise.
 - `tools/`: script di automazione build/copy/cache.
-  - `tools/serve-dist.js` risolve le richieste `/mobile/*` su `apps/pwa/dist/public/mobile/*` in produzione.
+  - `tools/serve-dist.js` serve `apps/pwa/dist` e risolve le richieste `/mobile/*` su `apps/pwa/dist/public/mobile/*`.
 
 ## Build & run (sviluppo)
 
@@ -20,6 +20,7 @@
   - AI support server (local): `npm run ai:support` (default port 8787)
   - Dev + AI support together: `npm --workspace apps/mobile run dev:with-ai`
   - Build+sync in PWA: `npm run build:mobile`
+  - Allowlist host Vite (dev/preview): `VITE_ALLOWED_HOSTS` (comma-separated)
 
 ## AI support (mobile)
 
@@ -44,14 +45,21 @@
 
 - Service Worker: `apps/pwa/public/sw.js`
 - Il versioning della cache viene aggiornato dallo script `tools/update-cache-version.js` (invocato da `npm run build:pwa`) per forzare l’update degli asset core.
+- Il server `tools/serve-dist.js` imposta cache differenziata:
+  - `no-store` per HTML, `sw.js` e manifest.
+  - Cache aggressiva per asset hashed, icone e QR (immutabili).
+
+## Routing `/mobile` (produzione)
+
+- La Mobile UI ha `base: /mobile/` e viene copiata in `apps/pwa/public/mobile/` prima della build PWA.
+- In produzione, `tools/serve-dist.js` risolve `/mobile/*` su `apps/pwa/dist/public/mobile/*`.
+- Se si usa hosting statico esterno, garantire che `/mobile` punti a `dist/public/mobile` (o aggiungere rewrite equivalente), altrimenti `/mobile` va in 404.
 
 ## Header di sicurezza (Netlify/Render)
 
 - Netlify: gli header sono configurati in `netlify.toml` nella sezione `[[headers]]`.
 - Nota CSP: al momento `index.html` contiene uno script inline per il redirect mobile; per questo `script-src` include temporaneamente `'unsafe-inline'` finche' il bootstrap non viene spostato in un modulo esterno.
-- Render: il servizio PWA attuale usa `vite preview` (startCommand in `render.yaml`), quindi gli header vanno impostati a livello di reverse proxy o server applicativo.
-  - Opzione consigliata: mettere un reverse proxy (es. Caddy/Nginx) davanti al preview server e impostare gli header lì.
-  - In alternativa: sostituire il preview server con un piccolo server (Express/Fastify) che serva `apps/pwa/dist` e imposti gli stessi header.
+- Render: il servizio PWA usa `tools/serve-dist.js` (startCommand in `render.yaml`), quindi gli header e la cache vanno configurati lì.
   - Se si migra la PWA a “Static Site” su Render, utilizzare il supporto ai `headers` del manifest Render.
 
 ## Supabase (client)

--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -5,3 +5,6 @@ VITE_SUPABASE_ANON_KEY=
 VITE_AI_SUPPORT_ENDPOINT=https://localhost:8787/api/ai/chat
 VITE_AI_SUPPORT_PORT=8787
 VITE_AI_SUPPORT_ISSUE_ENDPOINT=https://localhost:8787/api/ai/issue
+
+# Vite dev/preview allowlist (comma-separated)
+VITE_ALLOWED_HOSTS=turni-di-palco-fq85.onrender.com

--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -42,9 +42,25 @@ function resolveHttps() {
   return flag || true;
 }
 
+const DEFAULT_ALLOWED_HOSTS = ['turni-di-palco-fq85.onrender.com'];
+
+function resolveAllowedHosts(env: Record<string, string>) {
+  const raw =
+    env.VITE_ALLOWED_HOSTS ||
+    env.ALLOWED_HOSTS ||
+    process.env.VITE_ALLOWED_HOSTS ||
+    process.env.ALLOWED_HOSTS;
+  if (!raw) return DEFAULT_ALLOWED_HOSTS;
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const httpsOption = resolveHttps();
+  const allowedHosts = resolveAllowedHosts(env);
   const aiSupportPort = Number(
     env.AI_SUPPORT_PORT || env.VITE_AI_SUPPORT_PORT || process.env.AI_SUPPORT_PORT
   ) || 8787;
@@ -104,7 +120,7 @@ export default defineConfig(({ mode }) => {
       host: true,
       port: 3000,
       https: httpsOption,
-      allowedHosts: ['turni-di-palco-fq85.onrender.com'],
+      allowedHosts,
       open: true,
       proxy: {
         '/api/ai/chat': {
@@ -121,7 +137,7 @@ export default defineConfig(({ mode }) => {
       host: true,
       port: 4174,
       https: httpsOption,
-      allowedHosts: ['turni-di-palco-fq85.onrender.com'],
+      allowedHosts,
     },
   };
 });

--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -104,7 +104,7 @@ export default defineConfig(({ mode }) => {
       host: true,
       port: 3000,
       https: httpsOption,
-      allowedHosts: ['turni-di-palco-fq85.onrender.com', '.onrender.com'],
+      allowedHosts: ['turni-di-palco-fq85.onrender.com'],
       open: true,
       proxy: {
         '/api/ai/chat': {
@@ -121,7 +121,7 @@ export default defineConfig(({ mode }) => {
       host: true,
       port: 4174,
       https: httpsOption,
-      allowedHosts: ['turni-di-palco-fq85.onrender.com', '.onrender.com'],
+      allowedHosts: ['turni-di-palco-fq85.onrender.com'],
     },
   };
 });

--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -104,7 +104,7 @@ export default defineConfig(({ mode }) => {
       host: true,
       port: 3000,
       https: httpsOption,
-      allowedHosts: ['turni-di-palco.onrender.com', '.onrender.com'],
+      allowedHosts: ['turni-di-palco-fq85.onrender.com', '.onrender.com'],
       open: true,
       proxy: {
         '/api/ai/chat': {
@@ -121,7 +121,7 @@ export default defineConfig(({ mode }) => {
       host: true,
       port: 4174,
       https: httpsOption,
-      allowedHosts: ['turni-di-palco.onrender.com', '.onrender.com'],
+      allowedHosts: ['turni-di-palco-fq85.onrender.com', '.onrender.com'],
     },
   };
 });

--- a/apps/pwa/.env.example
+++ b/apps/pwa/.env.example
@@ -8,3 +8,6 @@ VITE_PWA_DEV_EMAILS=
 
 # Service worker in dev: set to "true" to register
 VITE_SW_DEV=
+
+# Vite dev/preview allowlist (comma-separated)
+VITE_ALLOWED_HOSTS=turni-di-palco-fq85.onrender.com

--- a/apps/pwa/vite.config.ts
+++ b/apps/pwa/vite.config.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import type { ServerOptions as HttpsServerOptions } from "https";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 
 function resolveHttps(): HttpsServerOptions | undefined {
@@ -42,43 +42,63 @@ function resolveHttps(): HttpsServerOptions | undefined {
   return {};
 }
 
-const httpsOption = resolveHttps();
-const publicModeValue = process.env.VITE_PUBLIC_MODE;
-const isPublicMode = publicModeValue === "true" || publicModeValue === "1";
-const buildInputs: Record<string, string> = {
-  main: path.resolve(__dirname, "index.html"),
-  game: path.resolve(__dirname, "game.html"),
-  map: path.resolve(__dirname, "map.html"),
-  avatar: path.resolve(__dirname, "avatar.html"),
-  profile: path.resolve(__dirname, "profile.html"),
-  privacy: path.resolve(__dirname, "privacy.html"),
-  events: path.resolve(__dirname, "events.html"),
-  turns: path.resolve(__dirname, "turns.html"),
-  leaderboard: path.resolve(__dirname, "leaderboard.html"),
-};
+const DEFAULT_ALLOWED_HOSTS = ["turni-di-palco-fq85.onrender.com"];
 
-if (!isPublicMode) {
-  buildInputs.dev = path.resolve(__dirname, "dev.html");
+function resolveAllowedHosts(env: Record<string, string>) {
+  const raw =
+    env.VITE_ALLOWED_HOSTS ||
+    env.ALLOWED_HOSTS ||
+    process.env.VITE_ALLOWED_HOSTS ||
+    process.env.ALLOWED_HOSTS;
+  if (!raw) return DEFAULT_ALLOWED_HOSTS;
+  return raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
 }
 
-export default defineConfig({
-  appType: "mpa",
-  plugins: [tailwindcss()],
-  build: {
-    rollupOptions: {
-      input: buildInputs,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const httpsOption = resolveHttps();
+  const publicModeValue = env.VITE_PUBLIC_MODE || process.env.VITE_PUBLIC_MODE;
+  const isPublicMode = publicModeValue === "true" || publicModeValue === "1";
+  const allowedHosts = resolveAllowedHosts(env);
+
+  const buildInputs: Record<string, string> = {
+    main: path.resolve(__dirname, "index.html"),
+    game: path.resolve(__dirname, "game.html"),
+    map: path.resolve(__dirname, "map.html"),
+    avatar: path.resolve(__dirname, "avatar.html"),
+    profile: path.resolve(__dirname, "profile.html"),
+    privacy: path.resolve(__dirname, "privacy.html"),
+    events: path.resolve(__dirname, "events.html"),
+    turns: path.resolve(__dirname, "turns.html"),
+    leaderboard: path.resolve(__dirname, "leaderboard.html"),
+  };
+
+  if (!isPublicMode) {
+    buildInputs.dev = path.resolve(__dirname, "dev.html");
+  }
+
+  return {
+    appType: "mpa",
+    plugins: [tailwindcss()],
+    build: {
+      rollupOptions: {
+        input: buildInputs,
+      },
     },
-  },
-  server: {
-    host: true,
-    port: 5173,
-    https: httpsOption,
-    allowedHosts: ["turni-di-palco-fq85.onrender.com"],
-  },
-  preview: {
-    host: true,
-    port: 4173,
-    https: httpsOption,
-    allowedHosts: ["turni-di-palco-fq85.onrender.com"],
-  },
+    server: {
+      host: true,
+      port: 5173,
+      https: httpsOption,
+      allowedHosts,
+    },
+    preview: {
+      host: true,
+      port: 4173,
+      https: httpsOption,
+      allowedHosts,
+    },
+  };
 });

--- a/apps/pwa/vite.config.ts
+++ b/apps/pwa/vite.config.ts
@@ -73,12 +73,12 @@ export default defineConfig({
     host: true,
     port: 5173,
     https: httpsOption,
-    allowedHosts: ["turni-di-palco-fq85.onrender.com", ".onrender.com"],
+    allowedHosts: ["turni-di-palco-fq85.onrender.com"],
   },
   preview: {
     host: true,
     port: 4173,
     https: httpsOption,
-    allowedHosts: ["turni-di-palco-fq85.onrender.com", ".onrender.com"],
+    allowedHosts: ["turni-di-palco-fq85.onrender.com"],
   },
 });

--- a/apps/pwa/vite.config.ts
+++ b/apps/pwa/vite.config.ts
@@ -73,12 +73,12 @@ export default defineConfig({
     host: true,
     port: 5173,
     https: httpsOption,
-    allowedHosts: ["turni-di-palco.onrender.com", ".onrender.com"],
+    allowedHosts: ["turni-di-palco-fq85.onrender.com", ".onrender.com"],
   },
   preview: {
     host: true,
     port: 4173,
     https: httpsOption,
-    allowedHosts: ["turni-di-palco.onrender.com", ".onrender.com"],
+    allowedHosts: ["turni-di-palco-fq85.onrender.com", ".onrender.com"],
   },
 });

--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -29,16 +29,18 @@ serve(async (req) => {
     
     const cutoffDate = new Date()
     cutoffDate.setDate(cutoffDate.getDate() - daysToKeep)
+    const cutoffDateStr = cutoffDate.toISOString().slice(0, 10)
     
     const { data: events, error } = await supabaseClient
       .from('events')
       .select('id, name, event_date, event_time')
+      .lt('event_date', cutoffDateStr)
     
     if (error) throw error
     
-    const eventsToDelete = events.filter(event => {
-      const eventDateTime = new Date(`${event.event_date} ${event.event_time}`)
-      return eventDateTime < cutoffDate
+    const eventsToDelete = (events || []).filter(event => {
+      if (!event?.event_date) return false
+      return event.event_date < cutoffDateStr
     })
     
     if (eventsToDelete.length === 0) {

--- a/tools/cleanup-old-events.js
+++ b/tools/cleanup-old-events.js
@@ -12,16 +12,19 @@ async function cleanupOldEvents(daysToKeep = 7) {
     
     const cutoffDate = new Date();
     cutoffDate.setDate(cutoffDate.getDate() - daysToKeep);
+    const cutoffDateStr = cutoffDate.toISOString().slice(0, 10);
     
     const { data: events, error } = await supabase
       .from('events')
-      .select('id, name, event_date, event_time');
+      .select('id, name, event_date, event_time')
+      .lt('event_date', cutoffDateStr);
     
     if (error) throw error;
     
-    const eventsToDelete = events.filter(event => {
-      const eventDateTime = new Date(`${event.event_date} ${event.event_time}`);
-      return eventDateTime < cutoffDate;
+    const eventsToDelete = (events || []).filter(event => {
+      if (!event?.event_date) return false;
+      if (event.event_date < cutoffDateStr) return true;
+      return false;
     });
     
     if (eventsToDelete.length === 0) {

--- a/tools/maxwell-watchdog.js
+++ b/tools/maxwell-watchdog.js
@@ -6,7 +6,7 @@
  */
 
 const https = require('https');
-const { spawn } = require('child_process');
+const { spawnSync } = require('child_process');
 
 // Configurazione
 const CONFIG = {
@@ -194,12 +194,24 @@ class ProblemDetector {
     const problems = [];
     
     try {
-      const result = spawnSync('npm', ['audit', '--json'], { 
+      const result = spawnSync('npm', ['audit', '--json'], {
         encoding: 'utf8',
         cwd: process.cwd()
       });
 
-      if (result.stdout) {
+      if (result.error) {
+        throw result.error;
+      }
+
+      if (!result.stdout) {
+        log('warn', 'Security audit returned no output', {
+          status: result.status,
+          stderr: result.stderr ? result.stderr.trim() : ''
+        });
+        return problems;
+      }
+
+      try {
         const audit = JSON.parse(result.stdout);
         const vulnerabilities = audit.vulnerabilities || {};
 
@@ -214,6 +226,11 @@ class ProblemDetector {
               suggestion: `Run 'npm audit fix' or update ${pkg} to safe version`
             });
           }
+        });
+      } catch (parseError) {
+        log('warn', 'Failed to parse security audit output', {
+          error: parseError.message,
+          output: result.stdout.slice(0, 2000)
         });
       }
     } catch (error) {
@@ -461,23 +478,6 @@ class MaxwellWatchdog {
 
     log('info', `⏰ Next scan scheduled in ${CONFIG.scanInterval / 1000 / 60} minutes`);
   }
-}
-
-// Helper function for sync processes
-function spawnSync(command, args, options = {}) {
-  const { spawn } = require('child_process');
-  return new Promise((resolve) => {
-    const child = spawn(command, args, { ...options, encoding: 'utf8' });
-    let stdout = '';
-    let stderr = '';
-
-    child.stdout?.on('data', (data) => stdout += data);
-    child.stderr?.on('data', (data) => stderr += data);
-
-    child.on('close', (code) => {
-      resolve({ stdout, stderr, status: code });
-    });
-  });
 }
 
 // Start if run directly

--- a/tools/serve-dist.js
+++ b/tools/serve-dist.js
@@ -112,6 +112,49 @@ function resolveRequestPath(distDir, urlPath) {
   return null;
 }
 
+function resolveMobileRequestPath(distDir, urlPath) {
+  const mobileRoot = path.join(distDir, 'public', 'mobile');
+  const safePath = decodeURIComponent(urlPath.split('?')[0]).replace(/\\/g, '/');
+  if (safePath === '/mobile' || safePath === '/mobile/') {
+    return resolveRequestPath(mobileRoot, '/');
+  }
+
+  if (!safePath.startsWith('/mobile/')) {
+    return null;
+  }
+
+  const withoutPrefix = safePath.slice('/mobile'.length);
+  return resolveRequestPath(mobileRoot, withoutPrefix || '/');
+}
+
+function hasHashedFilename(filePath) {
+  const file = path.basename(filePath);
+  return /-[a-f0-9]{8,}\./i.test(file);
+}
+
+function resolveCacheControl(distDir, filePath) {
+  const relPath = path.relative(distDir, filePath).replace(/\\/g, '/');
+  const ext = path.extname(filePath).toLowerCase();
+
+  if (ext === '.html' || ext === '.webmanifest') {
+    return 'no-store';
+  }
+
+  if (relPath.endsWith('/sw.js') || relPath === 'sw.js') {
+    return 'no-store';
+  }
+
+  if (relPath.startsWith('assets/') && hasHashedFilename(relPath)) {
+    return 'public, max-age=31536000, immutable';
+  }
+
+  if (relPath.includes('/icons/') || relPath.includes('/qrcodes/')) {
+    return 'public, max-age=31536000, immutable';
+  }
+
+  return 'no-cache';
+}
+
 function createHandler(distDir) {
   return (req, res) => {
     // Health check endpoint per keep-alive incrociato
@@ -133,7 +176,8 @@ function createHandler(distDir) {
       return;
     }
 
-    const filePath = resolveRequestPath(distDir, req.url);
+    const mobileFilePath = resolveMobileRequestPath(distDir, req.url);
+    const filePath = mobileFilePath || resolveRequestPath(distDir, req.url);
     if (!filePath) {
       res.statusCode = 404;
       res.end('Not Found');
@@ -142,7 +186,7 @@ function createHandler(distDir) {
 
     res.statusCode = 200;
     res.setHeader('Content-Type', getMimeType(filePath));
-    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Cache-Control', resolveCacheControl(distDir, filePath));
 
     const stream = fs.createReadStream(filePath);
     stream.on('error', () => {


### PR DESCRIPTION
## Summary
- Route /mobile/* to dist/public/mobile and apply cache headers by file type.
- Fix watchdog security audit to use real sync spawn.
- Filter cleanup events server-side in tool + edge function.
- Document /mobile routing convention.

## Testing
- Not run (not requested).