### PR TITLE
Add QR validation & deep-link API and integrate mobile handling

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -39,6 +39,8 @@ import { useNavigation } from './hooks/useNavigation';
 import { useAuth } from './hooks/useAuth';
 import { useNotifications } from './hooks/useNotifications';
 import { useQrLanding } from './hooks/useQrLanding';
+import { PENDING_EVENT_KEY, readPendingEventFromUrl, stripEventLinkParams } from './lib/event-linking';
+import { validateQrPayload } from './services/event-links';
 
 function AppShell() {
   const {
@@ -198,13 +200,49 @@ function AppShell() {
     setSelectedActivityId,
   ]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const pendingFromUrl = readPendingEventFromUrl(window.location.href);
+    if (!pendingFromUrl?.eventId) return;
+
+    window.sessionStorage.setItem(PENDING_EVENT_KEY, pendingFromUrl.eventId);
+
+    try {
+      window.history.replaceState({}, '', stripEventLinkParams(window.location.href));
+    } catch {
+      // ignore
+    }
+
+    if (authReady && isAuthValid) {
+      setScannedEventId(pendingFromUrl.eventId);
+      setCurrentScreen('event-confirmation');
+      window.sessionStorage.removeItem(PENDING_EVENT_KEY);
+    }
+  }, [authReady, isAuthValid, setCurrentScreen, setScannedEventId]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!authReady || !isAuthValid) return;
+
+    const pendingEventId = window.sessionStorage.getItem(PENDING_EVENT_KEY);
+    if (!pendingEventId) return;
+
+    setScannedEventId(pendingEventId);
+    setCurrentScreen('event-confirmation');
+    window.sessionStorage.removeItem(PENDING_EVENT_KEY);
+  }, [authReady, isAuthValid, setCurrentScreen, setScannedEventId]);
+
   // Handler Actions
-  const handleQRScanAttempt = (code: string) => {
+  const handleQRScanAttempt = async (code: string) => {
     if (!authReady) return { ok: false as const, error: 'Verifica sessione...' };
     if (!isAuthValid) { setCurrentScreen('welcome'); return { ok: false as const, error: 'Login richiesto.' }; }
-    const resolved = events.find(e => code.toLowerCase().includes(e.id.toLowerCase()));
-    if (!resolved) return { ok: false as const, error: 'QR non valido.' };
-    setScannedEventId(resolved.id);
+
+    const result = await validateQrPayload(code, events.map((event) => event.id));
+    if (!result.valid || !result.eventId) {
+      return { ok: false as const, error: result.error ?? 'QR non valido.' };
+    }
+
+    setScannedEventId(result.eventId);
     setCurrentScreen('event-confirmation');
     return { ok: true as const };
   };

--- a/apps/mobile/src/lib/event-linking.ts
+++ b/apps/mobile/src/lib/event-linking.ts
@@ -1,0 +1,54 @@
+const EVENT_ID_PATTERN = /\b([A-Za-z]{2,10}-\d{1,6})\b/;
+
+export type ParsedEventLink = {
+  eventId: string;
+  roleId?: string;
+};
+
+export const PENDING_EVENT_KEY = 'tdp-mobile-pending-event';
+
+export function normalizeEventId(value: string | null | undefined): string {
+  return (value ?? '').trim().toUpperCase();
+}
+
+export function extractEventIdFromPayload(payload: string): string {
+  const raw = payload.trim();
+  if (!raw) return '';
+
+  try {
+    const url = new URL(raw);
+    const fromQuery = url.searchParams.get('event_id') ?? url.searchParams.get('eid');
+    if (fromQuery) return normalizeEventId(fromQuery);
+    const fromPath = url.pathname.match(EVENT_ID_PATTERN)?.[1];
+    if (fromPath) return normalizeEventId(fromPath);
+  } catch {
+    // fall through for plain payloads
+  }
+
+  const token = raw.match(EVENT_ID_PATTERN)?.[1];
+  return normalizeEventId(token ?? raw);
+}
+
+export function parseEventLink(urlText: string): ParsedEventLink | null {
+  try {
+    const url = new URL(urlText);
+    const eventId = normalizeEventId(url.searchParams.get('event_id') ?? url.searchParams.get('eid'));
+    if (!eventId) return null;
+    const roleId = url.searchParams.get('role_id')?.trim() || undefined;
+    return { eventId, roleId };
+  } catch {
+    return null;
+  }
+}
+
+export function readPendingEventFromUrl(locationHref: string): ParsedEventLink | null {
+  return parseEventLink(locationHref);
+}
+
+export function stripEventLinkParams(locationHref: string): string {
+  const url = new URL(locationHref);
+  url.searchParams.delete('event_id');
+  url.searchParams.delete('eid');
+  url.searchParams.delete('role_id');
+  return url.toString();
+}

--- a/apps/mobile/src/services/event-links.ts
+++ b/apps/mobile/src/services/event-links.ts
@@ -1,0 +1,53 @@
+import { isSupabaseConfigured, supabase } from '../lib/supabase';
+import { extractEventIdFromPayload, normalizeEventId } from '../lib/event-linking';
+
+type ValidateQrResponse = {
+  valid: boolean;
+  eventId?: string;
+  error?: string;
+};
+
+async function invokeEventLinks(payload: Record<string, unknown>) {
+  if (!supabase || !isSupabaseConfigured) {
+    return null;
+  }
+
+  const { data, error } = await supabase.functions.invoke('event-links', {
+    body: payload,
+  });
+
+  if (error) {
+    throw new Error(error.message || 'Errore durante la chiamata backend.');
+  }
+
+  return data as Record<string, unknown>;
+}
+
+export async function validateQrPayload(code: string, knownEventIds: string[]): Promise<ValidateQrResponse> {
+  const extracted = extractEventIdFromPayload(code);
+  if (!extracted) {
+    return { valid: false, error: 'QR non valido.' };
+  }
+
+  if (isSupabaseConfigured && supabase) {
+    try {
+      const data = await invokeEventLinks({ action: 'validate_qr', qrPayload: code });
+      if (data) {
+        return {
+          valid: Boolean(data.valid),
+          eventId: typeof data.eventId === 'string' ? normalizeEventId(data.eventId) : extracted,
+          error: typeof data.error === 'string' ? data.error : undefined,
+        };
+      }
+    } catch {
+      // fallback to local matching
+    }
+  }
+
+  const matched = knownEventIds.find((id) => id.toLowerCase() === extracted.toLowerCase());
+  if (!matched) {
+    return { valid: false, eventId: extracted, error: 'Evento non trovato.' };
+  }
+
+  return { valid: true, eventId: matched };
+}

--- a/supabase/functions/event-links/index.ts
+++ b/supabase/functions/event-links/index.ts
@@ -1,0 +1,188 @@
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.48.0';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+const EVENT_ID_PATTERN = /\b([A-Za-z]{2,10}-\d{1,6})\b/;
+
+type EventRow = {
+  id: string;
+  name: string;
+  theatre: string;
+  event_date: string;
+  event_time: string;
+  genre: string;
+  base_rewards: Record<string, number>;
+  focus_role: string | null;
+};
+
+function json(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+function normalizeEventId(value: string | null | undefined) {
+  return (value ?? '').trim().toUpperCase();
+}
+
+function extractEventId(payload: string | null | undefined) {
+  const raw = (payload ?? '').trim();
+  if (!raw) return '';
+
+  try {
+    const asUrl = new URL(raw);
+    const fromQuery = asUrl.searchParams.get('event_id') ?? asUrl.searchParams.get('eid');
+    if (fromQuery) return normalizeEventId(fromQuery);
+    const fromPath = asUrl.pathname.match(EVENT_ID_PATTERN)?.[1];
+    if (fromPath) return normalizeEventId(fromPath);
+  } catch {
+    // ignore and fallback to plain-text parsing
+  }
+
+  const textMatch = raw.match(EVENT_ID_PATTERN)?.[1];
+  return normalizeEventId(textMatch ?? raw);
+}
+
+function buildDeepLink(baseUrl: string, eventId: string, roleId: string | null) {
+  const url = new URL(baseUrl);
+  url.searchParams.set('from', 'qr');
+  url.searchParams.set('event_id', eventId);
+  if (roleId) {
+    url.searchParams.set('role_id', roleId);
+  }
+  return url.toString();
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return json({ error: 'Metodo non consentito' }, 405);
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const anonKey = Deno.env.get('SUPABASE_ANON_KEY');
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  if (!supabaseUrl || !anonKey || !serviceKey) {
+    return json({ error: 'Missing Supabase env vars' }, 500);
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  const key = authHeader ? anonKey : serviceKey;
+  const supabase = createClient(supabaseUrl, key, {
+    global: {
+      headers: authHeader ? { Authorization: authHeader } : undefined,
+    },
+  });
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: 'Payload JSON non valido' }, 400);
+  }
+
+  const action = String(body.action ?? 'validate_qr');
+
+  if (action === 'validate_qr') {
+    const qrPayload = String(body.qrPayload ?? body.code ?? '');
+    const extractedId = extractEventId(qrPayload);
+    if (!extractedId) {
+      return json({ valid: false, error: 'QR non valido: ID evento mancante.' }, 400);
+    }
+
+    const { data, error } = await supabase
+      .from('events')
+      .select('id,name,theatre,event_date,event_time,genre,base_rewards,focus_role')
+      .eq('id', extractedId)
+      .maybeSingle<EventRow>();
+
+    if (error) {
+      return json({ valid: false, error: error.message }, 500);
+    }
+
+    if (!data) {
+      return json({ valid: false, error: 'Evento non trovato.', eventId: extractedId }, 404);
+    }
+
+    const baseUrl = String(body.baseUrl ?? 'https://turnidipalco.it/mobile/index.html');
+    return json({
+      valid: true,
+      eventId: data.id,
+      event: data,
+      deepLink: buildDeepLink(baseUrl, data.id, null),
+    });
+  }
+
+  if (action === 'create_deep_link') {
+    const eventId = normalizeEventId(String(body.eventId ?? ''));
+    const roleId = String(body.roleId ?? '').trim() || null;
+    const baseUrl = String(body.baseUrl ?? 'https://turnidipalco.it/mobile/index.html');
+
+    if (!eventId) {
+      return json({ error: 'eventId obbligatorio' }, 400);
+    }
+
+    const { data, error } = await supabase
+      .from('events')
+      .select('id')
+      .eq('id', eventId)
+      .maybeSingle<{ id: string }>();
+
+    if (error) {
+      return json({ error: error.message }, 500);
+    }
+
+    if (!data) {
+      return json({ error: 'Evento non trovato', eventId }, 404);
+    }
+
+    return json({ eventId, deepLink: buildDeepLink(baseUrl, eventId, roleId) });
+  }
+
+  if (action === 'resolve_deep_link') {
+    const targetUrl = String(body.url ?? '');
+    if (!targetUrl) {
+      return json({ error: 'url obbligatorio' }, 400);
+    }
+
+    let url: URL;
+    try {
+      url = new URL(targetUrl);
+    } catch {
+      return json({ error: 'url non valida' }, 400);
+    }
+
+    const eventId = normalizeEventId(url.searchParams.get('event_id') ?? url.searchParams.get('eid'));
+    const roleId = url.searchParams.get('role_id');
+    if (!eventId) {
+      return json({ error: 'event_id mancante' }, 400);
+    }
+
+    const { data, error } = await supabase
+      .from('events')
+      .select('id,name,theatre,event_date,event_time,genre,base_rewards,focus_role')
+      .eq('id', eventId)
+      .maybeSingle<EventRow>();
+
+    if (error) {
+      return json({ resolved: false, error: error.message }, 500);
+    }
+
+    if (!data) {
+      return json({ resolved: false, error: 'Evento non trovato', eventId }, 404);
+    }
+
+    return json({ resolved: true, eventId, roleId, event: data });
+  }
+
+  return json({ error: `Azione non supportata: ${action}` }, 400);
+});


### PR DESCRIPTION
### Motivation
- Ensure scanned QR codes reliably map to existing events and provide clear errors when they don't. 
- Support deep links that prefill event registration (including optional role) for a smoother onboarding/registration flow. 
- Preserve UX when backend is unavailable by falling back to client-side catalog matching.

### Description
- Added a Supabase Edge Function `event-links` (`supabase/functions/event-links/index.ts`) exposing `validate_qr`, `create_deep_link`, and `resolve_deep_link` actions to validate QR payloads and generate/resolve deep links. 
- Added client utilities in `apps/mobile/src/lib/event-linking.ts` to parse/normalize event IDs, read pending deep-link params, and strip params after handling. 
- Implemented `apps/mobile/src/services/event-links.ts` which invokes the `event-links` function (backend-first) and falls back to local event catalog when unavailable. 
- Integrated the mobile app flow in `apps/mobile/src/App.tsx` to store/handle pending deep links, redirect authenticated users into `event-confirmation`, and update QR scanning to use `validateQrPayload`.

### Testing
- Ran the mobile production build with `npm --workspace apps/mobile run build`, which completed successfully. 
- No unit/integration tests were added in this change set; behavior validated via the production build and local smoke checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c573c93648326987f4f623d142bf5)