### PR TITLE
Refactor HTML attribute builders into shared helper

### DIFF
--- a/apps/pwa/src/components/chip.ts
+++ b/apps/pwa/src/components/chip.ts
@@ -1,4 +1,5 @@
 import { colorTokens, radiusTokens, spacingTokens, typographyTokens } from "./tokens";
+import { buildAttributeString } from "../utils/html-attributes";
 
 export type ChipVariant = "solid" | "ghost";
 export type ChipSize = "sm" | "md";
@@ -30,13 +31,6 @@ const sizeConfig: Record<ChipSize, ChipSizeConfig> = {
   },
 };
 
-function dataAttributeString(dataAttributes?: Record<string, string>) {
-  if (!dataAttributes) return "";
-  return Object.entries(dataAttributes)
-    .map(([key, value]) => ` data-${key}="${value}"`)
-    .join("");
-}
-
 export function renderChip({
   label,
   href,
@@ -55,7 +49,7 @@ export function renderChip({
   const aria = title ? ` aria-label="${title}" title="${title}"` : "";
   const attrs = href ? `href="${href}"` : "type=\"button\"";
   const sizeVars = sizeConfig[size];
-  const dataAttrs = dataAttributeString(dataAttributes);
+  const dataAttrs = buildAttributeString(dataAttributes, { keyPrefix: "data-" });
   const style = `style="--chip-py:${sizeVars.paddingY};--chip-px:${sizeVars.paddingX};--chip-fz:${sizeVars.fontSize};--chip-radius:${radiusTokens.pill};--chip-bg:${colorTokens.surface};--chip-border:${colorTokens.surfaceBorder};--chip-hover-border:${colorTokens.surfaceHoverBorder};--chip-active-bg:${colorTokens.accentTint};--chip-active-border:${colorTokens.accentBorder};"`;
 
   return `<${tag} class="${classes.join(" ")}" data-state="${state}" ${attrs}${aria} ${style}${dataAttrs}>${iconMarkup}<span>${label}</span></${tag}>`;

--- a/apps/pwa/src/components/stat-pill.ts
+++ b/apps/pwa/src/components/stat-pill.ts
@@ -1,4 +1,5 @@
 import { colorTokens, radiusTokens, spacingTokens, typographyTokens } from "./tokens";
+import { buildAttributeString } from "../utils/html-attributes";
 
 export type StatPillSize = "sm" | "md";
 export type StatPillState = "default" | "positive" | "warning" | "danger";
@@ -27,13 +28,6 @@ const sizeConfig: Record<StatPillSize, PillSizeConfig> = {
   },
 };
 
-function valueAttributeString(valueAttributes?: Record<string, string>) {
-  if (!valueAttributes) return "";
-  return Object.entries(valueAttributes)
-    .map(([key, value]) => ` ${key}="${value}"`)
-    .join("");
-}
-
 export function renderStatPill({
   label,
   value,
@@ -46,7 +40,7 @@ export function renderStatPill({
   if (size === "sm") classes.push("stat-pill-sm");
   const iconMarkup = icon ? `<span class="pill-icon">${icon}</span>` : "";
   const sizeVars = sizeConfig[size];
-  const valueAttrs = valueAttributeString(valueAttributes);
+  const valueAttrs = buildAttributeString(valueAttributes);
   const style = `style="--pill-py:${sizeVars.paddingY};--pill-px:${sizeVars.paddingX};--pill-fz:${sizeVars.fontSize};--pill-radius:${radiusTokens.pill};--pill-bg:${colorTokens.surface};--pill-border:${colorTokens.surfaceBorder};--pill-text:${colorTokens.text};--pill-muted:${colorTokens.muted};--pill-positive:${colorTokens.success};--pill-warning:${colorTokens.warning};--pill-danger:${colorTokens.danger};"`;
 
   return `<div class="${classes.join(" ")}" data-state="${state}" ${style}>${iconMarkup}<span>${label}</span><strong${valueAttrs}>${value}</strong></div>`;

--- a/apps/pwa/src/utils/html-attributes.ts
+++ b/apps/pwa/src/utils/html-attributes.ts
@@ -1,0 +1,12 @@
+type AttributeOptions = {
+  keyPrefix?: string;
+};
+
+export function buildAttributeString(attributes?: Record<string, string>, options: AttributeOptions = {}) {
+  if (!attributes) return "";
+  const { keyPrefix = "" } = options;
+
+  return Object.entries(attributes)
+    .map(([key, value]) => ` ${keyPrefix}${key}="${value}"`)
+    .join("");
+}


### PR DESCRIPTION
### Motivation
- Reduce duplication when building HTML and data attribute strings across components to follow DRY principles.

### Description
- Add a shared helper `buildAttributeString` in `apps/pwa/src/utils/html-attributes.ts` to build attribute strings from a record with an optional `keyPrefix` option.
- Replace the inline `dataAttributeString` implementation in `apps/pwa/src/components/chip.ts` with `buildAttributeString(dataAttributes, { keyPrefix: "data-" })`.
- Replace the inline `valueAttributeString` implementation in `apps/pwa/src/components/stat-pill.ts` with `buildAttributeString(valueAttributes)`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69898f81922883268a203bb45a0edc84)