### PR TITLE
Block mobile access to desktop PWA entrypoints

### DIFF
--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -34,7 +34,7 @@ const NON_PUBLIC_PATHS = new Set(CORE_ASSETS_BY_ENV.dev);
 const OFFLINE_URL = "/index.html";
 
 const CORE_CACHE_VERSION = "__SW_CACHE_VERSION__";
-const CACHE_VERSION_TAG = "v4";
+const CACHE_VERSION_TAG = "v5";
 const CORE_CACHE_NAME = `turni-di-palco-core-${CORE_CACHE_VERSION}-${CACHE_VERSION_TAG}`;
 const TILE_CACHE_NAME = `turni-di-palco-tiles-${CORE_CACHE_VERSION}-${CACHE_VERSION_TAG}`;
 const META_CACHE_NAME = `turni-di-palco-meta-${CORE_CACHE_VERSION}-${CACHE_VERSION_TAG}`;

--- a/apps/pwa/src/avatar.ts
+++ b/apps/pwa/src/avatar.ts
@@ -6,8 +6,10 @@ import { deriveRpmThumbnail, loadState, saveState, STORAGE_KEY } from "./state";
 import { getAvatarVisual } from "./avatar-visual";
 import type { SaveStateResult } from "./types";
 import { requireDevAccess } from "./services/dev-gate";
+import { enforceDesktopOnly } from "./utils/desktop-only";
 
 const start = async () => {
+  if (enforceDesktopOnly()) return;
   if (!(await requireDevAccess())) return;
 
 

--- a/apps/pwa/src/dev.ts
+++ b/apps/pwa/src/dev.ts
@@ -17,8 +17,10 @@ import {
 import type { AvatarIcon, GameState, Rewards, RoleId, SaveStateResult, TurnRecord } from "./types";
 import { buildProgressCopy, getEarnedMilestones, getProgressState, repMilestones, xpMilestones } from "./progression";
 import { requireDevAccess } from "./services/dev-gate";
+import { enforceDesktopOnly } from "./utils/desktop-only";
 
 const start = async () => {
+  if (enforceDesktopOnly()) return;
   if (!(await requireDevAccess())) return;
 
 

--- a/apps/pwa/src/events.ts
+++ b/apps/pwa/src/events.ts
@@ -2,8 +2,10 @@ import "../../../shared/styles/main.css";
 import { renderPageHero } from "./components/page-hero";
 import { mockEvents, resolveRole } from "./state";
 import { requireDevAccess } from "./services/dev-gate";
+import { enforceDesktopOnly } from "./utils/desktop-only";
 
 const start = async () => {
+  if (enforceDesktopOnly()) return;
   if (!(await requireDevAccess())) return;
 
 

--- a/apps/pwa/src/game.ts
+++ b/apps/pwa/src/game.ts
@@ -7,8 +7,10 @@ import { formatRewards, loadState, resolveRole, STORAGE_KEY } from "./state";
 import { getAvatarVisual } from "./avatar-visual";
 import { showSyncBadge } from "./utils/sync-badge";
 import { requireDevAccess } from "./services/dev-gate";
+import { enforceDesktopOnly } from "./utils/desktop-only";
 
 const start = async () => {
+  if (enforceDesktopOnly()) return;
   if (!(await requireDevAccess())) return;
 
 

--- a/apps/pwa/src/leaderboard.ts
+++ b/apps/pwa/src/leaderboard.ts
@@ -5,8 +5,10 @@ import { calculateLeaderboardStats, loadState, STORAGE_KEY } from "./state";
 import type { LeaderboardEntry, RoleId } from "./types";
 import { supabase, isSupabaseConfigured } from "./services/supabase";
 import { requireDevAccess } from "./services/dev-gate";
+import { enforceDesktopOnly } from "./utils/desktop-only";
 
 const start = async () => {
+  if (enforceDesktopOnly()) return;
   if (!(await requireDevAccess())) return;
 
 

--- a/apps/pwa/src/main.ts
+++ b/apps/pwa/src/main.ts
@@ -4,8 +4,10 @@ import { renderPermissionsCard, attachPermissionsListeners } from "./features/pe
 import { renderStatusCard, attachStatusListeners } from "./features/status-card";
 import { isPublicMode, requireDevAccess } from "./services/dev-gate";
 import { isFeatureEnabled } from "./services/feature-flags";
+import { enforceDesktopOnly } from "./utils/desktop-only";
 
 const start = async () => {
+  if (enforceDesktopOnly()) return;
   if (!(await requireDevAccess())) return;
 
   const root = document.querySelector<HTMLDivElement>("#app");

--- a/apps/pwa/src/map.ts
+++ b/apps/pwa/src/map.ts
@@ -19,8 +19,10 @@ import {
 import { getAvatarVisual } from "./avatar-visual";
 import type { Rewards, RoleId, SaveStateResult, TurnRecord } from "./types";
 import { requireDevAccess } from "./services/dev-gate";
+import { enforceDesktopOnly } from "./utils/desktop-only";
 
 const start = async () => {
+  if (enforceDesktopOnly()) return;
   if (!(await requireDevAccess())) return;
 
   type DecoratedEvent = (typeof mockEvents)[number] & { distanceKm: number };

--- a/apps/pwa/src/privacy.ts
+++ b/apps/pwa/src/privacy.ts
@@ -1,5 +1,6 @@
 import "../../../shared/styles/main.css";
 import { renderPageHero } from "./components/page-hero";
+import { enforceDesktopOnly } from "./utils/desktop-only";
 
 const IUBENDA_PRIVACY_POLICY_URL = "https://www.iubenda.com/privacy-policy/78603233";
 const IUBENDA_SCRIPT_SRC = "https://cdn.iubenda.com/iubenda.js";
@@ -16,6 +17,7 @@ function ensureIubendaScript() {
 }
 
 const start = () => {
+  if (enforceDesktopOnly()) return;
   const root = document.querySelector<HTMLDivElement>("#app");
 
   if (!root) {
@@ -60,4 +62,3 @@ const start = () => {
 };
 
 void start();
-

--- a/apps/pwa/src/profile.ts
+++ b/apps/pwa/src/profile.ts
@@ -4,8 +4,10 @@ import { buildProgressCopy, getEarnedMilestones, getProgressState, repMilestones
 import { formatRewards, loadState, resolveRole, STORAGE_KEY } from "./state";
 import { getAvatarVisual } from "./avatar-visual";
 import { requireDevAccess } from "./services/dev-gate";
+import { enforceDesktopOnly } from "./utils/desktop-only";
 
 const start = async () => {
+  if (enforceDesktopOnly()) return;
   if (!(await requireDevAccess())) return;
 
 

--- a/apps/pwa/src/turns.ts
+++ b/apps/pwa/src/turns.ts
@@ -2,8 +2,10 @@ import "../../../shared/styles/main.css";
 import { renderPageHero } from "./components/page-hero";
 import { formatRewards, loadState, resolveRole, roles, STORAGE_KEY } from "./state";
 import { requireDevAccess } from "./services/dev-gate";
+import { enforceDesktopOnly } from "./utils/desktop-only";
 
 const start = async () => {
+  if (enforceDesktopOnly()) return;
   if (!(await requireDevAccess())) return;
 
 

--- a/apps/pwa/src/utils/desktop-only.ts
+++ b/apps/pwa/src/utils/desktop-only.ts
@@ -1,0 +1,22 @@
+const isMobileDevice = () => {
+  if (typeof window === "undefined") return false;
+
+  const userAgent = navigator.userAgent.toLowerCase();
+  const isMobileUserAgent = /android|iphone|ipad|ipod|windows phone|mobile/.test(userAgent);
+  const isMobileUserAgentData = navigator.userAgentData?.mobile ?? false;
+  const isCoarsePointer = window.matchMedia?.("(pointer: coarse)").matches ?? false;
+  const isNarrowViewport = window.matchMedia?.("(max-width: 768px)").matches ?? false;
+
+  return isMobileUserAgent || isMobileUserAgentData || (isCoarsePointer && isNarrowViewport);
+};
+
+export const enforceDesktopOnly = (targetPath = "/mobile") => {
+  if (window.location.pathname.startsWith(targetPath)) return false;
+
+  if (isMobileDevice()) {
+    window.location.replace(targetPath);
+    return true;
+  }
+
+  return false;
+};


### PR DESCRIPTION
### Motivation
- Ensure the desktop PWA is only accessible from desktop clients and redirect mobile clients to the mobile entry at `/mobile` to avoid UI/UX mismatches.
- Centralize mobile detection and redirect logic to a shared guard to keep entrypoints lightweight and consistent.
- Force a service worker cache refresh after changing routing/asset behavior so clients pick up the updated redirect logic and assets.

### Description
- Added `apps/pwa/src/utils/desktop-only.ts` which implements `isMobileDevice()` heuristics and exports `enforceDesktopOnly(targetPath)` to perform a redirect via `window.location.replace` when a mobile device is detected.
- Invoked `enforceDesktopOnly()` at the start of all desktop PWA entrypoints to early-return and avoid rendering desktop UI; updated files include `apps/pwa/src/main.ts`, `apps/pwa/src/game.ts`, `apps/pwa/src/map.ts`, `apps/pwa/src/avatar.ts`, `apps/pwa/src/dev.ts`, `apps/pwa/src/events.ts`, `apps/pwa/src/leaderboard.ts`, `apps/pwa/src/profile.ts`, `apps/pwa/src/turns.ts`, and `apps/pwa/src/privacy.ts`.
- Bumped the service worker cache tag in `apps/pwa/public/sw.js` from `v4` to `v5` to invalidate the previous core cache and force clients to refresh assets.
- Redirect target defaults to `/mobile` and the guard skips redirect when already on the mobile path.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989cb162d3483269571ceb7fbcbc083)