### PR TITLE
Improve mobile layout for dashboard, missions, and events

### DIFF
--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -34,7 +34,7 @@ const NON_PUBLIC_PATHS = new Set(CORE_ASSETS_BY_ENV.dev);
 const OFFLINE_URL = "/index.html";
 
 const CORE_CACHE_VERSION = "__SW_CACHE_VERSION__";
-const CACHE_VERSION_TAG = "v4";
+const CACHE_VERSION_TAG = "v5";
 const CORE_CACHE_NAME = `turni-di-palco-core-${CORE_CACHE_VERSION}-${CACHE_VERSION_TAG}`;
 const TILE_CACHE_NAME = `turni-di-palco-tiles-${CORE_CACHE_VERSION}-${CACHE_VERSION_TAG}`;
 const META_CACHE_NAME = `turni-di-palco-meta-${CORE_CACHE_VERSION}-${CACHE_VERSION_TAG}`;

--- a/apps/pwa/src/dev.ts
+++ b/apps/pwa/src/dev.ts
@@ -228,7 +228,30 @@ const start = async () => {
 
         <article class="card">
           <h2>Attivita simulate</h2>
-          <div class="form-grid">
+          <div class="mission-board">
+            <div class="mission-header">
+              <div>
+                <p class="eyebrow">Missioni giornaliere</p>
+                <p class="muted">Completa le missioni per mantenere la costanza di allenamento.</p>
+              </div>
+              <div class="mission-progress">
+                <span class="mission-progress__value" data-mission-progress-value>0 / 0</span>
+                <div
+                  class="mission-progress__track"
+                  role="progressbar"
+                  aria-label="Progresso giornaliero missioni"
+                  aria-valuemin="0"
+                  aria-valuemax="100"
+                  aria-valuenow="0"
+                >
+                  <span class="mission-progress__fill" data-mission-progress-bar style="width: 0%"></span>
+                </div>
+                <p class="muted tiny" data-mission-progress-copy>0% completato</p>
+              </div>
+            </div>
+            <div class="mission-list" data-mission-list></div>
+          </div>
+          <div class="form-grid mission-actions">
             <label class="field">
               <span>Scenario</span>
               <select data-field="activity-select"></select>
@@ -300,6 +323,10 @@ const start = async () => {
   const activityGuardChip = root.querySelector<HTMLElement>('[data-activity-guard]');
   const activityLimitChip = root.querySelector<HTMLElement>('[data-activity-limit]');
   const tutorialBox = root.querySelector<HTMLElement>('[data-activity-tutorial]');
+  const missionList = root.querySelector<HTMLElement>('[data-mission-list]');
+  const missionProgressBar = root.querySelector<HTMLElement>('[data-mission-progress-bar]');
+  const missionProgressValue = root.querySelector<HTMLElement>('[data-mission-progress-value]');
+  const missionProgressCopy = root.querySelector<HTMLElement>('[data-mission-progress-copy]');
   const eventSelect = root.querySelector<HTMLSelectElement>('[data-field="event-select"]');
   const turnRoleSelect = root.querySelector<HTMLSelectElement>('[data-field="turn-role"]');
   const turnFeedbackBox = root.querySelector<HTMLElement>('[data-turn-feedback]');
@@ -407,6 +434,59 @@ const start = async () => {
     }
     activityLimitChip.textContent = `Limite sessione: ${Math.min(stats.runs, MAX_ACTIVITY_RUNS)} / ${MAX_ACTIVITY_RUNS}`;
     activityLimitChip.dataset.state = stats.runs >= MAX_ACTIVITY_RUNS ? "warn" : "info";
+  }
+
+  function getMissionTotals() {
+    const runs = activities.reduce((acc, activity) => {
+      const stats = getActivityStats(activity.id);
+      return acc + Math.min(stats.runs, MAX_ACTIVITY_RUNS);
+    }, 0);
+    const limit = activities.length * MAX_ACTIVITY_RUNS;
+    const percent = limit ? Math.min(100, Math.round((runs / limit) * 100)) : 0;
+    return { runs, limit, percent };
+  }
+
+  function renderMissionProgress() {
+    if (!missionProgressBar || !missionProgressValue || !missionProgressCopy) return;
+    const { runs, limit, percent } = getMissionTotals();
+    missionProgressValue.textContent = `${runs} / ${limit}`;
+    missionProgressCopy.textContent = `${percent}% completato`;
+    missionProgressBar.style.width = `${percent}%`;
+    missionProgressBar.parentElement?.setAttribute("aria-valuenow", percent.toString());
+  }
+
+  function getMissionRewards(activity: Activity) {
+    const xp = Math.max(...activity.choices.map((choice) => choice.rewards.xp));
+    const reputation = Math.max(...activity.choices.map((choice) => choice.rewards.reputation));
+    return { xp, reputation };
+  }
+
+  function renderMissionList(selectedId?: string) {
+    if (!missionList) return;
+    if (!activities.length) {
+      missionList.innerHTML = '<p class="muted">Nessuna missione disponibile.</p>';
+      return;
+    }
+    missionList.innerHTML = activities
+      .map((activity) => {
+        const stats = getActivityStats(activity.id);
+        const { xp, reputation } = getMissionRewards(activity);
+        const isActive = activity.id === selectedId;
+        return `
+          <button class="mission-card${isActive ? " active" : ""}" type="button" data-activity-id="${activity.id}">
+            <div class="mission-card__title">
+              <h3>${activity.title}</h3>
+              <span class="mission-card__count">${Math.min(stats.runs, MAX_ACTIVITY_RUNS)} / ${MAX_ACTIVITY_RUNS}</span>
+            </div>
+            <p class="muted">${activity.description}</p>
+            <div class="mission-card__badges">
+              <span class="glass-badge xp"><span aria-hidden="true">⚡</span> +${xp} XP</span>
+              <span class="glass-badge rep"><span aria-hidden="true">★</span> +${reputation} Rep</span>
+            </div>
+          </button>
+        `;
+      })
+      .join("");
   }
 
   function renderTutorialBox() {
@@ -547,6 +627,8 @@ const start = async () => {
         activityChoices.innerHTML = "";
       }
       renderTutorialBox();
+      renderMissionList();
+      renderMissionProgress();
       return;
     }
 
@@ -562,6 +644,8 @@ const start = async () => {
     }
     renderActivityOptions(activity);
     renderActivityGuard(activity.id);
+    renderMissionList(activity.id);
+    renderMissionProgress();
     renderTutorialBox();
   }
 
@@ -602,6 +686,8 @@ const start = async () => {
     persistState(gameState, activityResultBox || undefined);
     renderCareerCard();
     renderActivityGuard(activity.id);
+    renderMissionList(activity.id);
+    renderMissionProgress();
     renderTutorialBox();
     if (activityResultBox) {
       activityResultBox.dataset.state = "ok";
@@ -697,6 +783,17 @@ const start = async () => {
     const choiceId = button.dataset.choiceId;
     if (choiceId) {
       handleActivityChoice(choiceId);
+    }
+  });
+
+  missionList?.addEventListener("click", (event) => {
+    const target = event.target as HTMLElement | null;
+    const button = target?.closest<HTMLButtonElement>("[data-activity-id]");
+    if (!button || !activitySelect) return;
+    const missionId = button.dataset.activityId;
+    if (missionId) {
+      activitySelect.value = missionId;
+      renderActivityUI(missionId);
     }
   });
 

--- a/apps/pwa/src/events.ts
+++ b/apps/pwa/src/events.ts
@@ -32,7 +32,8 @@ const start = async () => {
       <section class="grid layout-grid">
         <article class="card layout-span-2">
           <h2>Prossimi eventi</h2>
-          <ul class="log-list dense" data-event-list></ul>
+          <p class="muted">Schede ATCL con focus ruolo e ricompense principali.</p>
+          <ul class="event-grid" data-event-list></ul>
         </article>
       </section>
     </main>
@@ -45,10 +46,30 @@ const start = async () => {
       eventList.innerHTML = `<li class="muted">Nessun evento disponibile.</li>`;
     } else {
       eventList.innerHTML = mockEvents
-        .map(
-          (item) =>
-            `<li><div><strong>${item.name}</strong> - ${item.theatre}</div><div class="muted">${item.date} | Focus: ${item.focusRole ? resolveRole(item.focusRole).name : "Any"} - Lat ${item.lat.toFixed(3)} / Lng ${item.lng.toFixed(3)}</div></li>`
-        )
+        .map((item) => {
+          const focusRole = item.focusRole ? resolveRole(item.focusRole) : null;
+          return `
+            <li>
+              <article class="event-card static">
+                <div class="event-card__header">
+                  <div>
+                    <strong>${item.name}</strong>
+                    <p class="muted tiny">${item.theatre} • ${item.date}</p>
+                  </div>
+                  <span class="focus-pill ghost">${focusRole ? focusRole.name : "Multi-ruolo"}</span>
+                </div>
+                <div class="event-card__meta">
+                  <span class="pill ghost">Lat ${item.lat.toFixed(3)} / Lng ${item.lng.toFixed(3)}</span>
+                  <span class="pill ghost">Cachet +${item.baseRewards.cachet}</span>
+                </div>
+                <div class="event-card__badges">
+                  <span class="glass-badge xp"><span aria-hidden="true">⚡</span> +${item.baseRewards.xp} XP</span>
+                  <span class="glass-badge rep"><span aria-hidden="true">★</span> +${item.baseRewards.reputation} Rep</span>
+                </div>
+              </article>
+            </li>
+          `;
+        })
         .join("");
     }
   }

--- a/apps/pwa/src/game.ts
+++ b/apps/pwa/src/game.ts
@@ -42,52 +42,75 @@ const start = async () => {
       ${pageHero}
 
       <section class="grid layout-grid">
-        <article class="card">
-          <h2>Profilo</h2>
-          <div class="profile-pane">
-            <div class="avatar-display large" data-avatar="profile">
-              <img data-avatar-img alt="Avatar ReadyPlayerMe" />
-              <span class="avatar-icon" data-avatar-label></span>
-            </div>
+        <article class="card dashboard-card layout-span-2">
+          <div class="dashboard-header">
             <div>
-              <p class="eyebrow" data-player-name>Profilo non configurato</p>
-              <p class="muted" data-player-role>Ruolo non impostato</p>
-              <div class="pill-row" data-role-tags></div>
+              <p class="eyebrow">Home dashboard</p>
+              <h2>Profilo in scena</h2>
+              <p class="muted">Riepilogo rapido con progressi circolari e statistiche chiave.</p>
             </div>
           </div>
-        </article>
-
-        <article class="card">
-          <h2>Statistiche</h2>
-          <ul class="stat-list">
-            <li><span>XP</span><strong data-stat="xp">0</strong></li>
-            <li><span>Cachet</span><strong data-stat="cachet">0</strong></li>  
-            <li><span>Reputazione ATCL</span><strong data-stat="rep">0</strong></li>
-          </ul>
-          <div class="progress-grid compact">
-            <div class="progress-track slim" data-track="xp">
-              <div class="progress-head">
-                <p class="muted" data-progress-copy="xp">Traguardi XP</p>      
-                <strong data-progress-value="xp">0 XP</strong>
+          <div class="dashboard-body">
+            <div class="profile-pane">
+              <div class="avatar-display large" data-avatar="profile">
+                <img data-avatar-img alt="Avatar ReadyPlayerMe" />
+                <span class="avatar-icon" data-avatar-label></span>
               </div>
-              <div class="progress-bar" role="progressbar" aria-label="Progresso XP" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-                <span class="progress-fill" data-progress-bar="xp" style="width: 0%"></span>
+              <div>
+                <p class="eyebrow" data-player-name>Profilo non configurato</p>
+                <p class="muted" data-player-role>Ruolo non impostato</p>
+                <div class="pill-row" data-role-tags></div>
               </div>
             </div>
-            <div class="progress-track slim" data-track="rep">
-              <div class="progress-head">
-                <p class="muted" data-progress-copy="rep">Traguardi reputazione</p>
-                <strong data-progress-value="rep">0 rep</strong>
+            <div class="dashboard-rings">
+              <div class="dashboard-ring">
+                <div
+                  class="progress-ring"
+                  data-ring="xp"
+                  role="progressbar"
+                  aria-label="Progresso XP"
+                  aria-valuemin="0"
+                  aria-valuemax="100"
+                  aria-valuenow="0"
+                >
+                  <span class="ring-value" data-progress-value="xp">0 XP</span>
+                  <span class="ring-label">XP</span>
+                </div>
+                <div class="dashboard-ring__meta">
+                  <p class="eyebrow">Crescita XP</p>
+                  <p class="muted" data-progress-copy="xp">Traguardi XP</p>
+                </div>
               </div>
-              <div class="progress-bar" role="progressbar" aria-label="Progresso reputazione" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-                <span class="progress-fill accent" data-progress-bar="rep" style="width: 0%"></span>
+              <div class="dashboard-ring">
+                <div
+                  class="progress-ring accent"
+                  data-ring="rep"
+                  role="progressbar"
+                  aria-label="Progresso reputazione"
+                  aria-valuemin="0"
+                  aria-valuemax="100"
+                  aria-valuenow="0"
+                >
+                  <span class="ring-value" data-progress-value="rep">0 rep</span>
+                  <span class="ring-label">Rep</span>
+                </div>
+                <div class="dashboard-ring__meta">
+                  <p class="eyebrow">Reputazione</p>
+                  <p class="muted" data-progress-copy="rep">Traguardi reputazione</p>
+                </div>
               </div>
             </div>
+            <ul class="stat-quick-list">
+              <li><span>XP totali</span><strong data-stat="xp">0</strong></li>
+              <li><span>Cachet</span><strong data-stat="cachet">0</strong></li>
+              <li><span>Reputazione ATCL</span><strong data-stat="rep">0</strong></li>
+            </ul>
           </div>
         </article>
 
         <article class="card layout-span-2">
           <h2>Ultimi turni</h2>
+          <p class="muted">Registro rapido delle ultime sessioni salvate.</p>
           <ul class="log-list dense" data-turn-log></ul>
         </article>
       </section>
@@ -98,8 +121,8 @@ const start = async () => {
   const progressCopyRep = root.querySelector<HTMLElement>('[data-progress-copy="rep"]');
   const progressValueXp = root.querySelector<HTMLElement>('[data-progress-value="xp"]');
   const progressValueRep = root.querySelector<HTMLElement>('[data-progress-value="rep"]');
-  const progressBarXp = root.querySelector<HTMLElement>('[data-progress-bar="xp"]');
-  const progressBarRep = root.querySelector<HTMLElement>('[data-progress-bar="rep"]');
+  const progressRingXp = root.querySelector<HTMLElement>('[data-ring="xp"]');
+  const progressRingRep = root.querySelector<HTMLElement>('[data-ring="rep"]');
   const avatarDisplay = root.querySelector<HTMLElement>('[data-avatar="profile"]');
   const avatarImg = root.querySelector<HTMLImageElement>('[data-avatar-img]');
   const avatarLabel = root.querySelector<HTMLElement>('[data-avatar-label]');
@@ -147,13 +170,13 @@ const start = async () => {
     if (progressCopyRep) progressCopyRep.textContent = buildProgressCopy(repProgress, "punti rep");
     if (progressValueXp) progressValueXp.textContent = `${state.profile.xp} XP`;
     if (progressValueRep) progressValueRep.textContent = `${state.profile.repAtcl} rep`;
-    if (progressBarXp) {
-      progressBarXp.style.width = `${xpProgress.percent}%`;
-      progressBarXp.parentElement?.setAttribute("aria-valuenow", xpProgress.percent.toString());
+    if (progressRingXp) {
+      progressRingXp.style.setProperty("--ring-progress", xpProgress.percent.toString());
+      progressRingXp.setAttribute("aria-valuenow", xpProgress.percent.toString());
     }
-    if (progressBarRep) {
-      progressBarRep.style.width = `${repProgress.percent}%`;
-      progressBarRep.parentElement?.setAttribute("aria-valuenow", repProgress.percent.toString());
+    if (progressRingRep) {
+      progressRingRep.style.setProperty("--ring-progress", repProgress.percent.toString());
+      progressRingRep.setAttribute("aria-valuenow", repProgress.percent.toString());
     }
   }
 

--- a/apps/pwa/src/map.ts
+++ b/apps/pwa/src/map.ts
@@ -436,7 +436,11 @@ const start = async () => {
             </div>
             <div class="event-card__meta">
               <span class="pill ghost">~${item.distanceKm} km</span>
-              <span class="pill ghost">${formatRewards(rewards)}</span>
+              <span class="pill ghost">Cachet +${rewards.cachet}</span>
+            </div>
+            <div class="event-card__badges">
+              <span class="glass-badge xp"><span aria-hidden="true">⚡</span> +${rewards.xp} XP</span>
+              <span class="glass-badge rep"><span aria-hidden="true">★</span> +${rewards.reputation} Rep</span>
             </div>
           </button>
         </li>`;

--- a/apps/pwa/src/style.css
+++ b/apps/pwa/src/style.css
@@ -817,10 +817,24 @@ code {
   background: var(--surface-veil);
   border: 1px solid var(--border-soft);
   border-radius: 12px;
-  padding: 0.65rem 0.75rem;
+  padding: 0.75rem 0.85rem;
   color: var(--text-primary);
   display: grid;
-  gap: 0.35rem;
+  gap: 0.45rem;
+  position: relative;
+  backdrop-filter: blur(12px) saturate(1.2);
+}
+
+.event-card.static {
+  cursor: default;
+}
+
+.event-grid {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0 0;
+  display: grid;
+  gap: 0.85rem;
 }
 
 .event-card.active {
@@ -839,6 +853,34 @@ code {
   display: flex;
   gap: 0.35rem;
   flex-wrap: wrap;
+}
+
+.event-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.glass-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(12px) saturate(1.4);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-soft-elevated);
+}
+
+.glass-badge.xp {
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.glass-badge.rep {
+  border-color: rgba(244, 191, 79, 0.45);
 }
 
 .event-card strong {
@@ -1273,6 +1315,99 @@ code {
   flex-wrap: wrap;
 }
 
+.mission-board {
+  display: grid;
+  gap: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.mission-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.mission-progress {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 180px;
+}
+
+.mission-progress__value {
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.mission-progress__track {
+  height: 8px;
+  border-radius: 999px;
+  background: var(--surface-veil);
+  border: 1px solid var(--border-regular);
+  overflow: hidden;
+}
+
+.mission-progress__fill {
+  display: block;
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, var(--color-sky-300), var(--color-gold-400));
+  border-radius: inherit;
+  transition: width 160ms ease;
+}
+
+.mission-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.mission-card {
+  text-align: left;
+  border-radius: 14px;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-veil);
+  padding: 0.75rem 0.85rem;
+  display: grid;
+  gap: 0.5rem;
+  color: var(--text-primary);
+  box-shadow: var(--shadow-soft-elevated);
+  font: inherit;
+  cursor: pointer;
+}
+
+.mission-card.active {
+  border-color: var(--focus-ring);
+  box-shadow: 0 0 0 3px var(--surface-veil-highlight);
+}
+
+.mission-card__title {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.mission-card__title h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.mission-card__count {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.mission-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.mission-actions {
+  margin-top: 0.5rem;
+}
+
 .meta-chip {
   display: inline-flex;
   align-items: center;
@@ -1314,6 +1449,114 @@ code {
 
 .stat-list strong {
   color: var(--color-info-100);
+}
+
+.dashboard-card {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.dashboard-body {
+  display: grid;
+  gap: 1rem;
+}
+
+.dashboard-rings {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.dashboard-ring {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.85rem;
+  align-items: center;
+  padding: 0.75rem;
+  border-radius: 14px;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-veil-soft);
+}
+
+.dashboard-ring__meta {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.progress-ring {
+  --ring-progress: 0;
+  --ring-color: var(--color-sky-300);
+  width: 96px;
+  height: 96px;
+  border-radius: 999px;
+  background: conic-gradient(var(--ring-color) calc(var(--ring-progress) * 1%), var(--surface-veil) 0);
+  display: grid;
+  place-items: center;
+  position: relative;
+  box-shadow: var(--shadow-soft-elevated);
+}
+
+.progress-ring::after {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: inherit;
+  background: var(--bg-panel);
+  box-shadow: inset 0 0 0 1px var(--border-subtle);
+}
+
+.progress-ring.accent {
+  --ring-color: var(--color-gold-400);
+}
+
+.progress-ring .ring-value,
+.progress-ring .ring-label {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+}
+
+.progress-ring .ring-value {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--text-primary);
+}
+
+.progress-ring .ring-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.stat-quick-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.stat-quick-list li {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-veil);
+}
+
+.stat-quick-list strong {
+  color: var(--color-info-100);
+  font-size: 1.1rem;
 }
 
 .progress-grid {
@@ -1565,6 +1808,43 @@ code {
   .avatar-config {
     grid-template-columns: 1fr;
     justify-items: start;
+  }
+
+  .dashboard-ring {
+    grid-template-columns: 1fr;
+    text-align: center;
+    justify-items: center;
+  }
+
+  .dashboard-ring__meta {
+    text-align: center;
+  }
+
+  .progress-ring {
+    width: 84px;
+    height: 84px;
+  }
+
+  .stat-quick-list {
+    grid-template-columns: 1fr;
+  }
+
+  .mission-header {
+    align-items: flex-start;
+  }
+
+  .mission-progress {
+    width: 100%;
+  }
+
+  .mission-card__title {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .event-card__header {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Feedback noted the mobile view was not updated to match the refreshed dashboard/mission/event layouts, so responsive rules needed tuning to ensure components stack and scale correctly on small screens.
- Provide a compact, readable mobile presentation for dashboard rings, mission board, and event cards without altering desktop layouts.

### Description
- Updated responsive CSS in `apps/pwa/src/style.css` (inside `@media (max-width: 640px)`) to adjust dashboard ring layout, center ring metadata, and reduce `progress-ring` size for mobile screens.
- Made `stat-quick-list` collapse to a single column and ensured mission header, mission progress, mission-card titles, and event-card headers stack vertically on narrow viewports.
- Minor spacing and alignment tweaks to improve touch targets and readability for mission and event lists on mobile.
- Committed the changes with message `Tune mobile layout`.

### Testing
- Launched the PWA dev server with `npm run dev:pwa -- --host 0.0.0.0 --port 4173` which started successfully and served the app (Vite ready). (success)
- Ran a Playwright script that opened `http://127.0.0.1:5173/game.html` at a mobile viewport and saved a full-page screenshot at `artifacts/turni-dashboard-mobile.png` to validate the mobile layout. (screenshot created)
- No automated unit tests were executed as part of this change (`npm run test:pwa` not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c64c8c408326ba9699573191fce4)