### PR TITLE
Mobile prototype for QR activation + Python ticket-office generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ maxwell-ai-credentials.json
 
 # Python cache
 */__pycache__
+# QR output
+tools/ticket_qr_generator/out/

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,5 @@ apps/mobile/build/assets/index-*.css
 maxwell-ai-credentials.json
 
 # Python cache
-*/__pycache__
-# QR output
 tools/ticket_qr_generator/out/
+tools/ticket_qr_generator/__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ apps/mobile/build/index.html
 apps/mobile/build/assets/index-*.js
 apps/mobile/build/assets/index-*.css
 maxwell-ai-credentials.json
+
+# Python cache
+*/__pycache__

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -24,12 +24,12 @@ import { TermsAndConditions } from './components/screens/TermsAndConditions';
 import { PrivacyPolicy } from './components/screens/PrivacyPolicy';
 import { EarnedTitles } from './components/screens/EarnedTitles';
 import { TicketQrActivationPrototype } from './components/screens/TicketQrActivationPrototype';
-import { Activity, GameStateProvider, Rewards, useGameState } from './state/store';
+import { Activity, GameEvent, GameStateProvider, Rewards, useGameState } from './state/store';
 import { isSupabaseConfigured } from './lib/supabase';
 import { hasStoredAuthState, PUBLIC_SCREENS } from './lib/auth-storage';
 import { openInMaps, openEventsMap } from './lib/navigation-utils';
 import { uploadProfileImage } from './services/storage';
-import { activateTicketHash, parseTicketQrValue } from './services/ticket-activation';
+import { activateTicketHash, parseTicketQrValue, type ActivatedEventPayload } from './services/ticket-activation';
 import { ScreenTransition } from './components/ui/ScreenTransition';
 import { ErrorOverlay } from './components/ui/ErrorOverlay';
 import { initErrorHandler, subscribeToCriticalErrors, getLastCriticalError, clearLastCriticalError } from './services/error-handler';
@@ -240,11 +240,50 @@ function AppShell() {
     if (!isAuthValid) { setCurrentScreen('welcome'); return { ok: false as const, error: 'Login richiesto.' }; }
 
     const activationUserId = (authUserId ?? state.profile.email ?? '').trim();
+    const confirmTurnActivation = (details: string) =>
+      window.confirm(
+        `Confermi l'attivazione del turno per questo ticket?\n\n${details}`
+      );
+    const toNumber = (value: unknown) => {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : 0;
+    };
+    const mapActivatedEvent = (
+      eventId: string,
+      eventPayload?: ActivatedEventPayload
+    ): GameEvent | undefined => {
+      const existingEvent = events.find((event) => event.id === eventId);
+      if (existingEvent) return existingEvent;
+      if (!eventPayload) return undefined;
+
+      const theatre = String(eventPayload.theatre ?? '').trim();
+      const date = String(eventPayload.event_date ?? '').trim();
+      const time = String(eventPayload.event_time ?? '').trim();
+      if (!theatre || !date || !time) return undefined;
+
+      const baseRewards = eventPayload.base_rewards ?? {};
+      return {
+        id: eventId,
+        name: String(eventPayload.name ?? eventId).trim() || eventId,
+        theatre,
+        date,
+        time,
+        genre: String(eventPayload.genre ?? 'Evento').trim() || 'Evento',
+        baseRewards: {
+          xp: toNumber(baseRewards.xp),
+          reputation: toNumber(baseRewards.reputation),
+          cachet: toNumber(baseRewards.cachet),
+        },
+      };
+    };
 
     // 1. Manual Ticket Entry (e.g. from manual-ticket:EVENT_ID:TICKET_NUM)
     if (code.startsWith('manual-ticket:')) {
       const [, eventId, ticketNumber] = code.split(':');
       if (!eventId || !ticketNumber) return { ok: false as const, error: 'Dati manuali incompleti.' };
+      if (!confirmTurnActivation(`Evento: ${eventId}\nBiglietto: ${ticketNumber}`)) {
+        return { ok: false as const, error: 'Attivazione annullata.' };
+      }
 
       const { activateTicketByDetails } = await import('./services/ticket-activation');
       const activation = await activateTicketByDetails(eventId, ticketNumber, activationUserId);
@@ -252,8 +291,16 @@ function AppShell() {
 
       // Auto-register turn on success
       if (activation.eventId) {
-        registerTurn(activation.eventId, state.profile.roleId);
-        window.alert('Ticket attivato e turno registrato con successo.');
+        const turnRecord = registerTurn(
+          activation.eventId,
+          state.profile.roleId,
+          mapActivatedEvent(activation.eventId, activation.event)
+        );
+        if (turnRecord) {
+          window.alert('Ticket attivato e turno registrato con successo.');
+        } else {
+          window.alert('Ticket attivato, ma non è stato possibile aggiornare le statistiche turno.');
+        }
       } else {
         window.alert('Ticket attivato.');
       }
@@ -268,6 +315,9 @@ function AppShell() {
       if (!activationUserId) {
         return { ok: false as const, error: 'Utente non disponibile per l\'attivazione ticket.' };
       }
+      if (!confirmTurnActivation(`Hash ticket: ${ticketHash.slice(0, 12)}...`)) {
+        return { ok: false as const, error: 'Attivazione annullata.' };
+      }
 
       const activation = await activateTicketHash(ticketHash, activationUserId);
       if (!activation.ok) {
@@ -276,8 +326,16 @@ function AppShell() {
 
       // Auto-register turn on success
       if (activation.eventId) {
-        registerTurn(activation.eventId, state.profile.roleId);
-        window.alert('Ticket attivato e turno registrato correttamente.');
+        const turnRecord = registerTurn(
+          activation.eventId,
+          state.profile.roleId,
+          mapActivatedEvent(activation.eventId, activation.event)
+        );
+        if (turnRecord) {
+          window.alert('Ticket attivato e turno registrato correttamente.');
+        } else {
+          window.alert('Ticket attivato, ma non è stato possibile aggiornare le statistiche turno.');
+        }
       } else {
         window.alert('Ticket attivato correttamente.');
       }

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -250,7 +250,14 @@ function AppShell() {
       const activation = await activateTicketByDetails(eventId, ticketNumber, activationUserId);
       if (!activation.ok) return { ok: false as const, error: activation.error };
 
-      window.alert('Ticket attivato con successo (manuale).');
+      // Auto-register turn on success
+      if (activation.eventId) {
+        registerTurn(activation.eventId, state.profile.roleId);
+        window.alert('Ticket attivato e turno registrato con successo.');
+      } else {
+        window.alert('Ticket attivato.');
+      }
+      
       setCurrentScreen(activeTab === 'home' ? 'home' : 'turns');
       return { ok: true as const };
     }
@@ -267,7 +274,14 @@ function AppShell() {
         return { ok: false as const, error: activation.error };
       }
 
-      window.alert('Ticket attivato correttamente.');
+      // Auto-register turn on success
+      if (activation.eventId) {
+        registerTurn(activation.eventId, state.profile.roleId);
+        window.alert('Ticket attivato e turno registrato correttamente.');
+      } else {
+        window.alert('Ticket attivato correttamente.');
+      }
+      
       setCurrentScreen(activeTab === 'home' ? 'home' : 'turns');
       return { ok: true as const };
     }

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -239,9 +239,25 @@ function AppShell() {
     if (!authReady) return { ok: false as const, error: 'Verifica sessione...' };
     if (!isAuthValid) { setCurrentScreen('welcome'); return { ok: false as const, error: 'Login richiesto.' }; }
 
+    const activationUserId = (authUserId ?? state.profile.email ?? '').trim();
+
+    // 1. Manual Ticket Entry (e.g. from manual-ticket:EVENT_ID:TICKET_NUM)
+    if (code.startsWith('manual-ticket:')) {
+      const [, eventId, ticketNumber] = code.split(':');
+      if (!eventId || !ticketNumber) return { ok: false as const, error: 'Dati manuali incompleti.' };
+
+      const { activateTicketByDetails } = await import('./services/ticket-activation');
+      const activation = await activateTicketByDetails(eventId, ticketNumber, activationUserId);
+      if (!activation.ok) return { ok: false as const, error: activation.error };
+
+      window.alert('Ticket attivato con successo (manuale).');
+      setCurrentScreen(activeTab === 'home' ? 'home' : 'turns');
+      return { ok: true as const };
+    }
+
+    // 2. Ticket Hash or turni://ticket/...
     const ticketHash = parseTicketQrValue(code);
     if (ticketHash) {
-      const activationUserId = (authUserId ?? state.profile.email ?? '').trim();
       if (!activationUserId) {
         return { ok: false as const, error: 'Utente non disponibile per l\'attivazione ticket.' };
       }
@@ -302,7 +318,7 @@ function AppShell() {
       case 'home': return <Home userName={state.profile.name} userRole={selectedRole?.name ?? 'Ruolo'} level={state.profile.level} xp={state.profile.xp} xpToNextLevel={state.profile.xpToNextLevel} reputation={state.profile.reputation} onScanQR={() => setCurrentScreen('qr-scanner')} onViewActivities={() => handleTabChange('activities')} onViewTurni={() => handleTabChange('turns')} onViewEventDetails={() => { setScannedEventId(upcomingEvent?.id ?? ''); setCurrentScreen('event-details'); }} onNavigateToEvent={() => openInMaps(upcomingEvent?.theatre ?? '')} upcomingEvent={upcomingEvent} totalTurns={turnStats.totalTurns} turnsThisMonth={turnStats.turnsThisMonth} uniqueTheatres={turnStats.uniqueTheatres} activitiesCount={activities.length} eventLoading={followedEventsLoading} statsLoading={statsLoading} newBadgesCount={newBadges.length} newBadgeTitle={newestNewBadge?.title} onDismissBadgeNotification={markBadgesSeen} />;
       case 'turns': return <ATCLTurns events={events} isEventFollowed={isEventFollowed} onToggleFollow={(id: string) => isEventFollowed(id) ? unfollowEvent(id) : followEvent(id)} onViewMap={() => openEventsMap(events.map(e => e.theatre))} onViewEvent={(id: string) => { setScannedEventId(id); setCurrentScreen('event-details'); }} onScanQR={() => setCurrentScreen('qr-scanner')} />;
       case 'leaderboard': return <Leaderboard />;
-      case 'qr-scanner': return <QRScanner onClose={() => handleTabChange(activeTab === 'home' ? 'home' : 'turns')} onScan={handleQRScanAttempt} />;
+      case 'qr-scanner': return <QRScanner onClose={() => handleTabChange(activeTab === 'home' ? 'home' : 'turns')} onScan={handleQRScanAttempt} events={events} />;
       case 'event-confirmation': return <EventConfirmation event={selectedEvent} role={selectedRole} onConfirm={handleEventConfirm} onCancel={() => setCurrentScreen('turns')} />;
       case 'event-details': return <EventDetails event={selectedEvent} onBack={() => setCurrentScreen('home')} onNavigate={() => openInMaps(selectedEvent?.theatre ?? '')} />;
       case 'activities': return <Activities activities={activities} onStartActivity={(id: string) => { setSelectedActivityId(id); setCurrentScreen('activity-detail'); }} />;

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -262,7 +262,7 @@ function AppShell() {
       return { ok: true as const };
     }
 
-    // 2. Ticket Hash or turni://ticket/...
+    // 2. Ticket hash (raw SHA-256) or legacy turni://ticket/...
     const ticketHash = parseTicketQrValue(code);
     if (ticketHash) {
       if (!activationUserId) {

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -23,6 +23,7 @@ import { InstallApp } from './components/screens/InstallApp';
 import { TermsAndConditions } from './components/screens/TermsAndConditions';
 import { PrivacyPolicy } from './components/screens/PrivacyPolicy';
 import { EarnedTitles } from './components/screens/EarnedTitles';
+import { TicketQrActivationPrototype } from './components/screens/TicketQrActivationPrototype';
 import { Activity, GameStateProvider, Rewards, useGameState } from './state/store';
 import { isSupabaseConfigured } from './lib/supabase';
 import { hasStoredAuthState, PUBLIC_SCREENS } from './lib/auth-storage';
@@ -317,13 +318,14 @@ function AppShell() {
           <Activities activities={activities} onStartActivity={(id: string) => { setSelectedActivityId(id); setCurrentScreen('activity-detail'); }} />
         );
       case 'profile': return <Profile userName={state.profile.name} userRole={selectedRole?.name ?? 'Ruolo'} level={state.profile.level} xp={state.profile.xp} xpTotal={state.profile.xpTotal} xpSulCampo={state.profile.xpField} reputationGlobal={state.profile.reputation} theatreReputation={theatreReputation.map(tr => ({ name: tr.theatre, reputation: tr.reputation }))} theatreReputationLoading={theatreReputationLoading} badgesUnlockedCount={unlockedBadges.length} newBadgesCount={newBadges.length} profileImage={state.profile.profileImage} onViewCarriera={() => setCurrentScreen('career')} onViewTitoli={() => setCurrentScreen('earned-titles')} onSettings={() => setCurrentScreen('account-settings')} onLogout={handleLogout} onUploadProfileImage={handleUploadImage} />;
-      case 'account-settings': return <AccountSettings userName={state.profile.name} email={state.profile.email} onBack={() => setCurrentScreen('profile')} onViewTerms={() => openLegal('terms', 'account-settings')} onViewPrivacy={() => openLegal('privacy', 'account-settings')} onViewSupport={() => setCurrentScreen('support')} onChangePassword={() => { setIsPasswordRecovery(false); setCurrentScreen('change-password'); }} onResetProgress={async () => { await resetProgress(); handleTabChange('home'); setCurrentScreen('role-selection'); }} onLogout={handleLogout} />;
+      case 'account-settings': return <AccountSettings userName={state.profile.name} email={state.profile.email} onBack={() => setCurrentScreen('profile')} onViewTerms={() => openLegal('terms', 'account-settings')} onViewPrivacy={() => openLegal('privacy', 'account-settings')} onViewSupport={() => setCurrentScreen('support')} onViewTicketPrototype={() => setCurrentScreen('ticket-qr-prototype')} onChangePassword={() => { setIsPasswordRecovery(false); setCurrentScreen('change-password'); }} onResetProgress={async () => { await resetProgress(); handleTabChange('home'); setCurrentScreen('role-selection'); }} onLogout={handleLogout} />;
       case 'support': return <SupportChat userName={state.profile.name} onBack={() => setCurrentScreen('account-settings')} />;
       case 'change-password': return <ChangePassword email={state.profile.email} mode={isPasswordRecovery ? 'recovery' : 'change'} onBack={() => { setIsPasswordRecovery(false); setCurrentScreen(isPasswordRecovery ? 'home' : 'account-settings'); }} onChangePassword={(current, next) => changePassword(next, current)} onSendResetEmail={() => sendPasswordResetEmail(state.profile.email)} />;
       case 'career': return <Career userRole={selectedRole?.name ?? 'Ruolo'} roleId={state.profile.roleId} roleStats={selectedRole?.stats ?? { presence: 0, precision: 0, leadership: 0, creativity: 0 }} turnStats={turnStats} badges={badges} turns={state.turns} roles={roles} level={state.profile.level} xp={state.profile.xp} xpToNextLevel={state.profile.xpToNextLevel} xpTotal={state.profile.xpTotal} xpSulCampo={state.profile.xpField} reputationGlobal={state.profile.reputation} onBack={() => setCurrentScreen('profile')} />;
       case 'terms': return <TermsAndConditions onBack={() => setCurrentScreen(legalReturnScreen)} />;
       case 'privacy': return <PrivacyPolicy onBack={() => setCurrentScreen(legalReturnScreen)} />;
       case 'earned-titles': return <EarnedTitles badges={unlockedBadges} onBack={() => setCurrentScreen('profile')} onViewed={markBadgesSeen} />;
+      case 'ticket-qr-prototype': return <TicketQrActivationPrototype userId={authUserId ?? state.profile.email ?? 'guest-user'} onBack={() => setCurrentScreen('account-settings')} />;
       default: return null;
     }
   };

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -29,6 +29,7 @@ import { isSupabaseConfigured } from './lib/supabase';
 import { hasStoredAuthState, PUBLIC_SCREENS } from './lib/auth-storage';
 import { openInMaps, openEventsMap } from './lib/navigation-utils';
 import { uploadProfileImage } from './services/storage';
+import { activateTicketHash, parseTicketQrValue } from './services/ticket-activation';
 import { ScreenTransition } from './components/ui/ScreenTransition';
 import { ErrorOverlay } from './components/ui/ErrorOverlay';
 import { initErrorHandler, subscribeToCriticalErrors, getLastCriticalError, clearLastCriticalError } from './services/error-handler';
@@ -237,6 +238,23 @@ function AppShell() {
   const handleQRScanAttempt = async (code: string) => {
     if (!authReady) return { ok: false as const, error: 'Verifica sessione...' };
     if (!isAuthValid) { setCurrentScreen('welcome'); return { ok: false as const, error: 'Login richiesto.' }; }
+
+    const ticketHash = parseTicketQrValue(code);
+    if (ticketHash) {
+      const activationUserId = (authUserId ?? state.profile.email ?? '').trim();
+      if (!activationUserId) {
+        return { ok: false as const, error: 'Utente non disponibile per l\'attivazione ticket.' };
+      }
+
+      const activation = await activateTicketHash(ticketHash, activationUserId);
+      if (!activation.ok) {
+        return { ok: false as const, error: activation.error };
+      }
+
+      window.alert('Ticket attivato correttamente.');
+      setCurrentScreen(activeTab === 'home' ? 'home' : 'turns');
+      return { ok: true as const };
+    }
 
     const result = await validateQrPayload(code, events.map((event) => event.id));
     if (!result.valid || !result.eventId) {

--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -10,6 +10,7 @@ import {
   LogOut,
   MapPin,
   MessageCircle,
+  QrCode,
   Shield,
   ShieldCheck,
   Trash2,
@@ -31,6 +32,7 @@ interface AccountSettingsProps {
   onViewTerms: () => void;
   onViewPrivacy: () => void;
   onViewSupport: () => void;
+  onViewTicketPrototype: () => void;
   onChangePassword: () => void;
   onResetProgress: () => void;
   onLogout: () => void;
@@ -77,6 +79,7 @@ export function AccountSettings({
   onViewTerms,
   onViewPrivacy,
   onViewSupport,
+  onViewTicketPrototype,
   onChangePassword,
   onResetProgress,
   onLogout,
@@ -599,6 +602,26 @@ export function AccountSettings({
               Stato del supporto non verificabile. Puoi comunque provare ad aprire la chat.
             </p>
           ) : null}
+
+
+          <button
+            type="button"
+            onClick={onViewTicketPrototype}
+            className="h-[51px] flex items-center justify-between"
+          >
+            <div className="flex items-center gap-[12px]">
+              <QrCode className="text-[#f4bf4f]" size={24} />
+              <div className="text-left">
+                <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">
+                  Prototipo ticket QR
+                </p>
+                <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">
+                  Generazione hash e attivazione one-shot
+                </p>
+              </div>
+            </div>
+            <ChevronRight className="text-[#7a7577]" size={20} />
+          </button>
 
           <button
             type="button"

--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -40,6 +40,9 @@ export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
     isScanningRef.current = isScanning;
   }, [isScanning]);
 
+  const isAuthErrorMessage = (message: string) =>
+    /invalid jwt|sessione scaduta|login richiesto|unauthorized|401/i.test(message);
+
   const handleScanAttempt = async (code: string) => {
     const trimmed = code.trim();
     if (!trimmed) return;
@@ -57,8 +60,17 @@ export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
       }
 
       setScanError(result.error);
+      if (isAuthErrorMessage(result.error)) {
+        stopCamera();
+        shouldResume = false;
+      }
     } catch (error) {
-      setScanError(error instanceof Error ? error.message : 'QR non valido.');
+      const message = error instanceof Error ? error.message : 'QR non valido.';
+      setScanError(message);
+      if (isAuthErrorMessage(message)) {
+        stopCamera();
+        shouldResume = false;
+      }
     } finally {
       if (!shouldResume) {
         setIsHandlingScan(false);

--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -15,7 +15,6 @@ export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
   const [manualCode, setManualCode] = useState('');
   const [manualTicket, setManualTicket] = useState('');
   const [manualEventId, setManualEventId] = useState('');
-  const [manualMode, setManualMode] = useState<'event' | 'ticket'>('event');
   const [isScanning, setIsScanning] = useState(true);
   const [cameraError, setCameraError] = useState<string | null>(null);
   const [scanError, setScanError] = useState<string | null>(null);
@@ -253,18 +252,13 @@ export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
   const handleManualSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
-    if (manualMode === 'event') {
-      if (!manualCode.trim()) return;
-      await handleScanAttempt(manualCode);
-    } else {
-      if (!manualTicket.trim() || !manualEventId.trim()) {
-        setScanError('Inserisci sia ID Evento che Numero Ticket.');
-        return;
-      }
-      // Proviamo a costruire un payload finto o chiamiamo direttamente onScan 
-      // col formato speciale che App.tsx capirà
-      await handleScanAttempt(`manual-ticket:${manualEventId}:${manualTicket}`);
+    if (!manualTicket.trim() || !manualEventId.trim()) {
+      setScanError('Inserisci sia ID Evento che Numero Ticket.');
+      return;
     }
+    // Proviamo a costruire un payload finto o chiamiamo direttamente onScan 
+    // col formato speciale che App.tsx capirà
+    await handleScanAttempt(`manual-ticket:${manualEventId}:${manualTicket}`);
   };
 
   return (
@@ -389,24 +383,11 @@ export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
               </p>
             </div>
 
-            {/* Mode Toggle */}
-            <div className="flex bg-[#241f20] p-1 rounded-xl mb-6">
-              <button
-                onClick={() => setManualMode('event')}
-                className={`flex-1 py-2 text-xs font-semibold rounded-lg transition-all ${
-                  manualMode === 'event' ? 'bg-[#f4bf4f] text-[#0f0d0e]' : 'text-[#b8b2b3]'
-                }`}
-              >
-                Codice Evento
-              </button>
-              <button
-                onClick={() => setManualMode('ticket')}
-                className={`flex-1 py-2 text-xs font-semibold rounded-lg transition-all ${
-                  manualMode === 'ticket' ? 'bg-[#f4bf4f] text-[#0f0d0e]' : 'text-[#b8b2b3]'
-                }`}
-              >
-                Biglietto / Hash
-              </button>
+            {/* Manual Activation Header */}
+            <div className="mb-6 text-center">
+               <div className="inline-block px-3 py-1 bg-[#241f20] rounded-full text-[10px] text-[#f4bf4f] font-bold uppercase tracking-wider">
+                 Attivazione Biglietto
+               </div>
             </div>
 
             {scanError ? (
@@ -416,21 +397,6 @@ export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
             ) : null}
 
             <form onSubmit={handleManualSubmit} className="space-y-4">
-              {manualMode === 'event' ? (
-                <div className="space-y-2">
-                  <label className="text-xs text-[#7f797a] ml-1 uppercase font-bold tracking-wider">Codice stampato</label>
-                  <Input
-                    type="text"
-                    placeholder="es. ATCL-123"
-                    value={manualCode}
-                    onChange={(e) => setManualCode(e.target.value)}
-                    className="text-center uppercase"
-                  />
-                  <p className="text-[10px] text-[#7f797a] text-center px-2 italic">
-                    Inserisci l'ID alfuanumerico dell'evento (es. SR-98751)
-                  </p>
-                </div>
-              ) : (
                 <div className="space-y-4">
                   <div className="space-y-2">
                     <label className="text-xs text-[#7f797a] ml-1 uppercase font-bold tracking-wider">Seleziona Evento</label>
@@ -466,7 +432,6 @@ export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
                     </p>
                   </div>
                 </div>
-              )}
               
               <div className="pt-4 space-y-3">
                 <Button type="submit" variant="primary" size="lg" fullWidth disabled={isHandlingScan}>

--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -3,14 +3,19 @@ import { Button } from '../ui/Button';
 import { Input } from '../ui/Input';
 import { QrCode, X } from 'lucide-react';
 import jsQR from 'jsqr';
+import { GameEvent } from '../../state/store';
 
 interface QRScannerProps {
   onClose: () => void;
   onScan: (code: string) => Promise<{ ok: true } | { ok: false; error: string }> | { ok: true } | { ok: false; error: string };
+  events?: GameEvent[];
 }
 
-export function QRScanner({ onClose, onScan }: QRScannerProps) {
+export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
   const [manualCode, setManualCode] = useState('');
+  const [manualTicket, setManualTicket] = useState('');
+  const [manualEventId, setManualEventId] = useState('');
+  const [manualMode, setManualMode] = useState<'event' | 'ticket'>('event');
   const [isScanning, setIsScanning] = useState(true);
   const [cameraError, setCameraError] = useState<string | null>(null);
   const [scanError, setScanError] = useState<string | null>(null);
@@ -247,8 +252,19 @@ export function QRScanner({ onClose, onScan }: QRScannerProps) {
 
   const handleManualSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!manualCode.trim()) return;
-    await handleScanAttempt(manualCode);
+    
+    if (manualMode === 'event') {
+      if (!manualCode.trim()) return;
+      await handleScanAttempt(manualCode);
+    } else {
+      if (!manualTicket.trim() || !manualEventId.trim()) {
+        setScanError('Inserisci sia ID Evento che Numero Ticket.');
+        return;
+      }
+      // Proviamo a costruire un payload finto o chiamiamo direttamente onScan 
+      // col formato speciale che App.tsx capirà
+      await handleScanAttempt(`manual-ticket:${manualEventId}:${manualTicket}`);
+    }
   };
 
   return (
@@ -362,44 +378,109 @@ export function QRScanner({ onClose, onScan }: QRScannerProps) {
           </>
         ) : (
           // Manual Input
-          <div className="p-6 app-content">
+          <div className="p-6 app-content h-full overflow-y-auto pb-20">
             <div className="mb-6 text-center">
               <div className="w-16 h-16 bg-[#241f20] rounded-full flex items-center justify-center mx-auto mb-4">
                 <QrCode className="text-[#f4bf4f]" size={32} />
               </div>
-              <h3 className="text-white mb-2">Inserisci il codice evento</h3>
+              <h3 className="text-white mb-2">Inserimento Manuale</h3>
               <p className="text-sm text-[#b8b2b3]">
-                Trova il codice stampato sul tuo biglietto ATCL
+                Inserisci i dati se il QR non è leggibile
               </p>
             </div>
 
+            {/* Mode Toggle */}
+            <div className="flex bg-[#241f20] p-1 rounded-xl mb-6">
+              <button
+                onClick={() => setManualMode('event')}
+                className={`flex-1 py-2 text-xs font-semibold rounded-lg transition-all ${
+                  manualMode === 'event' ? 'bg-[#f4bf4f] text-[#0f0d0e]' : 'text-[#b8b2b3]'
+                }`}
+              >
+                Codice Evento
+              </button>
+              <button
+                onClick={() => setManualMode('ticket')}
+                className={`flex-1 py-2 text-xs font-semibold rounded-lg transition-all ${
+                  manualMode === 'ticket' ? 'bg-[#f4bf4f] text-[#0f0d0e]' : 'text-[#b8b2b3]'
+                }`}
+              >
+                Biglietto / Hash
+              </button>
+            </div>
+
             {scanError ? (
-              <div className="mb-4 rounded-xl border border-[#2d2728] bg-[#1a1617] px-4 py-3 text-center">
-                <p className="text-white mb-1">QR non valido</p>
-                <p className="text-sm text-[#b8b2b3]">{scanError}</p>
+              <div className="mb-4 rounded-xl border border-[#d32f2f]/30 bg-[#d32f2f]/10 px-4 py-3 text-center">
+                <p className="text-[#ff5252] text-xs">{scanError}</p>
               </div>
             ) : null}
 
             <form onSubmit={handleManualSubmit} className="space-y-4">
-              <Input
-                type="text"
-                placeholder="es. ATCL-001"
-                value={manualCode}
-                onChange={(e) => setManualCode(e.target.value)}
-                className="text-center uppercase"
-              />
+              {manualMode === 'event' ? (
+                <div className="space-y-2">
+                  <label className="text-xs text-[#7f797a] ml-1 uppercase font-bold tracking-wider">Codice stampato</label>
+                  <Input
+                    type="text"
+                    placeholder="es. ATCL-123"
+                    value={manualCode}
+                    onChange={(e) => setManualCode(e.target.value)}
+                    className="text-center uppercase"
+                  />
+                  <p className="text-[10px] text-[#7f797a] text-center px-2 italic">
+                    Inserisci l'ID alfuanumerico dell'evento (es. SR-98751)
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <label className="text-xs text-[#7f797a] ml-1 uppercase font-bold tracking-wider">Seleziona Evento</label>
+                    <div className="relative">
+                      <select
+                        value={manualEventId}
+                        onChange={(e) => setManualEventId(e.target.value)}
+                        className="w-full bg-[#1a1617] border border-[#2d2728] rounded-xl px-4 py-3 text-sm text-white appearance-none focus:outline-none focus:border-[#f4bf4f] transition-colors"
+                      >
+                        <option value="" disabled>Scegli l'evento...</option>
+                        {events.map(event => (
+                          <option key={event.id} value={event.id}>
+                            {event.name} ({event.date})
+                          </option>
+                        ))}
+                      </select>
+                      <div className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-[#f4bf4f]">
+                        <X size={14} className="rotate-45" />
+                      </div>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-xs text-[#7f797a] ml-1 uppercase font-bold tracking-wider">Numero Biglietto</label>
+                    <Input
+                      type="text"
+                      placeholder="es. 12345"
+                      value={manualTicket}
+                      onChange={(e) => setManualTicket(e.target.value)}
+                      className="text-center"
+                    />
+                    <p className="text-[10px] text-[#7f797a] text-center px-2 italic">
+                      Puoi anche incollare direttamente l'Hash se lo hai
+                    </p>
+                  </div>
+                </div>
+              )}
               
-              <Button type="submit" variant="primary" size="lg" fullWidth>
-                Conferma codice
-              </Button>
-              
-              <button
-                type="button"
-                onClick={() => setIsScanning(true)}
-                className="w-full rounded-md py-[10px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
-              >
-                Torna alla scansione QR
-              </button>
+              <div className="pt-4 space-y-3">
+                <Button type="submit" variant="primary" size="lg" fullWidth disabled={isHandlingScan}>
+                  {isHandlingScan ? 'Verifica in corso...' : 'Conferma dati'}
+                </Button>
+                
+                <button
+                  type="button"
+                  onClick={() => setIsScanning(true)}
+                  className="w-full rounded-md py-[10px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
+                >
+                  Torna alla scansione QR
+                </button>
+              </div>
             </form>
           </div>
         )}

--- a/apps/mobile/src/components/screens/TicketQrActivationPrototype.tsx
+++ b/apps/mobile/src/components/screens/TicketQrActivationPrototype.tsx
@@ -17,9 +17,11 @@ interface TicketQrActivationPrototypeProps {
 }
 
 export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivationPrototypeProps) {
-  const [ticketCode, setTicketCode] = useState('ATCL-2026-001');
-  const [theatreId, setTheatreId] = useState('teatro-rendano');
-  const [performanceIso, setPerformanceIso] = useState('2026-03-15T20:45:00+01:00');
+  const [circuit, setCircuit] = useState('TicketOne');
+  const [eventName, setEventName] = useState('Esempio');
+  const [eventID, setEventID] = useState('1234567890');
+  const [ticketNumber, setTicketNumber] = useState('1234567890');
+  const [date, setDate] = useState('2026-02-11T11:54:00+01:00');
   const [generated, setGenerated] = useState<GeneratedTicket | null>(null);
   const [generateMessage, setGenerateMessage] = useState<string | null>(null);
   const [scanInput, setScanInput] = useState('');
@@ -33,7 +35,13 @@ export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivati
     setGenerateMessage(null);
 
     try {
-      const result = await generateTicketQr({ ticketCode, theatreId, performanceIso });
+      const result = await generateTicketQr({
+        circuit,
+        eventName,
+        eventID,
+        ticketNumber,
+        date,
+      });
       setGenerated(result);
       setScanInput(result.qrValue);
       setGenerateMessage(
@@ -86,10 +94,15 @@ export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivati
           <QrCode size={18} className="text-[#f4bf4f]" />
           <h3 className="text-base !m-0">1) Generazione payload e hash QR</h3>
         </div>
+        <p className="text-sm text-[#b8b2b3]">
+          Struttura JSON richiesta: circuit, eventName, eventID, ticketNumber, date.
+        </p>
         <div className="grid grid-cols-1 gap-3">
-          <Input value={ticketCode} onChange={(event) => setTicketCode(event.target.value)} placeholder="Codice ticket" />
-          <Input value={theatreId} onChange={(event) => setTheatreId(event.target.value)} placeholder="ID teatro" />
-          <Input value={performanceIso} onChange={(event) => setPerformanceIso(event.target.value)} placeholder="Data ISO performance" />
+          <Input value={circuit} onChange={(event) => setCircuit(event.target.value)} placeholder="Circuito (es. TicketOne)" />
+          <Input value={eventName} onChange={(event) => setEventName(event.target.value)} placeholder="Nome evento" />
+          <Input value={eventID} onChange={(event) => setEventID(event.target.value)} placeholder="ID evento" />
+          <Input value={ticketNumber} onChange={(event) => setTicketNumber(event.target.value)} placeholder="Numero biglietto" />
+          <Input value={date} onChange={(event) => setDate(event.target.value)} placeholder="Data ISO (es. 2026-02-11T11:54:00+01:00)" />
         </div>
 
         <Button variant="primary" onClick={handleGenerate} disabled={busy}>
@@ -144,7 +157,7 @@ export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivati
                 records.map((record) => (
                   <tr key={record.hash} className="border-t border-[#2d2728]">
                     <td className="py-2 pr-2">{record.hash.slice(0, 12)}…</td>
-                    <td className="py-2 pr-2">{record.ticketCode}</td>
+                    <td className="py-2 pr-2">{record.ticketNumber}</td>
                     <td className="py-2 pr-2">{record.status}</td>
                     <td className="py-2">{record.activatedBy ?? '-'}</td>
                   </tr>

--- a/apps/mobile/src/components/screens/TicketQrActivationPrototype.tsx
+++ b/apps/mobile/src/components/screens/TicketQrActivationPrototype.tsx
@@ -1,0 +1,159 @@
+import React, { useMemo, useState } from 'react';
+import { ArrowLeft, Database, QrCode } from 'lucide-react';
+import { Screen } from '../ui/Screen';
+import { Button } from '../ui/Button';
+import { Input } from '../ui/Input';
+import {
+  activateTicketHash,
+  generateTicketQr,
+  listLocalTicketRecords,
+  parseTicketQrValue,
+  type GeneratedTicket,
+} from '../../services/ticket-activation';
+
+interface TicketQrActivationPrototypeProps {
+  userId: string;
+  onBack: () => void;
+}
+
+export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivationPrototypeProps) {
+  const [ticketCode, setTicketCode] = useState('ATCL-2026-001');
+  const [theatreId, setTheatreId] = useState('teatro-rendano');
+  const [performanceIso, setPerformanceIso] = useState('2026-03-15T20:45:00+01:00');
+  const [generated, setGenerated] = useState<GeneratedTicket | null>(null);
+  const [generateMessage, setGenerateMessage] = useState<string | null>(null);
+  const [scanInput, setScanInput] = useState('');
+  const [scanMessage, setScanMessage] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const records = useMemo(() => listLocalTicketRecords(), [generated, scanMessage]);
+
+  const handleGenerate = async () => {
+    setBusy(true);
+    setGenerateMessage(null);
+
+    try {
+      const result = await generateTicketQr({ ticketCode, theatreId, performanceIso });
+      setGenerated(result);
+      setScanInput(result.qrValue);
+      setGenerateMessage(
+        result.persistedRemotely
+          ? 'QR registrato su Supabase e cache locale.'
+          : 'QR generato in locale (fallback prototipo).'
+      );
+    } catch (error) {
+      setGenerateMessage(error instanceof Error ? error.message : 'Errore durante la generazione.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleActivate = async () => {
+    const hash = parseTicketQrValue(scanInput);
+    if (!hash) {
+      setScanMessage('Payload QR non valido. Formato atteso: turni://ticket/<hash>.');
+      return;
+    }
+
+    const shouldProceed = window.confirm('Confermi l\'attivazione del ticket per questo account?');
+    if (!shouldProceed) return;
+
+    setBusy(true);
+    const result = await activateTicketHash(hash, userId);
+    setScanMessage(result.ok ? 'Ticket attivato correttamente.' : result.error);
+    setBusy(false);
+  };
+
+  return (
+    <Screen
+      withBottomNavPadding={false}
+      className="app-gradient justify-start"
+      contentClassName="max-w-3xl space-y-6"
+    >
+      <div className="flex items-center justify-between rounded-2xl border border-[#2d2728] bg-[#1a1617] px-4 py-3">
+        <button
+          onClick={onBack}
+          className="inline-flex items-center gap-2 rounded-md px-2 py-1 text-[#f4bf4f] hover:text-[#e6a23c]"
+        >
+          <ArrowLeft size={18} />
+          Indietro
+        </button>
+        <p className="text-xs text-[#b8b2b3]">Prototipo mobile ticket office + attivazione</p>
+      </div>
+
+      <section className="rounded-2xl border border-[#2d2728] bg-[#1a1617] p-4 space-y-4">
+        <div className="flex items-center gap-2 text-white">
+          <QrCode size={18} className="text-[#f4bf4f]" />
+          <h3 className="text-base !m-0">1) Generazione payload e hash QR</h3>
+        </div>
+        <div className="grid grid-cols-1 gap-3">
+          <Input value={ticketCode} onChange={(event) => setTicketCode(event.target.value)} placeholder="Codice ticket" />
+          <Input value={theatreId} onChange={(event) => setTheatreId(event.target.value)} placeholder="ID teatro" />
+          <Input value={performanceIso} onChange={(event) => setPerformanceIso(event.target.value)} placeholder="Data ISO performance" />
+        </div>
+
+        <Button variant="primary" onClick={handleGenerate} disabled={busy}>
+          Genera QR ticket
+        </Button>
+
+        {generateMessage ? <p className="text-sm text-[#b8b2b3]">{generateMessage}</p> : null}
+
+        {generated ? (
+          <div className="rounded-xl border border-[#2d2728] bg-[#0f0d0e] p-3 text-xs text-[#d9d4d5] space-y-2">
+            <p className="!m-0"><strong>QR value:</strong> {generated.qrValue}</p>
+            <p className="!m-0 break-all"><strong>Hash SHA-256:</strong> {generated.hash}</p>
+            <p className="!m-0 break-all"><strong>JSON:</strong> {generated.json}</p>
+          </div>
+        ) : null}
+      </section>
+
+      <section className="rounded-2xl border border-[#2d2728] bg-[#1a1617] p-4 space-y-4">
+        <h3 className="text-base text-white !m-0">2) Scansione e attivazione one-shot</h3>
+        <Input
+          value={scanInput}
+          onChange={(event) => setScanInput(event.target.value)}
+          placeholder="Incolla il valore del QR"
+        />
+        <Button variant="secondary" onClick={handleActivate} disabled={busy}>
+          Verifica e attiva
+        </Button>
+        {scanMessage ? <p className="text-sm text-[#b8b2b3]">{scanMessage}</p> : null}
+      </section>
+
+      <section className="rounded-2xl border border-[#2d2728] bg-[#1a1617] p-4 space-y-3">
+        <div className="flex items-center gap-2 text-white">
+          <Database size={18} className="text-[#f4bf4f]" />
+          <h3 className="text-base !m-0">Stato archivio locale prototipo</h3>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs text-left text-[#d9d4d5]">
+            <thead>
+              <tr className="text-[#b8b2b3]">
+                <th className="pb-2">Hash</th>
+                <th className="pb-2">Ticket</th>
+                <th className="pb-2">Stato</th>
+                <th className="pb-2">Utente</th>
+              </tr>
+            </thead>
+            <tbody>
+              {records.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="py-2 text-[#7f797a]">Nessun ticket generato.</td>
+                </tr>
+              ) : (
+                records.map((record) => (
+                  <tr key={record.hash} className="border-t border-[#2d2728]">
+                    <td className="py-2 pr-2">{record.hash.slice(0, 12)}…</td>
+                    <td className="py-2 pr-2">{record.ticketCode}</td>
+                    <td className="py-2 pr-2">{record.status}</td>
+                    <td className="py-2">{record.activatedBy ?? '-'}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/components/screens/TicketQrActivationPrototype.tsx
+++ b/apps/mobile/src/components/screens/TicketQrActivationPrototype.tsx
@@ -59,7 +59,7 @@ export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivati
   const handleActivate = async () => {
     const hash = parseTicketQrValue(scanInput);
     if (!hash) {
-      setScanMessage('Payload QR non valido. Formato atteso: turni://ticket/<hash>.');
+      setScanMessage('Payload QR non valido. Formato atteso: hash SHA-256 (64 caratteri).');
       return;
     }
 
@@ -113,7 +113,7 @@ export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivati
 
         {generated ? (
           <div className="rounded-xl border border-[#2d2728] bg-[#0f0d0e] p-3 text-xs text-[#d9d4d5] space-y-2">
-            <p className="!m-0"><strong>QR value:</strong> {generated.qrValue}</p>
+            <p className="!m-0"><strong>QR value (hash):</strong> {generated.qrValue}</p>
             <p className="!m-0 break-all"><strong>Hash SHA-256:</strong> {generated.hash}</p>
             <p className="!m-0 break-all"><strong>JSON:</strong> {generated.json}</p>
           </div>
@@ -122,11 +122,11 @@ export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivati
 
       <section className="rounded-2xl border border-[#2d2728] bg-[#1a1617] p-4 space-y-4">
         <h3 className="text-base text-white !m-0">2) Scansione e attivazione one-shot</h3>
-        <Input
-          value={scanInput}
-          onChange={(event) => setScanInput(event.target.value)}
-          placeholder="Incolla il valore del QR"
-        />
+          <Input
+            value={scanInput}
+            onChange={(event) => setScanInput(event.target.value)}
+            placeholder="Incolla hash o valore QR"
+          />
         <Button variant="secondary" onClick={handleActivate} disabled={busy}>
           Verifica e attiva
         </Button>

--- a/apps/mobile/src/hooks/useNavigation.ts
+++ b/apps/mobile/src/hooks/useNavigation.ts
@@ -11,6 +11,7 @@ const VALID_SCREENS = new Set<Screen>([
     'event-details', 'activities', 'activity-detail', 'activity-minigame', 'activity-result', 'profile',
     'account-settings', 'support', 'change-password', 'career',
     'terms', 'privacy', 'earned-titles',
+    'ticket-qr-prototype',
 ]);
 
 const VALID_TABS = new Set<Tab>(['home', 'turns', 'leaderboard', 'activities', 'profile']);
@@ -19,7 +20,7 @@ const VALID_LEGAL_RETURN_SCREENS = new Set<LegalReturnScreen>([
     'welcome', 'login', 'signup', 'role-selection', 'home', 'turns',
     'qr-scanner', 'event-confirmation', 'activities', 'activity-detail', 'activity-minigame', 'activity-result',
     'profile', 'account-settings', 'support', 'change-password',
-    'career', 'earned-titles',
+    'career', 'earned-titles', 'ticket-qr-prototype',
 ]);
 
 function readNavState(): PersistedNavState | null {

--- a/apps/mobile/src/lib/auth-storage.ts
+++ b/apps/mobile/src/lib/auth-storage.ts
@@ -1,8 +1,27 @@
 import { isSupabaseConfigured } from './supabase';
 import type { Screen } from '../types/navigation';
 
-export const SUPABASE_SESSION_KEY = 'tdp-supabase-session';
-export const SUPABASE_SESSION_ID_KEY = 'tdp-supabase-session-id';
+const LEGACY_SESSION_KEY = 'tdp-supabase-session';
+const LEGACY_SESSION_ID_KEY = 'tdp-supabase-session-id';
+
+function resolveSupabaseProjectRef() {
+  const url = import.meta.env.VITE_SUPABASE_URL;
+  if (typeof url !== 'string' || !url.trim()) return 'default';
+
+  try {
+    const host = new URL(url).host;
+    const ref = host.split('.')[0]?.trim();
+    return ref || 'default';
+  } catch {
+    return 'default';
+  }
+}
+
+const STORAGE_NAMESPACE = resolveSupabaseProjectRef();
+export const SUPABASE_SESSION_KEY = `${LEGACY_SESSION_KEY}:${STORAGE_NAMESPACE}`;
+export const SUPABASE_SESSION_ID_KEY = `${LEGACY_SESSION_ID_KEY}:${STORAGE_NAMESPACE}`;
+export const LEGACY_SUPABASE_SESSION_KEY = LEGACY_SESSION_KEY;
+export const LEGACY_SUPABASE_SESSION_ID_KEY = LEGACY_SESSION_ID_KEY;
 export const USER_STATE_KEY = 'tdp-mobile-ui-state';
 
 export const PUBLIC_SCREENS = new Set<Screen>(['welcome', 'login', 'signup', 'install', 'terms', 'privacy']);
@@ -13,10 +32,16 @@ type StoredUserState = { profile?: { email?: unknown } };
 function hasStoredSupabaseSession() {
   if (typeof window === 'undefined') return false;
   try {
-    if (window.localStorage.getItem(SUPABASE_SESSION_ID_KEY)) return true;
+    if (
+      window.localStorage.getItem(SUPABASE_SESSION_ID_KEY) ||
+      window.localStorage.getItem(LEGACY_SUPABASE_SESSION_ID_KEY)
+    ) {
+      return true;
+    }
 
-    const storedSessionRaw = window.localStorage.getItem(SUPABASE_SESSION_KEY);
-    if (storedSessionRaw) {
+    for (const key of [SUPABASE_SESSION_KEY, LEGACY_SUPABASE_SESSION_KEY]) {
+      const storedSessionRaw = window.localStorage.getItem(key);
+      if (!storedSessionRaw) continue;
       const parsed = JSON.parse(storedSessionRaw) as StoredSession;
       if (typeof parsed.access_token === 'string' && typeof parsed.refresh_token === 'string') {
         return true;

--- a/apps/mobile/src/services/event-links.ts
+++ b/apps/mobile/src/services/event-links.ts
@@ -7,6 +7,73 @@ type ValidateQrResponse = {
   error?: string;
 };
 
+async function resolveFunctionErrorMessage(error: unknown, fallback: string): Promise<string> {
+  if (!error || typeof error !== 'object') {
+    return fallback;
+  }
+
+  const candidate = error as {
+    message?: unknown;
+    context?: {
+      status?: number;
+      json?: () => Promise<unknown>;
+      text?: () => Promise<string>;
+      clone?: () => unknown;
+    };
+  };
+
+  let message = typeof candidate.message === 'string' ? candidate.message.trim() : '';
+  const context = candidate.context;
+
+  if (context && typeof context === 'object') {
+    const cloneFn = typeof context.clone === 'function' ? context.clone.bind(context) : null;
+    const source = cloneFn ? (cloneFn() as typeof context) : context;
+
+    if (source && typeof source.json === 'function') {
+      try {
+        const body = await source.json();
+        if (body && typeof body === 'object') {
+          const payload = body as { error?: unknown; message?: unknown };
+          const bodyMessage =
+            (typeof payload.error === 'string' && payload.error.trim()) ||
+            (typeof payload.message === 'string' && payload.message.trim()) ||
+            '';
+          if (bodyMessage) {
+            return bodyMessage;
+          }
+        }
+      } catch {
+        // fall back to text/message below
+      }
+    }
+
+    const sourceForText = cloneFn ? (cloneFn() as typeof context) : context;
+    if (sourceForText && typeof sourceForText.text === 'function') {
+      try {
+        const text = (await sourceForText.text()).trim();
+        if (text) {
+          return text;
+        }
+      } catch {
+        // ignore and continue fallback
+      }
+    }
+
+    if (typeof context.status === 'number' && context.status > 0) {
+      if (message) {
+        return `HTTP ${context.status}: ${message}`;
+      }
+      return `HTTP ${context.status}: ${fallback}`;
+    }
+  }
+
+  if (!message || /non-2xx/i.test(message)) {
+    return fallback;
+  }
+
+  return message;
+}
+
 async function invokeEventLinks(payload: Record<string, unknown>) {
   if (!supabase || !isSupabaseConfigured) {
     return null;
@@ -17,7 +84,11 @@ async function invokeEventLinks(payload: Record<string, unknown>) {
   });
 
   if (error) {
-    throw new Error(error.message || 'Errore durante la chiamata backend.');
+    const errorMessage = await resolveFunctionErrorMessage(
+      error,
+      'Errore durante la chiamata backend.'
+    );
+    throw new Error(errorMessage);
   }
 
   return data as Record<string, unknown>;

--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -1,0 +1,201 @@
+import { isSupabaseConfigured, supabase } from '../lib/supabase';
+
+export type TicketPayload = {
+  source: string;
+  ticketCode: string;
+  theatreId: string;
+  performanceIso: string;
+  issuedAtIso: string;
+  salt: number;
+};
+
+export type GeneratedTicket = {
+  payload: TicketPayload;
+  json: string;
+  hash: string;
+  qrValue: string;
+  persistedRemotely: boolean;
+};
+
+export type TicketActivationRecord = {
+  hash: string;
+  ticketCode: string;
+  status: 'generated' | 'activated';
+  activatedBy: string | null;
+  activatedAtIso: string | null;
+};
+
+const PROTOCOL_PREFIX = 'turni://ticket/';
+const localActivationStore = new Map<string, TicketActivationRecord>();
+
+function stableStringify(value: TicketPayload): string {
+  return JSON.stringify({
+    source: value.source,
+    ticketCode: value.ticketCode,
+    theatreId: value.theatreId,
+    performanceIso: value.performanceIso,
+    issuedAtIso: value.issuedAtIso,
+    salt: value.salt,
+  });
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const encoded = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-256', encoded);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function reserveHashRemotely(payload: TicketPayload, hash: string) {
+  if (!supabase || !isSupabaseConfigured) return false;
+
+  const { data, error } = await supabase.functions.invoke('ticket-activation', {
+    body: {
+      action: 'reserve_hash',
+      hash,
+      payload,
+    },
+  });
+
+  if (error) {
+    throw new Error(error.message || 'Errore Supabase durante la prenotazione hash.');
+  }
+
+  return Boolean((data as { reserved?: boolean } | null)?.reserved);
+}
+
+export async function generateTicketQr(params: {
+  ticketCode: string;
+  theatreId: string;
+  performanceIso: string;
+  source?: string;
+  maxAttempts?: number;
+}): Promise<GeneratedTicket> {
+  const ticketCode = params.ticketCode.trim().toUpperCase();
+  const theatreId = params.theatreId.trim();
+  const performanceIso = params.performanceIso.trim();
+  const source = (params.source ?? 'ticket-office').trim();
+  const maxAttempts = params.maxAttempts ?? 8;
+
+  if (!ticketCode || !theatreId || !performanceIso) {
+    throw new Error('Compila ticket, teatro e data performance.');
+  }
+
+  for (let salt = 0; salt < maxAttempts; salt += 1) {
+    const payload: TicketPayload = {
+      source,
+      ticketCode,
+      theatreId,
+      performanceIso,
+      issuedAtIso: new Date().toISOString(),
+      salt,
+    };
+
+    const json = stableStringify(payload);
+    const hash = await sha256Hex(json);
+    const localCollision = localActivationStore.has(hash);
+    if (localCollision) continue;
+
+    let persistedRemotely = false;
+    try {
+      const reserved = await reserveHashRemotely(payload, hash);
+      persistedRemotely = reserved;
+      if (supabase && isSupabaseConfigured && !reserved) {
+        continue;
+      }
+    } catch {
+      persistedRemotely = false;
+    }
+
+    localActivationStore.set(hash, {
+      hash,
+      ticketCode,
+      status: 'generated',
+      activatedBy: null,
+      activatedAtIso: null,
+    });
+
+    return {
+      payload,
+      json,
+      hash,
+      qrValue: `${PROTOCOL_PREFIX}${hash}`,
+      persistedRemotely,
+    };
+  }
+
+  throw new Error('Collisione hash ripetuta: aumenta la complessità del payload.');
+}
+
+export function parseTicketQrValue(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith(PROTOCOL_PREFIX)) return null;
+
+  const hash = trimmed.slice(PROTOCOL_PREFIX.length).split('?')[0]?.toLowerCase();
+  if (!hash || !/^[0-9a-f]{64}$/.test(hash)) return null;
+  return hash;
+}
+
+async function activateRemotely(hash: string, userId: string) {
+  if (!supabase || !isSupabaseConfigured) return null;
+
+  const { data, error } = await supabase.functions.invoke('ticket-activation', {
+    body: {
+      action: 'activate_hash',
+      hash,
+      userId,
+    },
+  });
+
+  if (error) {
+    throw new Error(error.message || 'Errore Supabase durante l\'attivazione.');
+  }
+
+  return data as { ok?: boolean; alreadyActivated?: boolean; activatedBy?: string } | null;
+}
+
+export async function activateTicketHash(hash: string, userId: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  const normalizedHash = hash.trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(normalizedHash)) {
+    return { ok: false, error: 'Hash non valido.' };
+  }
+
+  if (!userId.trim()) {
+    return { ok: false, error: 'Utente non disponibile per l\'attivazione.' };
+  }
+
+  try {
+    const remote = await activateRemotely(normalizedHash, userId.trim());
+    if (remote?.alreadyActivated) {
+      return { ok: false, error: 'Ticket già attivato da un altro utente.' };
+    }
+    if (remote?.ok) {
+      return { ok: true };
+    }
+  } catch {
+    // fallback locale
+  }
+
+  const record = localActivationStore.get(normalizedHash);
+  if (!record) {
+    return { ok: false, error: 'Ticket non trovato.' };
+  }
+
+  if (record.status === 'activated') {
+    return { ok: false, error: 'Ticket già attivato.' };
+  }
+
+  localActivationStore.set(normalizedHash, {
+    ...record,
+    status: 'activated',
+    activatedBy: userId,
+    activatedAtIso: new Date().toISOString(),
+  });
+
+  return { ok: true };
+}
+
+export function listLocalTicketRecords(): TicketActivationRecord[] {
+  return Array.from(localActivationStore.values()).sort((a, b) => a.hash.localeCompare(b.hash));
+}

--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -144,12 +144,16 @@ async function activateRemotely(hash: string, userId: string) {
     throw new Error(error.message || 'Errore Supabase durante l\'attivazione.');
   }
 
-  return data as { ok?: boolean; alreadyActivated?: boolean; activatedBy?: string } | null;
+  return data as { ok?: boolean; alreadyActivated?: boolean; activatedBy?: string; error?: string } | null;
 }
 
-export async function activateTicketHash(hash: string, userId: string): Promise<{ ok: true } | { ok: false; error: string }> {
+export async function activateTicketHash(
+  hash: string,
+  userId: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
   const normalizedHash = hash.trim().toLowerCase();
   const normalizedUserId = userId.trim();
+
   if (!/^[0-9a-f]{64}$/.test(normalizedHash)) {
     return { ok: false, error: 'Hash non valido.' };
   }
@@ -160,22 +164,34 @@ export async function activateTicketHash(hash: string, userId: string): Promise<
 
   try {
     const remote = await activateRemotely(normalizedHash, normalizedUserId);
-    if (remote?.alreadyActivated) {
-      return { ok: false, error: 'Ticket già attivato da un altro utente.' };
-    }
+    
     if (remote?.ok) {
       const currentRecord = localActivationStore.get(normalizedHash);
       localActivationStore.set(normalizedHash, {
         hash: normalizedHash,
-        ticketNumber: currentRecord?.ticketNumber ?? '',
+        ticketNumber: currentRecord?.ticketNumber ?? 'N/A',
         status: 'activated',
         activatedBy: normalizedUserId,
         activatedAtIso: new Date().toISOString(),
       });
       return { ok: true };
     }
-  } catch {
-    // fallback locale
+
+    if (remote?.alreadyActivated) {
+      return { ok: false, error: 'Ticket già attivato da un altro utente.' };
+    }
+
+    if (remote?.error) {
+      return { ok: false, error: remote.error };
+    }
+  } catch (error) {
+    console.error('Remote activation failed:', error);
+    if (supabase && isSupabaseConfigured) {
+      return { 
+        ok: false, 
+        error: error instanceof Error ? error.message : 'Errore durante la comunicazione con il server.' 
+      };
+    }
   }
 
   const record = localActivationStore.get(normalizedHash);

--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -24,7 +24,7 @@ export type TicketActivationRecord = {
   activatedAtIso: string | null;
 };
 
-const PROTOCOL_PREFIX = 'turni://ticket/';
+const LEGACY_PROTOCOL_PREFIX = 'turni://ticket/';
 const localActivationStore = new Map<string, TicketActivationRecord>();
 
 function stableStringify(value: TicketPayload): string {
@@ -115,23 +115,23 @@ export async function generateTicketQr(params: {
     payload,
     json,
     hash,
-    qrValue: `${PROTOCOL_PREFIX}${hash}`,
+    qrValue: hash,
     persistedRemotely,
   };
 }
 
 export function parseTicketQrValue(input: string): string | null {
   const trimmed = input.trim();
-  
-  // if starts with protocol, extract hash
-  if (trimmed.startsWith(PROTOCOL_PREFIX)) {
-    const hash = trimmed.slice(PROTOCOL_PREFIX.length).split('?')[0]?.toLowerCase();
-    if (hash && /^[0-9a-f]{64}$/.test(hash)) return hash;
-  }
 
-  // if is raw 64-char hex hash, return it directly
+  // Preferred format: raw 64-char SHA-256 hash.
   if (/^[0-9a-f]{64}$/i.test(trimmed)) {
     return trimmed.toLowerCase();
+  }
+
+  // Backward compatibility for legacy QR values.
+  if (trimmed.startsWith(LEGACY_PROTOCOL_PREFIX)) {
+    const hash = trimmed.slice(LEGACY_PROTOCOL_PREFIX.length).split('?')[0]?.toLowerCase();
+    if (hash && /^[0-9a-f]{64}$/.test(hash)) return hash;
   }
 
   return null;

--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -122,11 +122,19 @@ export async function generateTicketQr(params: {
 
 export function parseTicketQrValue(input: string): string | null {
   const trimmed = input.trim();
-  if (!trimmed.startsWith(PROTOCOL_PREFIX)) return null;
+  
+  // if starts with protocol, extract hash
+  if (trimmed.startsWith(PROTOCOL_PREFIX)) {
+    const hash = trimmed.slice(PROTOCOL_PREFIX.length).split('?')[0]?.toLowerCase();
+    if (hash && /^[0-9a-f]{64}$/.test(hash)) return hash;
+  }
 
-  const hash = trimmed.slice(PROTOCOL_PREFIX.length).split('?')[0]?.toLowerCase();
-  if (!hash || !/^[0-9a-f]{64}$/.test(hash)) return null;
-  return hash;
+  // if is raw 64-char hex hash, return it directly
+  if (/^[0-9a-f]{64}$/i.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+
+  return null;
 }
 
 async function activateRemotely(hash: string, userId: string) {
@@ -211,6 +219,42 @@ export async function activateTicketHash(
   });
 
   return { ok: true };
+}
+
+export async function activateTicketByDetails(
+  eventID: string,
+  ticketNumber: string,
+  userId: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const normalizedEventId = eventID.trim();
+  const normalizedTicket = ticketNumber.trim();
+  const normalizedUserId = userId.trim();
+
+  if (!normalizedEventId || !normalizedTicket || !normalizedUserId) {
+    return { ok: false, error: 'Dati mancanti per l\'attivazione manuale.' };
+  }
+
+  try {
+    if (!supabase || !isSupabaseConfigured) return { ok: false, error: 'Supabase non configurata.' };
+
+    const { data, error } = await supabase.functions.invoke('ticket-activation', {
+      body: {
+        action: 'activate_by_details',
+        payload: { eventID: normalizedEventId, ticketNumber: normalizedTicket },
+        userId: normalizedUserId,
+      },
+    });
+
+    if (error) throw new Error(error.message);
+    const remote = data as { ok?: boolean; alreadyActivated?: boolean; error?: string } | null;
+
+    if (remote?.ok) return { ok: true };
+    if (remote?.alreadyActivated) return { ok: false, error: 'Ticket già attivato.' };
+    return { ok: false, error: remote?.error || 'Errore durante l\'attivazione manuale.' };
+  } catch (error) {
+    console.error('Manual activation failed:', error);
+    return { ok: false, error: error instanceof Error ? error.message : 'Errore tecnico.' };
+  }
 }
 
 export function listLocalTicketRecords(): TicketActivationRecord[] {

--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -26,6 +26,133 @@ export type TicketActivationRecord = {
 
 const LEGACY_PROTOCOL_PREFIX = 'turni://ticket/';
 const localActivationStore = new Map<string, TicketActivationRecord>();
+const SESSION_REQUIRED_MESSAGE = 'Sessione scaduta o non disponibile. Effettua di nuovo il login.';
+
+async function resolveFunctionErrorMessage(error: unknown, fallback: string): Promise<string> {
+  if (!error || typeof error !== 'object') {
+    return fallback;
+  }
+
+  const candidate = error as {
+    message?: unknown;
+    context?: {
+      status?: number;
+      json?: () => Promise<unknown>;
+      text?: () => Promise<string>;
+      clone?: () => unknown;
+    };
+  };
+
+  let message = typeof candidate.message === 'string' ? candidate.message.trim() : '';
+  const context = candidate.context;
+
+  if (context && typeof context === 'object') {
+    const cloneFn = typeof context.clone === 'function' ? context.clone.bind(context) : null;
+    const source = cloneFn ? (cloneFn() as typeof context) : context;
+
+    if (source && typeof source.json === 'function') {
+      try {
+        const body = await source.json();
+        if (body && typeof body === 'object') {
+          const payload = body as { error?: unknown; message?: unknown };
+          const bodyMessage =
+            (typeof payload.error === 'string' && payload.error.trim()) ||
+            (typeof payload.message === 'string' && payload.message.trim()) ||
+            '';
+          if (bodyMessage) {
+            return bodyMessage;
+          }
+        }
+      } catch {
+        // fall back to text/message below
+      }
+    }
+
+    const sourceForText = cloneFn ? (cloneFn() as typeof context) : context;
+    if (sourceForText && typeof sourceForText.text === 'function') {
+      try {
+        const text = (await sourceForText.text()).trim();
+        if (text) {
+          return text;
+        }
+      } catch {
+        // ignore and continue fallback
+      }
+    }
+
+    if (typeof context.status === 'number' && context.status > 0) {
+      if (message) {
+        return `HTTP ${context.status}: ${message}`;
+      }
+      return `HTTP ${context.status}: ${fallback}`;
+    }
+  }
+
+  if (!message || /non-2xx/i.test(message)) {
+    return fallback;
+  }
+
+  return message;
+}
+
+function getFunctionErrorStatus(error: unknown): number | null {
+  if (!error || typeof error !== 'object') return null;
+  const context = (error as { context?: { status?: unknown } }).context;
+  if (!context || typeof context !== 'object') return null;
+  return typeof context.status === 'number' ? context.status : null;
+}
+
+async function getAccessTokenForFunctions(): Promise<string> {
+  if (!supabase || !isSupabaseConfigured) {
+    throw new Error(SESSION_REQUIRED_MESSAGE);
+  }
+
+  const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+  if (sessionError) {
+    throw new Error(SESSION_REQUIRED_MESSAGE);
+  }
+
+  const sessionToken = sessionData.session?.access_token?.trim();
+  if (sessionToken) return sessionToken;
+
+  const { data: refreshed, error: refreshError } = await supabase.auth.refreshSession();
+  if (refreshError) {
+    throw new Error(SESSION_REQUIRED_MESSAGE);
+  }
+
+  const refreshedToken = refreshed.session?.access_token?.trim();
+  if (!refreshedToken) {
+    throw new Error(SESSION_REQUIRED_MESSAGE);
+  }
+
+  return refreshedToken;
+}
+
+async function invokeTicketActivation(body: Record<string, unknown>) {
+  if (!supabase || !isSupabaseConfigured) {
+    return { data: null, error: null };
+  }
+
+  const token = await getAccessTokenForFunctions();
+  let response = await supabase.functions.invoke('ticket-activation', {
+    headers: { Authorization: `Bearer ${token}` },
+    body,
+  });
+
+  // Retry once with a refreshed token if gateway rejects the request.
+  if (response.error && getFunctionErrorStatus(response.error) === 401) {
+    const { data: refreshed, error: refreshError } = await supabase.auth.refreshSession();
+    const refreshedToken = refreshed.session?.access_token?.trim();
+    if (!refreshError && refreshedToken) {
+      response = await supabase.functions.invoke('ticket-activation', {
+        headers: { Authorization: `Bearer ${refreshedToken}` },
+        body,
+      });
+    }
+  }
+
+  return response;
+}
 
 function stableStringify(value: TicketPayload): string {
   return JSON.stringify({
@@ -48,16 +175,18 @@ async function sha256Hex(input: string): Promise<string> {
 async function reserveHashRemotely(payload: TicketPayload, hash: string) {
   if (!supabase || !isSupabaseConfigured) return false;
 
-  const { data, error } = await supabase.functions.invoke('ticket-activation', {
-    body: {
-      action: 'reserve_hash',
-      hash,
-      payload,
-    },
+  const { data, error } = await invokeTicketActivation({
+    action: 'reserve_hash',
+    hash,
+    payload,
   });
 
   if (error) {
-    throw new Error(error.message || 'Errore Supabase durante la prenotazione hash.');
+    const errorMessage = await resolveFunctionErrorMessage(
+      error,
+      'Errore Supabase durante la prenotazione hash.'
+    );
+    throw new Error(errorMessage);
   }
 
   return Boolean((data as { reserved?: boolean } | null)?.reserved);
@@ -140,16 +269,18 @@ export function parseTicketQrValue(input: string): string | null {
 async function activateRemotely(hash: string, userId: string) {
   if (!supabase || !isSupabaseConfigured) return null;
 
-  const { data, error } = await supabase.functions.invoke('ticket-activation', {
-    body: {
-      action: 'activate_hash',
-      hash,
-      userId,
-    },
+  const { data, error } = await invokeTicketActivation({
+    action: 'activate_hash',
+    hash,
+    userId,
   });
 
   if (error) {
-    throw new Error(error.message || 'Errore Supabase durante l\'attivazione.');
+    const errorMessage = await resolveFunctionErrorMessage(
+      error,
+      'Errore Supabase durante l\'attivazione ticket.'
+    );
+    throw new Error(errorMessage);
   }
 
   return data as { ok?: boolean; alreadyActivated?: boolean; activatedBy?: string; eventId?: string; eventName?: string; error?: string } | null;
@@ -237,15 +368,19 @@ export async function activateTicketByDetails(
   try {
     if (!supabase || !isSupabaseConfigured) return { ok: false, error: 'Supabase non configurata.' };
 
-    const { data, error } = await supabase.functions.invoke('ticket-activation', {
-      body: {
-        action: 'activate_by_details',
-        payload: { eventID: normalizedEventId, ticketNumber: normalizedTicket },
-        userId: normalizedUserId,
-      },
+    const { data, error } = await invokeTicketActivation({
+      action: 'activate_by_details',
+      payload: { eventID: normalizedEventId, ticketNumber: normalizedTicket },
+      userId: normalizedUserId,
     });
 
-    if (error) throw new Error(error.message);
+    if (error) {
+      const errorMessage = await resolveFunctionErrorMessage(
+        error,
+        'Errore Supabase durante l\'attivazione manuale.'
+      );
+      throw new Error(errorMessage);
+    }
     const remote = data as { ok?: boolean; alreadyActivated?: boolean; error?: string; eventId?: string } | null;
 
     if (remote?.ok) return { ok: true, eventId: remote.eventId };

--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -152,13 +152,13 @@ async function activateRemotely(hash: string, userId: string) {
     throw new Error(error.message || 'Errore Supabase durante l\'attivazione.');
   }
 
-  return data as { ok?: boolean; alreadyActivated?: boolean; activatedBy?: string; error?: string } | null;
+  return data as { ok?: boolean; alreadyActivated?: boolean; activatedBy?: string; eventId?: string; eventName?: string; error?: string } | null;
 }
 
 export async function activateTicketHash(
   hash: string,
   userId: string
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<{ ok: true; eventId?: string } | { ok: false; error: string }> {
   const normalizedHash = hash.trim().toLowerCase();
   const normalizedUserId = userId.trim();
 
@@ -182,7 +182,7 @@ export async function activateTicketHash(
         activatedBy: normalizedUserId,
         activatedAtIso: new Date().toISOString(),
       });
-      return { ok: true };
+      return { ok: true, eventId: remote.eventId };
     }
 
     if (remote?.alreadyActivated) {
@@ -225,7 +225,7 @@ export async function activateTicketByDetails(
   eventID: string,
   ticketNumber: string,
   userId: string
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<{ ok: true; eventId?: string } | { ok: false; error: string }> {
   const normalizedEventId = eventID.trim();
   const normalizedTicket = ticketNumber.trim();
   const normalizedUserId = userId.trim();
@@ -246,9 +246,9 @@ export async function activateTicketByDetails(
     });
 
     if (error) throw new Error(error.message);
-    const remote = data as { ok?: boolean; alreadyActivated?: boolean; error?: string } | null;
+    const remote = data as { ok?: boolean; alreadyActivated?: boolean; error?: string; eventId?: string } | null;
 
-    if (remote?.ok) return { ok: true };
+    if (remote?.ok) return { ok: true, eventId: remote.eventId };
     if (remote?.alreadyActivated) return { ok: false, error: 'Ticket già attivato.' };
     return { ok: false, error: remote?.error || 'Errore durante l\'attivazione manuale.' };
   } catch (error) {

--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -24,6 +24,21 @@ export type TicketActivationRecord = {
   activatedAtIso: string | null;
 };
 
+export type ActivatedEventPayload = {
+  id?: string | null;
+  name?: string | null;
+  theatre?: string | null;
+  event_date?: string | null;
+  event_time?: string | null;
+  genre?: string | null;
+  base_rewards?: {
+    xp?: number | null;
+    reputation?: number | null;
+    cachet?: number | null;
+  } | null;
+  focus_role?: string | null;
+};
+
 const LEGACY_PROTOCOL_PREFIX = 'turni://ticket/';
 const localActivationStore = new Map<string, TicketActivationRecord>();
 const SESSION_REQUIRED_MESSAGE = 'Sessione scaduta o non disponibile. Effettua di nuovo il login.';
@@ -296,13 +311,21 @@ async function activateRemotely(hash: string, userId: string) {
     throw new Error(errorMessage);
   }
 
-  return data as { ok?: boolean; alreadyActivated?: boolean; activatedBy?: string; eventId?: string; eventName?: string; error?: string } | null;
+  return data as {
+    ok?: boolean;
+    alreadyActivated?: boolean;
+    activatedBy?: string;
+    eventId?: string;
+    eventName?: string;
+    event?: ActivatedEventPayload;
+    error?: string;
+  } | null;
 }
 
 export async function activateTicketHash(
   hash: string,
   userId: string
-): Promise<{ ok: true; eventId?: string } | { ok: false; error: string }> {
+): Promise<{ ok: true; eventId?: string; event?: ActivatedEventPayload } | { ok: false; error: string }> {
   const normalizedHash = hash.trim().toLowerCase();
   const normalizedUserId = userId.trim();
 
@@ -326,7 +349,7 @@ export async function activateTicketHash(
         activatedBy: normalizedUserId,
         activatedAtIso: new Date().toISOString(),
       });
-      return { ok: true, eventId: remote.eventId };
+      return { ok: true, eventId: remote.eventId, event: remote.event };
     }
 
     if (remote?.alreadyActivated) {
@@ -369,7 +392,7 @@ export async function activateTicketByDetails(
   eventID: string,
   ticketNumber: string,
   userId: string
-): Promise<{ ok: true; eventId?: string } | { ok: false; error: string }> {
+): Promise<{ ok: true; eventId?: string; event?: ActivatedEventPayload } | { ok: false; error: string }> {
   const normalizedEventId = eventID.trim();
   const normalizedTicket = ticketNumber.trim();
   const normalizedUserId = userId.trim();
@@ -394,9 +417,15 @@ export async function activateTicketByDetails(
       );
       throw new Error(errorMessage);
     }
-    const remote = data as { ok?: boolean; alreadyActivated?: boolean; error?: string; eventId?: string } | null;
+    const remote = data as {
+      ok?: boolean;
+      alreadyActivated?: boolean;
+      error?: string;
+      eventId?: string;
+      event?: ActivatedEventPayload;
+    } | null;
 
-    if (remote?.ok) return { ok: true, eventId: remote.eventId };
+    if (remote?.ok) return { ok: true, eventId: remote.eventId, event: remote.event };
     if (remote?.alreadyActivated) return { ok: false, error: 'Ticket già attivato.' };
     return { ok: false, error: remote?.error || 'Errore durante l\'attivazione manuale.' };
   } catch (error) {

--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -60,6 +60,9 @@ async function resolveFunctionErrorMessage(error: unknown, fallback: string): Pr
             (typeof payload.message === 'string' && payload.message.trim()) ||
             '';
           if (bodyMessage) {
+            if (/invalid jwt/i.test(bodyMessage)) {
+              return SESSION_REQUIRED_MESSAGE;
+            }
             return bodyMessage;
           }
         }
@@ -73,6 +76,9 @@ async function resolveFunctionErrorMessage(error: unknown, fallback: string): Pr
       try {
         const text = (await sourceForText.text()).trim();
         if (text) {
+          if (/invalid jwt/i.test(text)) {
+            return SESSION_REQUIRED_MESSAGE;
+          }
           return text;
         }
       } catch {
@@ -81,11 +87,18 @@ async function resolveFunctionErrorMessage(error: unknown, fallback: string): Pr
     }
 
     if (typeof context.status === 'number' && context.status > 0) {
+      if (context.status === 401) {
+        return SESSION_REQUIRED_MESSAGE;
+      }
       if (message) {
         return `HTTP ${context.status}: ${message}`;
       }
       return `HTTP ${context.status}: ${fallback}`;
     }
+  }
+
+  if (/invalid jwt/i.test(message)) {
+    return SESSION_REQUIRED_MESSAGE;
   }
 
   if (!message || /non-2xx/i.test(message)) {

--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -149,20 +149,29 @@ async function activateRemotely(hash: string, userId: string) {
 
 export async function activateTicketHash(hash: string, userId: string): Promise<{ ok: true } | { ok: false; error: string }> {
   const normalizedHash = hash.trim().toLowerCase();
+  const normalizedUserId = userId.trim();
   if (!/^[0-9a-f]{64}$/.test(normalizedHash)) {
     return { ok: false, error: 'Hash non valido.' };
   }
 
-  if (!userId.trim()) {
+  if (!normalizedUserId) {
     return { ok: false, error: 'Utente non disponibile per l\'attivazione.' };
   }
 
   try {
-    const remote = await activateRemotely(normalizedHash, userId.trim());
+    const remote = await activateRemotely(normalizedHash, normalizedUserId);
     if (remote?.alreadyActivated) {
       return { ok: false, error: 'Ticket già attivato da un altro utente.' };
     }
     if (remote?.ok) {
+      const currentRecord = localActivationStore.get(normalizedHash);
+      localActivationStore.set(normalizedHash, {
+        hash: normalizedHash,
+        ticketNumber: currentRecord?.ticketNumber ?? '',
+        status: 'activated',
+        activatedBy: normalizedUserId,
+        activatedAtIso: new Date().toISOString(),
+      });
       return { ok: true };
     }
   } catch {
@@ -181,7 +190,7 @@ export async function activateTicketHash(hash: string, userId: string): Promise<
   localActivationStore.set(normalizedHash, {
     ...record,
     status: 'activated',
-    activatedBy: userId,
+    activatedBy: normalizedUserId,
     activatedAtIso: new Date().toISOString(),
   });
 

--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -1,12 +1,11 @@
 import { isSupabaseConfigured, supabase } from '../lib/supabase';
 
 export type TicketPayload = {
-  source: string;
-  ticketCode: string;
-  theatreId: string;
-  performanceIso: string;
-  issuedAtIso: string;
-  salt: number;
+  circuit: string;
+  eventName: string;
+  eventID: string;
+  ticketNumber: string;
+  date: string;
 };
 
 export type GeneratedTicket = {
@@ -19,7 +18,7 @@ export type GeneratedTicket = {
 
 export type TicketActivationRecord = {
   hash: string;
-  ticketCode: string;
+  ticketNumber: string;
   status: 'generated' | 'activated';
   activatedBy: string | null;
   activatedAtIso: string | null;
@@ -30,12 +29,11 @@ const localActivationStore = new Map<string, TicketActivationRecord>();
 
 function stableStringify(value: TicketPayload): string {
   return JSON.stringify({
-    source: value.source,
-    ticketCode: value.ticketCode,
-    theatreId: value.theatreId,
-    performanceIso: value.performanceIso,
-    issuedAtIso: value.issuedAtIso,
-    salt: value.salt,
+    circuit: value.circuit,
+    eventName: value.eventName,
+    eventID: value.eventID,
+    ticketNumber: value.ticketNumber,
+    date: value.date,
   });
 }
 
@@ -66,66 +64,60 @@ async function reserveHashRemotely(payload: TicketPayload, hash: string) {
 }
 
 export async function generateTicketQr(params: {
-  ticketCode: string;
-  theatreId: string;
-  performanceIso: string;
-  source?: string;
-  maxAttempts?: number;
+  circuit: string;
+  eventName: string;
+  eventID: string;
+  ticketNumber: string;
+  date: string;
 }): Promise<GeneratedTicket> {
-  const ticketCode = params.ticketCode.trim().toUpperCase();
-  const theatreId = params.theatreId.trim();
-  const performanceIso = params.performanceIso.trim();
-  const source = (params.source ?? 'ticket-office').trim();
-  const maxAttempts = params.maxAttempts ?? 8;
+  const payload: TicketPayload = {
+    circuit: params.circuit.trim(),
+    eventName: params.eventName.trim(),
+    eventID: params.eventID.trim(),
+    ticketNumber: params.ticketNumber.trim(),
+    date: params.date.trim(),
+  };
 
-  if (!ticketCode || !theatreId || !performanceIso) {
-    throw new Error('Compila ticket, teatro e data performance.');
+  if (!payload.circuit || !payload.eventName || !payload.eventID || !payload.ticketNumber || !payload.date) {
+    throw new Error('Compila tutti i campi richiesti del JSON ticket.');
   }
 
-  for (let salt = 0; salt < maxAttempts; salt += 1) {
-    const payload: TicketPayload = {
-      source,
-      ticketCode,
-      theatreId,
-      performanceIso,
-      issuedAtIso: new Date().toISOString(),
-      salt,
-    };
+  const json = stableStringify(payload);
+  const hash = await sha256Hex(json);
 
-    const json = stableStringify(payload);
-    const hash = await sha256Hex(json);
-    const localCollision = localActivationStore.has(hash);
-    if (localCollision) continue;
+  if (localActivationStore.has(hash)) {
+    throw new Error('Hash già presente in archivio locale: controlla i dati ticket.');
+  }
 
-    let persistedRemotely = false;
-    try {
-      const reserved = await reserveHashRemotely(payload, hash);
-      persistedRemotely = reserved;
-      if (supabase && isSupabaseConfigured && !reserved) {
-        continue;
-      }
-    } catch {
-      persistedRemotely = false;
+  let persistedRemotely = false;
+  try {
+    const reserved = await reserveHashRemotely(payload, hash);
+    persistedRemotely = reserved;
+    if (supabase && isSupabaseConfigured && !reserved) {
+      throw new Error('Hash già esistente su Supabase: modifica il ticket e rigenera.');
     }
-
-    localActivationStore.set(hash, {
-      hash,
-      ticketCode,
-      status: 'generated',
-      activatedBy: null,
-      activatedAtIso: null,
-    });
-
-    return {
-      payload,
-      json,
-      hash,
-      qrValue: `${PROTOCOL_PREFIX}${hash}`,
-      persistedRemotely,
-    };
+  } catch (error) {
+    if (supabase && isSupabaseConfigured) {
+      throw error instanceof Error ? error : new Error('Errore durante la registrazione hash su Supabase.');
+    }
+    persistedRemotely = false;
   }
 
-  throw new Error('Collisione hash ripetuta: aumenta la complessità del payload.');
+  localActivationStore.set(hash, {
+    hash,
+    ticketNumber: payload.ticketNumber,
+    status: 'generated',
+    activatedBy: null,
+    activatedAtIso: null,
+  });
+
+  return {
+    payload,
+    json,
+    hash,
+    qrValue: `${PROTOCOL_PREFIX}${hash}`,
+    persistedRemotely,
+  };
 }
 
 export function parseTicketQrValue(input: string): string | null {

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -553,7 +553,7 @@ type GameContextValue = {
   isEventFollowed: (eventId: string) => boolean;
   markBadgesSeen: () => void;
   updateProfile: (updates: Partial<Pick<PlayerProfile, 'name' | 'email' | 'roleId' | 'profileImage'>>) => void;
-  registerTurn: (eventId: string, roleId: RoleId) => TurnRecord | null;
+  registerTurn: (eventId: string, roleId: RoleId, eventOverride?: GameEvent) => TurnRecord | null;
   completeActivity: (activityId: string) => { activity: Activity; rewards: Rewards } | null;
   resetProgress: () => Promise<void>;
   changePassword: (newPassword: string, currentPassword?: string) => Promise<void>;
@@ -1391,8 +1391,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   );
 
   const registerTurn = useCallback(
-    (eventId: string, roleId: RoleId): TurnRecord | null => {
-      const event = catalog.events.find((item) => item.id === eventId) ?? catalog.events[0];
+    (eventId: string, roleId: RoleId, eventOverride?: GameEvent): TurnRecord | null => {
+      const event = eventOverride ?? catalog.events.find((item) => item.id === eventId);
       if (!event) return null;
       const rewards = computeTurnRewards(event, roleId);
       const turnId =

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -1,7 +1,12 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import type { Session } from '@supabase/supabase-js';
 import { isSupabaseConfigured, supabase } from '../lib/supabase';
-import { SUPABASE_SESSION_ID_KEY, SUPABASE_SESSION_KEY } from '../lib/auth-storage';
+import {
+  LEGACY_SUPABASE_SESSION_ID_KEY,
+  LEGACY_SUPABASE_SESSION_KEY,
+  SUPABASE_SESSION_ID_KEY,
+  SUPABASE_SESSION_KEY,
+} from '../lib/auth-storage';
 import { resolveDisplayName } from '../lib/profile-utils';
 import { formatErrorDetails, reportCriticalError } from '../services/error-handler';
 import { withMobileWatchdog } from '../services/mobile-watchdog';
@@ -278,11 +283,15 @@ type StoredSession = { access_token: string; refresh_token: string; user_id?: st
 function readStoredSession(): StoredSession | null {
   if (typeof window === 'undefined') return null;
   try {
-    const raw = window.localStorage.getItem(SUPABASE_SESSION_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as StoredSession;
-    if (!parsed.access_token || !parsed.refresh_token) return null;
-    return parsed;
+    const keys = [SUPABASE_SESSION_KEY, LEGACY_SUPABASE_SESSION_KEY];
+    for (const key of keys) {
+      const raw = window.localStorage.getItem(key);
+      if (!raw) continue;
+      const parsed = JSON.parse(raw) as StoredSession;
+      if (!parsed.access_token || !parsed.refresh_token) continue;
+      return parsed;
+    }
+    return null;
   } catch {
     return null;
   }
@@ -291,9 +300,12 @@ function readStoredSession(): StoredSession | null {
 function persistStoredSession(session: Session | null) {
   if (typeof window === 'undefined') return;
   try {
+    const sessionKeys = [SUPABASE_SESSION_KEY, LEGACY_SUPABASE_SESSION_KEY];
+    const sessionIdKeys = [SUPABASE_SESSION_ID_KEY, LEGACY_SUPABASE_SESSION_ID_KEY];
+
     if (!session) {
-      window.localStorage.removeItem(SUPABASE_SESSION_KEY);
-      window.localStorage.removeItem(SUPABASE_SESSION_ID_KEY);
+      sessionKeys.forEach((key) => window.localStorage.removeItem(key));
+      sessionIdKeys.forEach((key) => window.localStorage.removeItem(key));
       return;
     }
     const payload: StoredSession = {
@@ -303,6 +315,9 @@ function persistStoredSession(session: Session | null) {
     };
     window.localStorage.setItem(SUPABASE_SESSION_KEY, JSON.stringify(payload));
     window.localStorage.setItem(SUPABASE_SESSION_ID_KEY, session.user.id);
+    // Cleanup unscoped legacy keys to avoid cross-project token bleed.
+    window.localStorage.removeItem(LEGACY_SUPABASE_SESSION_KEY);
+    window.localStorage.removeItem(LEGACY_SUPABASE_SESSION_ID_KEY);
   } catch {
     // ignore storage errors
   }
@@ -795,17 +810,31 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         async () => {
           const stored = readStoredSession();
           if (stored) {
-            await supabase!.auth.setSession({
+            const { data: restoredData, error: restoreError } = await supabase!.auth.setSession({
               access_token: stored.access_token,
               refresh_token: stored.refresh_token,
             });
+            if (restoreError || !restoredData.session) {
+              persistStoredSession(null);
+              await supabase!.auth.signOut();
+            }
           }
 
           const { data } = await supabase!.auth.getSession();
           if (!isMounted) return;
 
-          persistStoredSession(data.session ?? null);
-          setAuthUserId(data.session?.user.id ?? null);
+          let stableSession = data.session ?? null;
+          if (stableSession?.access_token) {
+            const { error: userError } = await supabase!.auth.getUser(stableSession.access_token);
+            if (userError) {
+              stableSession = null;
+              persistStoredSession(null);
+              await supabase!.auth.signOut();
+            }
+          }
+
+          persistStoredSession(stableSession);
+          setAuthUserId(stableSession?.user.id ?? null);
           setAuthReady(true);
         },
         {

--- a/apps/mobile/src/types/navigation.ts
+++ b/apps/mobile/src/types/navigation.ts
@@ -21,7 +21,8 @@ export type Screen =
     | 'career'
     | 'terms'
     | 'privacy'
-    | 'earned-titles';
+    | 'earned-titles'
+    | 'ticket-qr-prototype';
 
 export type Tab = 'home' | 'turns' | 'leaderboard' | 'activities' | 'profile';
 

--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -14,6 +14,23 @@ function jsonResponse(payload: Record<string, unknown>, status = 200) {
   });
 }
 
+async function loadEventSnapshot(supabase: ReturnType<typeof createClient>, eventId: string | null | undefined) {
+  if (!eventId) return null;
+
+  const { data, error } = await supabase
+    .from('events')
+    .select('id,name,theatre,event_date,event_time,genre,base_rewards,focus_role')
+    .eq('id', eventId)
+    .maybeSingle();
+
+  if (error) {
+    console.warn('Unable to load event snapshot', eventId, error.message);
+    return null;
+  }
+
+  return data ?? null;
+}
+
 serve(async (req) => {
   // Handle CORS
   if (req.method === 'OPTIONS') {
@@ -136,10 +153,12 @@ serve(async (req) => {
 
       if (data && data.length > 0) {
         const record = data[0];
+        const eventSnapshot = await loadEventSnapshot(supabase, record.event_id);
         return jsonResponse({
           ok: true,
           eventId: record.event_id,
           eventName: record.event_name,
+          event: eventSnapshot,
         }, 200);
       }
 

--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -1,0 +1,140 @@
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.48.0';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+};
+
+serve(async (req) => {
+  // Handle CORS
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+  if (!supabaseUrl || !serviceKey) {
+    return new Response(JSON.stringify({ error: 'Missing environment variables' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const supabase = createClient(supabaseUrl, serviceKey);
+
+  try {
+    const { action, hash, payload, userId } = await req.json();
+
+    if (action === 'reserve_hash') {
+      if (!hash || !payload) {
+        return new Response(JSON.stringify({ error: 'Missing hash or payload' }), {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Check if hash already exists
+      const { data: existing } = await supabase
+        .from('ticket_activations')
+        .select('hash')
+        .eq('hash', hash)
+        .single();
+
+      if (existing) {
+        return new Response(JSON.stringify({ reserved: false, error: 'Hash already exists' }), {
+          status: 200,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Insert new ticket activation record (unassigned)
+      const { error: insertError } = await supabase.from('ticket_activations').insert({
+        hash,
+        circuit: payload.circuit,
+        event_name: payload.eventName,
+        event_id: payload.eventID,
+        ticket_number: payload.ticketNumber,
+        date: payload.date,
+      });
+
+      if (insertError) {
+        throw insertError;
+      }
+
+      return new Response(JSON.stringify({ reserved: true }), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (action === 'activate_hash') {
+      if (!hash || !userId) {
+        return new Response(JSON.stringify({ error: 'Missing hash or userId' }), {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Atomic activation update
+      // We use a query with a filter on activated_by is null to ensure atomicity
+      const { data, error } = await supabase
+        .from('ticket_activations')
+        .update({
+          activated_by: userId,
+          activated_at: new Date().toISOString(),
+        })
+        .eq('hash', hash)
+        .is('activated_by', null)
+        .select();
+
+      if (error) throw error;
+
+      if (data && data.length > 0) {
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      // If no rows updated, it was either not found or already activated
+      const { data: current } = await supabase
+        .from('ticket_activations')
+        .select('activated_by')
+        .eq('hash', hash)
+        .single();
+
+      if (!current) {
+        return new Response(JSON.stringify({ ok: false, error: 'Ticket non trovato.' }), {
+          status: 200,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(
+        JSON.stringify({
+          ok: false,
+          alreadyActivated: true,
+          activatedBy: current.activated_by,
+        }),
+        {
+          status: 200,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    return new Response(JSON.stringify({ error: 'Invalid action' }), {
+      status: 400,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error(err);
+    return new Response(JSON.stringify({ error: err instanceof Error ? err.message : 'Unknown error' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -7,6 +7,13 @@ const corsHeaders = {
   'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
 };
 
+function jsonResponse(payload: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
 serve(async (req) => {
   // Handle CORS
   if (req.method === 'OPTIONS') {
@@ -15,25 +22,50 @@ serve(async (req) => {
 
   const supabaseUrl = Deno.env.get('SUPABASE_URL');
   const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  const anonKey = Deno.env.get('SUPABASE_ANON_KEY');
 
   if (!supabaseUrl || !serviceKey) {
-    return new Response(JSON.stringify({ error: 'Missing environment variables' }), {
-      status: 500,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    return jsonResponse({ error: 'Missing environment variables' }, 500);
   }
 
   const supabase = createClient(supabaseUrl, serviceKey);
 
   try {
-    const { action, hash, payload, userId } = await req.json();
+    const { action, hash, payload, userId: requestedUserId } = await req.json();
+
+    const needsAuthenticatedUser = action === 'activate_hash' || action === 'activate_by_details';
+    let resolvedUserId = typeof requestedUserId === 'string' ? requestedUserId.trim() : '';
+
+    if (needsAuthenticatedUser) {
+      if (!anonKey) {
+        return jsonResponse({ error: 'Missing SUPABASE_ANON_KEY' }, 500);
+      }
+
+      const authHeader = req.headers.get('Authorization') ?? '';
+      if (!authHeader.startsWith('Bearer ')) {
+        return jsonResponse({ error: 'Sessione scaduta o non disponibile. Effettua di nuovo il login.' }, 401);
+      }
+
+      const authClient = createClient(supabaseUrl, anonKey, {
+        global: {
+          headers: {
+            Authorization: authHeader,
+          },
+        },
+      });
+
+      const { data: authData, error: authError } = await authClient.auth.getUser();
+      if (authError || !authData.user) {
+        return jsonResponse({ error: 'Invalid JWT' }, 401);
+      }
+
+      // Do not trust userId sent by client payload.
+      resolvedUserId = authData.user.id;
+    }
 
     if (action === 'reserve_hash') {
       if (!hash || !payload) {
-        return new Response(JSON.stringify({ error: 'Missing hash or payload' }), {
-          status: 400,
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        });
+        return jsonResponse({ error: 'Missing hash or payload' }, 400);
       }
 
       // Check if hash already exists
@@ -44,10 +76,7 @@ serve(async (req) => {
         .single();
 
       if (existing) {
-        return new Response(JSON.stringify({ reserved: false, error: 'Hash already exists' }), {
-          status: 200,
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        });
+        return jsonResponse({ reserved: false, error: 'Hash already exists' }, 200);
       }
 
       // Insert new ticket activation record (unassigned)
@@ -64,18 +93,16 @@ serve(async (req) => {
         throw insertError;
       }
 
-      return new Response(JSON.stringify({ reserved: true }), {
-        status: 200,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
+      return jsonResponse({ reserved: true }, 200);
     }
 
     if (action === 'activate_hash' || action === 'activate_by_details') {
-      if (!userId || (action === 'activate_hash' && !hash) || (action === 'activate_by_details' && (!payload?.eventID || !payload?.ticketNumber))) {
-        return new Response(JSON.stringify({ error: 'Missing required parameters' }), {
-          status: 400,
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        });
+      if (
+        !resolvedUserId ||
+        (action === 'activate_hash' && !hash) ||
+        (action === 'activate_by_details' && (!payload?.eventID || !payload?.ticketNumber))
+      ) {
+        return jsonResponse({ error: 'Missing required parameters' }, 400);
       }
 
       // 1. Resolve hash if using details
@@ -89,10 +116,7 @@ serve(async (req) => {
           .single();
         
         if (!ticket) {
-          return new Response(JSON.stringify({ ok: false, error: 'Ticket non trovato.' }), {
-            status: 200,
-            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-          });
+          return jsonResponse({ ok: false, error: 'Ticket non trovato.' }, 200);
         }
         targetHash = ticket.hash;
       }
@@ -101,7 +125,7 @@ serve(async (req) => {
       const { data, error } = await supabase
         .from('ticket_activations')
         .update({
-          activated_by: userId,
+          activated_by: resolvedUserId,
           activated_at: new Date().toISOString(),
         })
         .eq('hash', targetHash)
@@ -112,14 +136,11 @@ serve(async (req) => {
 
       if (data && data.length > 0) {
         const record = data[0];
-        return new Response(JSON.stringify({ 
-          ok: true, 
+        return jsonResponse({
+          ok: true,
           eventId: record.event_id,
-          eventName: record.event_name
-        }), {
-          status: 200,
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        });
+          eventName: record.event_name,
+        }, 200);
       }
 
       // 3. Check current status if update failed
@@ -130,34 +151,19 @@ serve(async (req) => {
         .single();
 
       if (!current) {
-        return new Response(JSON.stringify({ ok: false, error: 'Ticket non trovato.' }), {
-          status: 200,
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        });
+        return jsonResponse({ ok: false, error: 'Ticket non trovato.' }, 200);
       }
 
-      return new Response(
-        JSON.stringify({
-          ok: false,
-          alreadyActivated: true,
-          activatedBy: current.activated_by,
-        }),
-        {
-          status: 200,
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        }
-      );
+      return jsonResponse({
+        ok: false,
+        alreadyActivated: true,
+        activatedBy: current.activated_by,
+      }, 200);
     }
 
-    return new Response(JSON.stringify({ error: 'Invalid action' }), {
-      status: 400,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    return jsonResponse({ error: 'Invalid action' }, 400);
   } catch (err) {
     console.error(err);
-    return new Response(JSON.stringify({ error: err instanceof Error ? err.message : 'Unknown error' }), {
-      status: 500,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    return jsonResponse({ error: err instanceof Error ? err.message : 'Unknown error' }, 500);
   }
 });

--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -70,23 +70,41 @@ serve(async (req) => {
       });
     }
 
-    if (action === 'activate_hash') {
-      if (!hash || !userId) {
-        return new Response(JSON.stringify({ error: 'Missing hash or userId' }), {
+    if (action === 'activate_hash' || action === 'activate_by_details') {
+      if (!userId || (action === 'activate_hash' && !hash) || (action === 'activate_by_details' && (!payload?.eventID || !payload?.ticketNumber))) {
+        return new Response(JSON.stringify({ error: 'Missing required parameters' }), {
           status: 400,
           headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         });
       }
 
-      // Atomic activation update
-      // We use a query with a filter on activated_by is null to ensure atomicity
+      // 1. Resolve hash if using details
+      let targetHash = hash;
+      if (action === 'activate_by_details') {
+        const { data: ticket } = await supabase
+          .from('ticket_activations')
+          .select('hash')
+          .eq('event_id', payload.eventID)
+          .eq('ticket_number', payload.ticketNumber)
+          .single();
+        
+        if (!ticket) {
+          return new Response(JSON.stringify({ ok: false, error: 'Ticket non trovato.' }), {
+            status: 200,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          });
+        }
+        targetHash = ticket.hash;
+      }
+
+      // 2. Atomic activation update
       const { data, error } = await supabase
         .from('ticket_activations')
         .update({
           activated_by: userId,
           activated_at: new Date().toISOString(),
         })
-        .eq('hash', hash)
+        .eq('hash', targetHash)
         .is('activated_by', null)
         .select();
 
@@ -99,11 +117,11 @@ serve(async (req) => {
         });
       }
 
-      // If no rows updated, it was either not found or already activated
+      // 3. Check current status if update failed
       const { data: current } = await supabase
         .from('ticket_activations')
         .select('activated_by')
-        .eq('hash', hash)
+        .eq('hash', targetHash)
         .single();
 
       if (!current) {

--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -111,7 +111,12 @@ serve(async (req) => {
       if (error) throw error;
 
       if (data && data.length > 0) {
-        return new Response(JSON.stringify({ ok: true }), {
+        const record = data[0];
+        return new Response(JSON.stringify({ 
+          ok: true, 
+          eventId: record.event_id,
+          eventName: record.event_name
+        }), {
           status: 200,
           headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         });

--- a/supabase/migrations/20260211_ticket_activations.sql
+++ b/supabase/migrations/20260211_ticket_activations.sql
@@ -1,0 +1,62 @@
+-- Migration: Create ticket_activations table for Issue #52
+-- Created: 2026-02-11
+
+create table if not exists public.ticket_activations (
+  hash text primary key, -- SHA-256 hash of the ticket payload
+  circuit text not null,
+  event_name text not null,
+  event_id text not null references public.events(id) on update cascade on delete cascade,
+  ticket_number text not null,
+  date timestamptz not null,
+  activated_by uuid references auth.users(id) on delete set null,
+  activated_at timestamptz,
+  created_at timestamptz not null default now(),
+  
+  -- Ensure that if activated_by is set, activated_at is also set
+  constraint ticket_activations_activation_consistency check (
+    (activated_by is null and activated_at is null)
+    or (activated_by is not null and activated_at is not null)
+  )
+);
+
+-- Indices for performance
+create index if not exists ticket_activations_event_id_idx on public.ticket_activations(event_id);
+create index if not exists ticket_activations_activated_by_idx on public.ticket_activations(activated_by) where activated_by is not null;
+
+-- Enable RLS
+alter table public.ticket_activations enable row level security;
+alter table public.ticket_activations force row level security;
+
+-- Policies
+
+-- 1. Everyone (authenticated) can see their own activations
+create policy "Users can see their own ticket activations"
+on public.ticket_activations
+for select
+to authenticated
+using (auth.uid() = activated_by);
+
+-- 2. Operators/Admins can see everything (using the role system from control_plane)
+-- If control_plane_has_any_role exists (it does from previous migration)
+create policy "Operators and admins can see all ticket activations"
+on public.ticket_activations
+for select
+to authenticated
+using (
+  public.control_plane_has_any_role(array['control_admin', 'control_operator', 'control_auditor']::text[])
+);
+
+-- 3. Insert is restricted to service role (Edge Function) by default if no policy allows it.
+-- We want to allow the Edge Function to manage this table.
+-- Usually service role bypasses RLS, so we don't need a specific 'for insert' policy unless 
+-- we want to allow users to reserve their own (which we don't, the operator tool does it).
+
+-- 4. Update policy for activation (allowing a user to activate a ticket that belongs to NO ONE)
+create policy "Users can activate an unassigned ticket"
+on public.ticket_activations
+for update
+to authenticated
+using (activated_by is null)
+with check (auth.uid() = activated_by);
+
+-- Note: The Edge Function will handle the atomic check-and-set for activation to be safe.

--- a/tools/ticket_qr_generator/Example.json
+++ b/tools/ticket_qr_generator/Example.json
@@ -1,0 +1,7 @@
+{
+    "circuit": "TicketOne",
+    "eventName": "Esempio",
+    "eventID": "1234567890",
+    "ticketNumber": "1234567890",
+    "date": "2026-02-11T11:54:00+01:00" 
+}

--- a/tools/ticket_qr_generator/README.md
+++ b/tools/ticket_qr_generator/README.md
@@ -42,6 +42,7 @@ Nella UI:
 
 Il circuito predefinito viene salvato localmente in `~/.turni_ticket_qr_ui.json`.
 Puoi cambiare path impostando `TICKET_QR_UI_SETTINGS_PATH`.
+Il contenuto del QR e il solo hash SHA-256 (64 caratteri), senza schema `turni://`.
 
 La lista circuiti del menu e esterna in `tools/ticket_qr_generator/circuit_options.json`.
 Puoi sovrascrivere il file con `TICKET_QR_CIRCUITS_PATH` oppure passare una lista CSV diretta con `TICKET_QR_CIRCUITS` (es: `TicketOne,Vivaticket,Ciaotickets`).

--- a/tools/ticket_qr_generator/README.md
+++ b/tools/ticket_qr_generator/README.md
@@ -1,39 +1,60 @@
 # Ticket QR generator (Python prototype)
 
-Prototipo CLI per biglietterie teatrali, pensato per essere distribuibile come app standalone (es. PyInstaller).
+Prototipo per biglietterie teatrali con:
+- **CLI** per integrazioni/script.
+- **UI desktop (Tkinter)** semplice per operatori non tecnici.
 
-## Flusso implementato
+## Struttura JSON del ticket
 
-1. Raccoglie i dati del ticket (`ticket_code`, `theatre_id`, `performance_iso`).
-2. Costruisce JSON canonico con `salt` incrementale.
-3. Calcola hash SHA-256 del JSON.
-4. Chiama Supabase Edge Function `ticket-activation` (`action: reserve_hash`) per validare unicità.
-5. Genera PNG QR con payload `turni://ticket/<hash>`.
+Il payload usato per hashing e registrazione è:
 
-## Esecuzione
+```json
+{
+  "circuit": "TicketOne",
+  "eventName": "Esempio",
+  "eventID": "1234567890",
+  "ticketNumber": "1234567890",
+  "date": "2026-02-11T11:54:00+01:00"
+}
+```
+
+## Setup
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
 pip install -r tools/ticket_qr_generator/requirements.txt
-
-export SUPABASE_URL="https://<project>.supabase.co"
-export SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
-
-python tools/ticket_qr_generator/generate_ticket_qr.py \
-  --ticket-code "ATCL-2026-001" \
-  --theatre-id "teatro-rendano" \
-  --performance-iso "2026-03-15T20:45:00+01:00" \
-  --output "./out/atcl-2026-001.png"
 ```
 
-Per una demo locale senza backend:
+## Avvio UI desktop (consigliato)
+
+```bash
+python tools/ticket_qr_generator/ticket_qr_generator_ui.py
+```
+
+Nella UI:
+1. Compila i campi del ticket.
+2. Scegli il file PNG di output.
+3. Premi **Genera QR**.
+4. Ottieni hash, JSON e anteprima QR.
+
+Per usare Supabase nella UI, disattiva "Modalità locale" e imposta variabili ambiente:
+
+```bash
+export SUPABASE_URL="https://<project>.supabase.co"
+export SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
+```
+
+## Esecuzione CLI
 
 ```bash
 python tools/ticket_qr_generator/generate_ticket_qr.py \
-  --ticket-code "ATCL-LOCAL-001" \
-  --theatre-id "demo" \
-  --performance-iso "2026-01-01T18:00:00+01:00" \
+  --circuit "TicketOne" \
+  --event-name "Esempio" \
+  --event-id "1234567890" \
+  --ticket-number "1234567890" \
+  --date "2026-02-11T11:54:00+01:00" \
+  --output "./out/atcl-2026-001.png" \
   --skip-supabase
 ```
 
@@ -41,7 +62,7 @@ python tools/ticket_qr_generator/generate_ticket_qr.py \
 
 ```bash
 pip install pyinstaller
-pyinstaller --onefile tools/ticket_qr_generator/generate_ticket_qr.py
+pyinstaller --onefile tools/ticket_qr_generator/ticket_qr_generator_ui.py
 ```
 
 Output previsto: eseguibile singolo in `dist/` da distribuire sulle postazioni di biglietteria.

--- a/tools/ticket_qr_generator/README.md
+++ b/tools/ticket_qr_generator/README.md
@@ -1,0 +1,47 @@
+# Ticket QR generator (Python prototype)
+
+Prototipo CLI per biglietterie teatrali, pensato per essere distribuibile come app standalone (es. PyInstaller).
+
+## Flusso implementato
+
+1. Raccoglie i dati del ticket (`ticket_code`, `theatre_id`, `performance_iso`).
+2. Costruisce JSON canonico con `salt` incrementale.
+3. Calcola hash SHA-256 del JSON.
+4. Chiama Supabase Edge Function `ticket-activation` (`action: reserve_hash`) per validare unicità.
+5. Genera PNG QR con payload `turni://ticket/<hash>`.
+
+## Esecuzione
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r tools/ticket_qr_generator/requirements.txt
+
+export SUPABASE_URL="https://<project>.supabase.co"
+export SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
+
+python tools/ticket_qr_generator/generate_ticket_qr.py \
+  --ticket-code "ATCL-2026-001" \
+  --theatre-id "teatro-rendano" \
+  --performance-iso "2026-03-15T20:45:00+01:00" \
+  --output "./out/atcl-2026-001.png"
+```
+
+Per una demo locale senza backend:
+
+```bash
+python tools/ticket_qr_generator/generate_ticket_qr.py \
+  --ticket-code "ATCL-LOCAL-001" \
+  --theatre-id "demo" \
+  --performance-iso "2026-01-01T18:00:00+01:00" \
+  --skip-supabase
+```
+
+## Distribuzione standalone (valutazione)
+
+```bash
+pip install pyinstaller
+pyinstaller --onefile tools/ticket_qr_generator/generate_ticket_qr.py
+```
+
+Output previsto: eseguibile singolo in `dist/` da distribuire sulle postazioni di biglietteria.

--- a/tools/ticket_qr_generator/README.md
+++ b/tools/ticket_qr_generator/README.md
@@ -33,11 +33,18 @@ python tools/ticket_qr_generator/ticket_qr_generator_ui.py
 ```
 
 Nella UI:
-1. Premi **Aggiorna calendario** e seleziona l'evento.
-2. Inserisci **solo** il numero biglietto.
-3. Scegli il file PNG di output.
-4. Premi **Genera QR**.
-5. Ottieni hash, JSON e anteprima QR.
+1. (Prima volta) Apri **Impostazioni circuito** e seleziona il circuito emittente predefinito.
+2. Premi **Aggiorna calendario** e seleziona l'evento.
+3. Inserisci **solo** il numero biglietto.
+4. Scegli il file PNG di output.
+5. Premi **Genera QR**.
+6. Ottieni hash, JSON e anteprima QR.
+
+Il circuito predefinito viene salvato localmente in `~/.turni_ticket_qr_ui.json`.
+Puoi cambiare path impostando `TICKET_QR_UI_SETTINGS_PATH`.
+
+La lista circuiti del menu e esterna in `tools/ticket_qr_generator/circuit_options.json`.
+Puoi sovrascrivere il file con `TICKET_QR_CIRCUITS_PATH` oppure passare una lista CSV diretta con `TICKET_QR_CIRCUITS` (es: `TicketOne,Vivaticket,Ciaotickets`).
 
 Per leggere il calendario eventi nella UI imposta:
 

--- a/tools/ticket_qr_generator/README.md
+++ b/tools/ticket_qr_generator/README.md
@@ -2,17 +2,17 @@
 
 Prototipo per biglietterie teatrali con:
 - **CLI** per integrazioni/script.
-- **UI desktop (Tkinter)** semplice per operatori non tecnici.
+- **UI desktop (Tkinter)** per operatori non tecnici.
 
 ## Struttura JSON del ticket
 
-Il payload usato per hashing e registrazione è:
+Il payload usato per hashing e registrazione e:
 
 ```json
 {
-  "circuit": "TicketOne",
+  "circuit": "ATCL",
   "eventName": "Esempio",
-  "eventID": "1234567890",
+  "eventID": "ATCL-001",
   "ticketNumber": "1234567890",
   "date": "2026-02-11T11:54:00+01:00"
 }
@@ -33,25 +33,44 @@ python tools/ticket_qr_generator/ticket_qr_generator_ui.py
 ```
 
 Nella UI:
-1. Compila i campi del ticket.
-2. Scegli il file PNG di output.
-3. Premi **Genera QR**.
-4. Ottieni hash, JSON e anteprima QR.
+1. Premi **Aggiorna calendario** e seleziona l'evento.
+2. Inserisci **solo** il numero biglietto.
+3. Scegli il file PNG di output.
+4. Premi **Genera QR**.
+5. Ottieni hash, JSON e anteprima QR.
 
-Per usare Supabase nella UI, disattiva "Modalità locale" e imposta variabili ambiente:
+Per leggere il calendario eventi nella UI imposta:
 
 ```bash
 export SUPABASE_URL="https://<project>.supabase.co"
+export SUPABASE_ANON_KEY="<anon-or-service-key>"
+```
+
+Per prenotare hash su Supabase (quando disattivi "Modalita locale"), serve anche:
+
+```bash
 export SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
 ```
 
 ## Esecuzione CLI
 
+### Modalita calendario (consigliata)
+
 ```bash
 python tools/ticket_qr_generator/generate_ticket_qr.py \
-  --circuit "TicketOne" \
+  --event-id "ATCL-001" \
+  --ticket-number "1234567890" \
+  --event-from-calendar \
+  --output "./out/atcl-2026-001.png"
+```
+
+### Modalita manuale (compatibilita)
+
+```bash
+python tools/ticket_qr_generator/generate_ticket_qr.py \
+  --circuit "ATCL" \
   --event-name "Esempio" \
-  --event-id "1234567890" \
+  --event-id "ATCL-001" \
   --ticket-number "1234567890" \
   --date "2026-02-11T11:54:00+01:00" \
   --output "./out/atcl-2026-001.png" \

--- a/tools/ticket_qr_generator/circuit_options.json
+++ b/tools/ticket_qr_generator/circuit_options.json
@@ -1,0 +1,8 @@
+{
+  "circuits": [
+    "TicketOne",
+    "Vivaticket",
+    "Ciaotickets",
+    "DIY ticketing"
+  ]
+}

--- a/tools/ticket_qr_generator/generate_ticket_qr.py
+++ b/tools/ticket_qr_generator/generate_ticket_qr.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import hashlib
+import html
 import json
 import os
 import pathlib
@@ -168,7 +169,7 @@ def fetch_calendar_events(*, supabase_url: str, api_key: str, timeout_s: int = 1
     events: list[CalendarEvent] = []
     for row in rows:
         event_id = str(row.get("id", "")).strip()
-        event_name = str(row.get("name", "")).strip()
+        event_name = html.unescape(str(row.get("name", ""))).strip()
         event_date = str(row.get("event_date", "")).strip()
         event_time = str(row.get("event_time", "")).strip()
         if not all([event_id, event_name, event_date, event_time]):

--- a/tools/ticket_qr_generator/generate_ticket_qr.py
+++ b/tools/ticket_qr_generator/generate_ticket_qr.py
@@ -353,7 +353,7 @@ def main() -> int:
             print("Hash already exists on Supabase. Please verify ticket details.", file=sys.stderr)
             return 2
 
-    qr_value = f"turni://ticket/{payload_hash}"
+    qr_value = payload_hash
     output_path = pathlib.Path(args.output).resolve()
     generate_qr_png(qr_value, output_path)
 

--- a/tools/ticket_qr_generator/generate_ticket_qr.py
+++ b/tools/ticket_qr_generator/generate_ticket_qr.py
@@ -26,6 +26,7 @@ load_dotenv()
 
 @dataclass
 class TicketPayload:
+    circuit: str
     event_name: str
     event_id: str
     ticket_number: str
@@ -91,7 +92,7 @@ ITALIAN_MONTHS = {
 
 
 def default_ticket_circuit() -> str:
-    return os.getenv("TICKET_QR_CIRCUIT", "ATCL").strip() or "ATCL"
+    return os.getenv("TICKET_QR_CIRCUIT", "TicketOne").strip() or "TicketOne"
 
 
 def _normalize_month_token(value: str) -> str:

--- a/tools/ticket_qr_generator/generate_ticket_qr.py
+++ b/tools/ticket_qr_generator/generate_ticket_qr.py
@@ -17,11 +17,14 @@ from dataclasses import dataclass
 
 import qrcode
 import requests
+from dotenv import load_dotenv
+
+# Load local .env if present
+load_dotenv()
 
 
 @dataclass
 class TicketPayload:
-    circuit: str
     event_name: str
     event_id: str
     ticket_number: str

--- a/tools/ticket_qr_generator/generate_ticket_qr.py
+++ b/tools/ticket_qr_generator/generate_ticket_qr.py
@@ -336,7 +336,7 @@ def main() -> int:
         print("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required (or use --skip-supabase).", file=sys.stderr)
         return 1
 
-    reserved = True
+    reserved = False
     if not args.skip_supabase:
         reserved = reserve_hash(
             supabase_url=supabase_url,
@@ -344,10 +344,9 @@ def main() -> int:
             payload=payload,
             payload_hash=payload_hash,
         )
-
-    if not reserved:
-        print("Hash already exists on Supabase. Please verify ticket details.", file=sys.stderr)
-        return 2
+        if not reserved:
+            print("Hash already exists on Supabase. Please verify ticket details.", file=sys.stderr)
+            return 2
 
     qr_value = f"turni://ticket/{payload_hash}"
     output_path = pathlib.Path(args.output).resolve()

--- a/tools/ticket_qr_generator/generate_ticket_qr.py
+++ b/tools/ticket_qr_generator/generate_ticket_qr.py
@@ -1,13 +1,5 @@
 #!/usr/bin/env python3
-"""Prototype CLI for theatre box offices.
-
-Flow:
-1) collect ticket metadata
-2) build canonical JSON payload
-3) hash payload (SHA-256)
-4) reserve hash on Supabase Edge Function
-5) generate PNG QR with value `turni://ticket/<hash>`
-"""
+"""Ticket QR generator CLI for theatre box offices."""
 
 from __future__ import annotations
 
@@ -17,8 +9,8 @@ import json
 import os
 import pathlib
 import sys
-from dataclasses import dataclass, asdict
-from datetime import datetime, timezone
+from collections import OrderedDict
+from dataclasses import dataclass
 
 import qrcode
 import requests
@@ -26,16 +18,27 @@ import requests
 
 @dataclass
 class TicketPayload:
-    source: str
-    ticket_code: str
-    theatre_id: str
-    performance_iso: str
-    issued_at_iso: str
-    salt: int
+    circuit: str
+    event_name: str
+    event_id: str
+    ticket_number: str
+    date: str
+
+
+def to_payload_dict(payload: TicketPayload) -> OrderedDict[str, str]:
+    return OrderedDict(
+        (
+            ("circuit", payload.circuit),
+            ("eventName", payload.event_name),
+            ("eventID", payload.event_id),
+            ("ticketNumber", payload.ticket_number),
+            ("date", payload.date),
+        )
+    )
 
 
 def canonical_payload_json(payload: TicketPayload) -> str:
-    return json.dumps(asdict(payload), separators=(",", ":"), sort_keys=True)
+    return json.dumps(to_payload_dict(payload), ensure_ascii=False, indent=2)
 
 
 def sha256_hex(text: str) -> str:
@@ -58,24 +61,12 @@ def reserve_hash(
             "apikey": service_role_key,
             "Content-Type": "application/json",
         },
-        json={"action": "reserve_hash", "hash": payload_hash, "payload": asdict(payload)},
+        json={"action": "reserve_hash", "hash": payload_hash, "payload": to_payload_dict(payload)},
         timeout=timeout_s,
     )
     response.raise_for_status()
     body = response.json() if response.content else {}
     return bool(body.get("reserved"))
-
-
-def build_ticket_payload(args: argparse.Namespace, salt: int) -> TicketPayload:
-    now_iso = datetime.now(timezone.utc).isoformat()
-    return TicketPayload(
-        source=args.source,
-        ticket_code=args.ticket_code.strip().upper(),
-        theatre_id=args.theatre_id.strip(),
-        performance_iso=args.performance_iso.strip(),
-        issued_at_iso=now_iso,
-        salt=salt,
-    )
 
 
 def generate_qr_png(qr_value: str, output_path: pathlib.Path) -> None:
@@ -86,11 +77,11 @@ def generate_qr_png(qr_value: str, output_path: pathlib.Path) -> None:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate one-shot activation QR for Turni di Palco.")
-    parser.add_argument("--ticket-code", required=True)
-    parser.add_argument("--theatre-id", required=True)
-    parser.add_argument("--performance-iso", required=True)
-    parser.add_argument("--source", default="ticket-office")
-    parser.add_argument("--max-attempts", type=int, default=8)
+    parser.add_argument("--circuit", required=True, help="Ticket circuit, e.g. TicketOne")
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--event-id", required=True)
+    parser.add_argument("--ticket-number", required=True)
+    parser.add_argument("--date", required=True, help="ISO datetime, e.g. 2026-02-11T11:54:00+01:00")
     parser.add_argument("--output", default="./out/ticket-qr.png")
     parser.add_argument("--skip-supabase", action="store_true", help="Allow local-only generation")
     return parser.parse_args()
@@ -98,6 +89,20 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    payload = TicketPayload(
+        circuit=args.circuit.strip(),
+        event_name=args.event_name.strip(),
+        event_id=args.event_id.strip(),
+        ticket_number=args.ticket_number.strip(),
+        date=args.date.strip(),
+    )
+
+    if not all([payload.circuit, payload.event_name, payload.event_id, payload.ticket_number, payload.date]):
+        print("All fields are required.", file=sys.stderr)
+        return 1
+
+    json_payload = canonical_payload_json(payload)
+    payload_hash = sha256_hex(json_payload)
 
     supabase_url = os.getenv("SUPABASE_URL", "")
     service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
@@ -106,28 +111,25 @@ def main() -> int:
         print("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required (or use --skip-supabase).", file=sys.stderr)
         return 1
 
-    for salt in range(args.max_attempts):
-        payload = build_ticket_payload(args, salt)
-        json_payload = canonical_payload_json(payload)
-        payload_hash = sha256_hex(json_payload)
+    reserved = True
+    if not args.skip_supabase:
+        reserved = reserve_hash(
+            supabase_url=supabase_url,
+            service_role_key=service_role_key,
+            payload=payload,
+            payload_hash=payload_hash,
+        )
 
-        reserved = True
-        if not args.skip_supabase:
-            reserved = reserve_hash(
-                supabase_url=supabase_url,
-                service_role_key=service_role_key,
-                payload=payload,
-                payload_hash=payload_hash,
-            )
+    if not reserved:
+        print("Hash already exists on Supabase. Please verify ticket details.", file=sys.stderr)
+        return 2
 
-        if not reserved:
-            continue
+    qr_value = f"turni://ticket/{payload_hash}"
+    output_path = pathlib.Path(args.output).resolve()
+    generate_qr_png(qr_value, output_path)
 
-        qr_value = f"turni://ticket/{payload_hash}"
-        output_path = pathlib.Path(args.output).resolve()
-        generate_qr_png(qr_value, output_path)
-
-        print(json.dumps(
+    print(
+        json.dumps(
             {
                 "hash": payload_hash,
                 "qr_value": qr_value,
@@ -135,12 +137,11 @@ def main() -> int:
                 "output": str(output_path),
                 "supabase_reserved": reserved,
             },
+            ensure_ascii=False,
             indent=2,
-        ))
-        return 0
-
-    print("Unable to reserve a unique hash after max attempts.", file=sys.stderr)
-    return 2
+        )
+    )
+    return 0
 
 
 if __name__ == "__main__":

--- a/tools/ticket_qr_generator/generate_ticket_qr.py
+++ b/tools/ticket_qr_generator/generate_ticket_qr.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Prototype CLI for theatre box offices.
+
+Flow:
+1) collect ticket metadata
+2) build canonical JSON payload
+3) hash payload (SHA-256)
+4) reserve hash on Supabase Edge Function
+5) generate PNG QR with value `turni://ticket/<hash>`
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import sys
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+
+import qrcode
+import requests
+
+
+@dataclass
+class TicketPayload:
+    source: str
+    ticket_code: str
+    theatre_id: str
+    performance_iso: str
+    issued_at_iso: str
+    salt: int
+
+
+def canonical_payload_json(payload: TicketPayload) -> str:
+    return json.dumps(asdict(payload), separators=(",", ":"), sort_keys=True)
+
+
+def sha256_hex(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def reserve_hash(
+    *,
+    supabase_url: str,
+    service_role_key: str,
+    payload: TicketPayload,
+    payload_hash: str,
+    timeout_s: int = 15,
+) -> bool:
+    endpoint = f"{supabase_url.rstrip('/')}/functions/v1/ticket-activation"
+    response = requests.post(
+        endpoint,
+        headers={
+            "Authorization": f"Bearer {service_role_key}",
+            "apikey": service_role_key,
+            "Content-Type": "application/json",
+        },
+        json={"action": "reserve_hash", "hash": payload_hash, "payload": asdict(payload)},
+        timeout=timeout_s,
+    )
+    response.raise_for_status()
+    body = response.json() if response.content else {}
+    return bool(body.get("reserved"))
+
+
+def build_ticket_payload(args: argparse.Namespace, salt: int) -> TicketPayload:
+    now_iso = datetime.now(timezone.utc).isoformat()
+    return TicketPayload(
+        source=args.source,
+        ticket_code=args.ticket_code.strip().upper(),
+        theatre_id=args.theatre_id.strip(),
+        performance_iso=args.performance_iso.strip(),
+        issued_at_iso=now_iso,
+        salt=salt,
+    )
+
+
+def generate_qr_png(qr_value: str, output_path: pathlib.Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    image = qrcode.make(qr_value)
+    image.save(output_path)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate one-shot activation QR for Turni di Palco.")
+    parser.add_argument("--ticket-code", required=True)
+    parser.add_argument("--theatre-id", required=True)
+    parser.add_argument("--performance-iso", required=True)
+    parser.add_argument("--source", default="ticket-office")
+    parser.add_argument("--max-attempts", type=int, default=8)
+    parser.add_argument("--output", default="./out/ticket-qr.png")
+    parser.add_argument("--skip-supabase", action="store_true", help="Allow local-only generation")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    supabase_url = os.getenv("SUPABASE_URL", "")
+    service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
+
+    if not args.skip_supabase and (not supabase_url or not service_role_key):
+        print("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required (or use --skip-supabase).", file=sys.stderr)
+        return 1
+
+    for salt in range(args.max_attempts):
+        payload = build_ticket_payload(args, salt)
+        json_payload = canonical_payload_json(payload)
+        payload_hash = sha256_hex(json_payload)
+
+        reserved = True
+        if not args.skip_supabase:
+            reserved = reserve_hash(
+                supabase_url=supabase_url,
+                service_role_key=service_role_key,
+                payload=payload,
+                payload_hash=payload_hash,
+            )
+
+        if not reserved:
+            continue
+
+        qr_value = f"turni://ticket/{payload_hash}"
+        output_path = pathlib.Path(args.output).resolve()
+        generate_qr_png(qr_value, output_path)
+
+        print(json.dumps(
+            {
+                "hash": payload_hash,
+                "qr_value": qr_value,
+                "json_payload": json_payload,
+                "output": str(output_path),
+                "supabase_reserved": reserved,
+            },
+            indent=2,
+        ))
+        return 0
+
+    print("Unable to reserve a unique hash after max attempts.", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ticket_qr_generator/generate_ticket_qr.py
+++ b/tools/ticket_qr_generator/generate_ticket_qr.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import hashlib
 import json
 import os
 import pathlib
+import re
 import sys
+import unicodedata
 from collections import OrderedDict
 from dataclasses import dataclass
 
@@ -23,6 +26,196 @@ class TicketPayload:
     event_id: str
     ticket_number: str
     date: str
+
+
+@dataclass(frozen=True)
+class CalendarEvent:
+    event_id: str
+    event_name: str
+    event_date: str
+    event_time: str
+    event_datetime_iso: str
+
+
+ITALIAN_MONTHS = {
+    "gen": 1,
+    "gennaio": 1,
+    "feb": 2,
+    "febbraio": 2,
+    "mar": 3,
+    "marzo": 3,
+    "apr": 4,
+    "aprile": 4,
+    "mag": 5,
+    "maggio": 5,
+    "giu": 6,
+    "giugno": 6,
+    "lug": 7,
+    "luglio": 7,
+    "ago": 8,
+    "agosto": 8,
+    "set": 9,
+    "settembre": 9,
+    "ott": 10,
+    "ottobre": 10,
+    "nov": 11,
+    "novembre": 11,
+    "dic": 12,
+    "dicembre": 12,
+    "jan": 1,
+    "january": 1,
+    "february": 2,
+    "march": 3,
+    "apr": 4,
+    "april": 4,
+    "may": 5,
+    "jun": 6,
+    "june": 6,
+    "jul": 7,
+    "july": 7,
+    "aug": 8,
+    "august": 8,
+    "sep": 9,
+    "september": 9,
+    "oct": 10,
+    "october": 10,
+    "nov": 11,
+    "november": 11,
+    "dec": 12,
+    "december": 12,
+}
+
+
+def default_ticket_circuit() -> str:
+    return os.getenv("TICKET_QR_CIRCUIT", "ATCL").strip() or "ATCL"
+
+
+def _normalize_month_token(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_only = normalized.encode("ascii", "ignore").decode("ascii")
+    return ascii_only.lower().strip().strip(".")
+
+
+def _parse_calendar_date(value: str) -> dt.date:
+    raw = value.strip()
+    if not raw:
+        raise ValueError("event_date vuota.")
+
+    try:
+        return dt.date.fromisoformat(raw)
+    except ValueError:
+        pass
+
+    day_month_year = re.fullmatch(r"(\d{1,2})[/-](\d{1,2})[/-](\d{4})", raw)
+    if day_month_year:
+        day, month, year = (int(part) for part in day_month_year.groups())
+        return dt.date(year=year, month=month, day=day)
+
+    text_date = re.fullmatch(r"(\d{1,2})\s+([A-Za-z.]+)\s+(\d{4})", raw)
+    if text_date:
+        day, month_token, year = text_date.groups()
+        month = ITALIAN_MONTHS.get(_normalize_month_token(month_token))
+        if not month:
+            raise ValueError(f"Mese non riconosciuto: {month_token!r}.")
+        return dt.date(year=int(year), month=month, day=int(day))
+
+    raise ValueError(f"Formato data non supportato: {value!r}.")
+
+
+def _parse_calendar_time(value: str) -> dt.time:
+    raw = value.strip()
+    match = re.fullmatch(r"(\d{1,2}):(\d{2})(?::(\d{2}))?", raw)
+    if not match:
+        raise ValueError(f"Formato ora non supportato: {value!r}.")
+    hour = int(match.group(1))
+    minute = int(match.group(2))
+    second = int(match.group(3) or "0")
+    return dt.time(hour=hour, minute=minute, second=second)
+
+
+def event_datetime_iso(event_date: str, event_time: str) -> str:
+    date_value = _parse_calendar_date(event_date)
+    time_value = _parse_calendar_time(event_time)
+    rome = dt.timezone(dt.timedelta(hours=1))
+    event_dt = dt.datetime.combine(date_value, time_value, tzinfo=rome)
+    return event_dt.isoformat(timespec="seconds")
+
+
+def fetch_calendar_events(*, supabase_url: str, api_key: str, timeout_s: int = 15) -> list[CalendarEvent]:
+    endpoint = f"{supabase_url.rstrip('/')}/rest/v1/events"
+    response = requests.get(
+        endpoint,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "apikey": api_key,
+            "Content-Type": "application/json",
+        },
+        params={
+            "select": "id,name,event_date,event_time",
+            "order": "event_date.asc,event_time.asc",
+            "limit": "500",
+        },
+        timeout=timeout_s,
+    )
+    response.raise_for_status()
+    rows = response.json()
+    if not isinstance(rows, list):
+        raise ValueError("Formato risposta calendario non valido.")
+
+    events: list[CalendarEvent] = []
+    for row in rows:
+        event_id = str(row.get("id", "")).strip()
+        event_name = str(row.get("name", "")).strip()
+        event_date = str(row.get("event_date", "")).strip()
+        event_time = str(row.get("event_time", "")).strip()
+        if not all([event_id, event_name, event_date, event_time]):
+            continue
+        events.append(
+            CalendarEvent(
+                event_id=event_id,
+                event_name=event_name,
+                event_date=event_date,
+                event_time=event_time,
+                event_datetime_iso=event_datetime_iso(event_date, event_time),
+            )
+        )
+
+    if not events:
+        raise ValueError("Calendario vuoto o senza eventi validi.")
+
+    events.sort(key=lambda event: event.event_datetime_iso)
+    return events
+
+
+def get_calendar_api_key() -> str:
+    return (
+        os.getenv("SUPABASE_SERVICE_ROLE_KEY", "").strip()
+        or os.getenv("SUPABASE_ANON_KEY", "").strip()
+    )
+
+
+def resolve_payload_from_calendar(
+    *,
+    supabase_url: str,
+    api_key: str,
+    event_id: str,
+    ticket_number: str,
+    circuit: str,
+) -> TicketPayload:
+    normalized_id = event_id.strip()
+    if not normalized_id:
+        raise ValueError("event_id mancante.")
+    events = fetch_calendar_events(supabase_url=supabase_url, api_key=api_key)
+    selected = next((event for event in events if event.event_id.lower() == normalized_id.lower()), None)
+    if not selected:
+        raise ValueError(f"Evento non trovato nel calendario: {event_id!r}.")
+    return TicketPayload(
+        circuit=circuit.strip(),
+        event_name=selected.event_name,
+        event_id=selected.event_id,
+        ticket_number=ticket_number.strip(),
+        date=selected.event_datetime_iso,
+    )
 
 
 def to_payload_dict(payload: TicketPayload) -> OrderedDict[str, str]:
@@ -82,11 +275,16 @@ def generate_qr_png(qr_value: str, output_path: pathlib.Path) -> None:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate one-shot activation QR for Turni di Palco.")
-    parser.add_argument("--circuit", required=True, help="Ticket circuit, e.g. TicketOne")
-    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--circuit", default=default_ticket_circuit(), help="Ticket circuit, e.g. ATCL")
+    parser.add_argument("--event-name")
     parser.add_argument("--event-id", required=True)
     parser.add_argument("--ticket-number", required=True)
-    parser.add_argument("--date", required=True, help="ISO datetime, e.g. 2026-02-11T11:54:00+01:00")
+    parser.add_argument("--date", help="ISO datetime, e.g. 2026-02-11T11:54:00+01:00")
+    parser.add_argument(
+        "--event-from-calendar",
+        action="store_true",
+        help="Load event name/date from Supabase events calendar using --event-id.",
+    )
     parser.add_argument("--output", default="./out/ticket-qr.png")
     parser.add_argument("--skip-supabase", action="store_true", help="Allow local-only generation")
     return parser.parse_args()
@@ -94,13 +292,38 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    payload = TicketPayload(
-        circuit=args.circuit.strip(),
-        event_name=args.event_name.strip(),
-        event_id=args.event_id.strip(),
-        ticket_number=args.ticket_number.strip(),
-        date=args.date.strip(),
-    )
+
+    supabase_url = os.getenv("SUPABASE_URL", "")
+    service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
+    calendar_api_key = get_calendar_api_key()
+
+    try:
+        if args.event_from_calendar:
+            if not supabase_url or not calendar_api_key:
+                print(
+                    "SUPABASE_URL and a Supabase API key (SUPABASE_SERVICE_ROLE_KEY or SUPABASE_ANON_KEY) "
+                    "are required with --event-from-calendar.",
+                    file=sys.stderr,
+                )
+                return 1
+            payload = resolve_payload_from_calendar(
+                supabase_url=supabase_url,
+                api_key=calendar_api_key,
+                event_id=args.event_id,
+                ticket_number=args.ticket_number,
+                circuit=args.circuit,
+            )
+        else:
+            payload = TicketPayload(
+                circuit=args.circuit.strip(),
+                event_name=(args.event_name or "").strip(),
+                event_id=args.event_id.strip(),
+                ticket_number=args.ticket_number.strip(),
+                date=(args.date or "").strip(),
+            )
+    except Exception as error:
+        print(str(error), file=sys.stderr)
+        return 1
 
     if not all([payload.circuit, payload.event_name, payload.event_id, payload.ticket_number, payload.date]):
         print("All fields are required.", file=sys.stderr)
@@ -108,9 +331,6 @@ def main() -> int:
 
     canonical_json = canonical_payload_json(payload)
     payload_hash = sha256_hex(canonical_json)
-
-    supabase_url = os.getenv("SUPABASE_URL", "")
-    service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
 
     if not args.skip_supabase and (not supabase_url or not service_role_key):
         print("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required (or use --skip-supabase).", file=sys.stderr)

--- a/tools/ticket_qr_generator/generate_ticket_qr.py
+++ b/tools/ticket_qr_generator/generate_ticket_qr.py
@@ -38,6 +38,11 @@ def to_payload_dict(payload: TicketPayload) -> OrderedDict[str, str]:
 
 
 def canonical_payload_json(payload: TicketPayload) -> str:
+    # Match browser JSON.stringify output exactly for cross-platform hash parity.
+    return json.dumps(to_payload_dict(payload), ensure_ascii=False, separators=(",", ":"))
+
+
+def pretty_payload_json(payload: TicketPayload) -> str:
     return json.dumps(to_payload_dict(payload), ensure_ascii=False, indent=2)
 
 
@@ -101,8 +106,8 @@ def main() -> int:
         print("All fields are required.", file=sys.stderr)
         return 1
 
-    json_payload = canonical_payload_json(payload)
-    payload_hash = sha256_hex(json_payload)
+    canonical_json = canonical_payload_json(payload)
+    payload_hash = sha256_hex(canonical_json)
 
     supabase_url = os.getenv("SUPABASE_URL", "")
     service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
@@ -133,7 +138,8 @@ def main() -> int:
             {
                 "hash": payload_hash,
                 "qr_value": qr_value,
-                "json_payload": json_payload,
+                "json_payload": pretty_payload_json(payload),
+                "canonical_json": canonical_json,
                 "output": str(output_path),
                 "supabase_reserved": reserved,
             },

--- a/tools/ticket_qr_generator/requirements.txt
+++ b/tools/ticket_qr_generator/requirements.txt
@@ -1,0 +1,2 @@
+qrcode[pil]==7.4.2
+requests==2.32.3

--- a/tools/ticket_qr_generator/requirements.txt
+++ b/tools/ticket_qr_generator/requirements.txt
@@ -1,2 +1,3 @@
-qrcode[pil]==7.4.2
-requests==2.32.3
+qrcode[pil]
+requests
+python-dotenv

--- a/tools/ticket_qr_generator/ticket_qr_generator_ui.py
+++ b/tools/ticket_qr_generator/ticket_qr_generator_ui.py
@@ -53,18 +53,18 @@ COLOR_TEXT_MUTED = "#aab4d3"
 COLOR_ACCENT = "#4c7dff"
 COLOR_ACCENT_HOVER = "#3a69e3"
 COLOR_SUCCESS = "#2ea97d"
-INPUT_FONT = ("Segoe UI", 10)
-TITLE_FONT = ("Segoe UI Semibold", 19)
-SUBTITLE_FONT = ("Segoe UI", 10)
-SECTION_TITLE_FONT = ("Segoe UI Semibold", 11)
+INPUT_FONT = ("TkDefaultFont", 10)
+TITLE_FONT = ("TkDefaultFont", 20, "bold")
+SUBTITLE_FONT = ("TkDefaultFont", 10)
+SECTION_TITLE_FONT = ("TkDefaultFont", 11, "bold")
 
 
 class TicketQrGeneratorUI:
     def __init__(self, root: tk.Tk):
         self.root = root
         self.root.title("Turni di Palco - Generatore QR Biglietteria")
-        self.root.geometry("980x820")
-        self.root.minsize(920, 760)
+        self.root.geometry("1240x760")
+        self.root.minsize(980, 680)
 
         supabase_url = os.getenv("SUPABASE_URL", "").strip()
         service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "").strip()
@@ -130,7 +130,7 @@ class TicketQrGeneratorUI:
             pass
 
         self.root.configure(bg=COLOR_APP_BG)
-        self.root.option_add("*Font", "Segoe UI 10")
+        self.root.option_add("*Font", "TkDefaultFont 10")
         self.root.option_add("*TCombobox*Listbox.background", COLOR_INPUT_BG)
         self.root.option_add("*TCombobox*Listbox.foreground", COLOR_TEXT)
         self.root.option_add("*TCombobox*Listbox.selectBackground", COLOR_ACCENT)
@@ -144,14 +144,14 @@ class TicketQrGeneratorUI:
             "HeaderKicker.TLabel",
             background=COLOR_APP_BG,
             foreground=COLOR_ACCENT,
-            font=("Segoe UI Semibold", 9),
+            font=("TkDefaultFont", 9, "bold"),
         )
         style.configure("HeaderTitle.TLabel", background=COLOR_APP_BG, foreground=COLOR_TEXT, font=TITLE_FONT)
         style.configure("HeaderSubtitle.TLabel", background=COLOR_APP_BG, foreground=COLOR_TEXT_MUTED, font=SUBTITLE_FONT)
         style.configure("CardTitle.TLabel", background=COLOR_CARD_BG, foreground=COLOR_TEXT, font=SECTION_TITLE_FONT)
         style.configure("CardHint.TLabel", background=COLOR_CARD_BG, foreground=COLOR_TEXT_MUTED, font=SUBTITLE_FONT)
         style.configure("FieldLabel.TLabel", background=COLOR_CARD_BG, foreground=COLOR_TEXT_MUTED, font=INPUT_FONT)
-        style.configure("Status.TLabel", background=COLOR_CARD_BG, foreground=COLOR_SUCCESS, font=("Segoe UI", 9))
+        style.configure("Status.TLabel", background=COLOR_CARD_BG, foreground=COLOR_SUCCESS, font=("TkDefaultFont", 9))
         style.configure("Preview.TLabel", background=COLOR_INPUT_BG, foreground=COLOR_TEXT_MUTED, font=SUBTITLE_FONT)
 
         style.configure(
@@ -161,7 +161,7 @@ class TicketQrGeneratorUI:
             borderwidth=0,
             relief="flat",
             padding=(16, 9),
-            font=("Segoe UI Semibold", 10),
+            font=("TkDefaultFont", 10, "bold"),
         )
         style.map(
             "Primary.TButton",
@@ -176,14 +176,19 @@ class TicketQrGeneratorUI:
             lightcolor=COLOR_BORDER,
             darkcolor=COLOR_BORDER,
             padding=(12, 8),
-            font=("Segoe UI", 9),
+            font=("TkDefaultFont", 9),
         )
         style.map(
             "Secondary.TButton",
             background=[("active", "#273252"), ("pressed", "#273252")],
             foreground=[("active", COLOR_TEXT), ("pressed", COLOR_TEXT)],
         )
-        style.configure("Card.TCheckbutton", background=COLOR_CARD_BG, foreground=COLOR_TEXT, font=("Segoe UI", 9))
+        style.configure("Card.TCheckbutton", background=COLOR_CARD_BG, foreground=COLOR_TEXT, font=("TkDefaultFont", 9))
+        style.map(
+            "Card.TCheckbutton",
+            background=[("active", COLOR_CARD_BG), ("focus", COLOR_CARD_BG)],
+            foreground=[("active", COLOR_TEXT), ("focus", COLOR_TEXT)],
+        )
 
         style.configure(
             "Value.TEntry",
@@ -218,21 +223,23 @@ class TicketQrGeneratorUI:
             selectforeground=[("readonly", COLOR_TEXT)],
         )
 
-    def _build_card(self, parent: ttk.Frame, title: str, hint: str | None = None) -> ttk.Frame:
+    def _build_card(self, parent: ttk.Frame, title: str, hint: str | None = None, *, expand: bool = False) -> ttk.Frame:
         card = ttk.Frame(parent, style="Card.TFrame", padding=16)
-        card.pack(fill="x", pady=(0, 12))
+        card.pack(fill="both" if expand else "x", expand=expand, pady=(0, 12))
         ttk.Label(card, text=title, style="CardTitle.TLabel").pack(anchor="w")
         if hint:
             ttk.Label(card, text=hint, style="CardHint.TLabel").pack(anchor="w", pady=(2, 10))
         content = ttk.Frame(card, style="Card.TFrame")
-        content.pack(fill="x")
+        content.pack(fill="both", expand=True)
         return content
 
-    def _build_field_row(self, parent: ttk.Frame, label: str) -> ttk.Frame:
+    def _build_field_row(self, parent: ttk.Frame, label: str) -> tuple[ttk.Frame, ttk.Frame]:
         row = ttk.Frame(parent, style="Card.TFrame")
         row.pack(fill="x", pady=4)
         ttk.Label(row, text=label, width=16, style="FieldLabel.TLabel").pack(side="left")
-        return row
+        field_container = ttk.Frame(row, style="Card.TFrame")
+        field_container.pack(side="left", fill="x", expand=True)
+        return row, field_container
 
     def _initial_circuit(self) -> str:
         configured = self._load_saved_circuit()
@@ -271,40 +278,52 @@ class TicketQrGeneratorUI:
             style="HeaderSubtitle.TLabel",
         ).pack(anchor="w", pady=(4, 0))
 
+        columns_container = ttk.Frame(frame, style="App.TFrame")
+        columns_container.pack(fill="both", expand=True)
+        columns_container.columnconfigure(0, weight=1, uniform="layout")
+        columns_container.columnconfigure(1, weight=1, uniform="layout")
+        columns_container.rowconfigure(0, weight=1)
+
+        left_column = ttk.Frame(columns_container, style="App.TFrame")
+        left_column.grid(row=0, column=0, sticky="nsew", padx=(0, 8))
+        right_column = ttk.Frame(columns_container, style="App.TFrame")
+        right_column.grid(row=0, column=1, sticky="nsew", padx=(8, 0))
+
         setup_card = self._build_card(
-            frame,
+            left_column,
             "Dati ticket",
             "Il circuito e predefinito. Evento e dati principali arrivano dal calendario.",
+            expand=True,
         )
 
-        event_row = self._build_field_row(setup_card, "Evento")
+        event_row, event_field = self._build_field_row(setup_card, "Evento")
         self.calendar_combo = ttk.Combobox(
-            event_row,
+            event_field,
             textvariable=self.calendar_event_var,
             state="readonly",
             style="Value.TCombobox",
         )
-        self.calendar_combo.pack(side="left", fill="x", expand=True)
+        self.calendar_combo.pack(fill="x", expand=True, side="left")
         self.calendar_combo.bind("<<ComboboxSelected>>", self._on_calendar_selected)
         ttk.Button(
             event_row,
             text="Aggiorna calendario",
             command=self._load_calendar_events,
             style="Secondary.TButton",
-        ).pack(side="left", padx=8)
+        ).pack(side="left", padx=(8, 0))
 
         ttk.Label(setup_card, textvariable=self.calendar_status_var, style="Status.TLabel").pack(anchor="w", pady=(2, 8))
 
-        circuit_row = self._build_field_row(setup_card, "Circuito")
-        ttk.Entry(circuit_row, textvariable=self.circuit_var, state="readonly", style="Value.TEntry").pack(
-            side="left", fill="x", expand=True
+        circuit_row, circuit_field = self._build_field_row(setup_card, "Circuito")
+        ttk.Entry(circuit_field, textvariable=self.circuit_var, state="readonly", style="Value.TEntry").pack(
+            fill="x", expand=True, side="left"
         )
         ttk.Button(
             circuit_row,
             text="Impostazioni circuito",
             command=self._open_circuit_settings,
             style="Secondary.TButton",
-        ).pack(side="left", padx=8)
+        ).pack(side="left", padx=(8, 0))
 
         readonly_fields = [
             ("Nome evento", self.event_name_var),
@@ -312,15 +331,15 @@ class TicketQrGeneratorUI:
             ("Data (ISO)", self.date_var),
         ]
         for label, var in readonly_fields:
-            row = self._build_field_row(setup_card, label)
-            ttk.Entry(row, textvariable=var, state="readonly", style="Value.TEntry").pack(side="left", fill="x", expand=True)
+            _, row_field = self._build_field_row(setup_card, label)
+            ttk.Entry(row_field, textvariable=var, state="readonly", style="Value.TEntry").pack(fill="x", expand=True)
 
-        ticket_row = self._build_field_row(setup_card, "Numero biglietto")
-        ttk.Entry(ticket_row, textvariable=self.ticket_number_var, style="Value.TEntry").pack(side="left", fill="x", expand=True)
+        _, ticket_field = self._build_field_row(setup_card, "Numero biglietto")
+        ttk.Entry(ticket_field, textvariable=self.ticket_number_var, style="Value.TEntry").pack(fill="x", expand=True)
 
-        output_row = self._build_field_row(setup_card, "File output")
-        ttk.Entry(output_row, textvariable=self.output_var, style="Value.TEntry").pack(side="left", fill="x", expand=True)
-        ttk.Button(output_row, text="Sfoglia", command=self._pick_output, style="Secondary.TButton").pack(side="left", padx=8)
+        output_row, output_field = self._build_field_row(setup_card, "File output")
+        ttk.Entry(output_field, textvariable=self.output_var, style="Value.TEntry").pack(fill="x", expand=True, side="left")
+        ttk.Button(output_row, text="Sfoglia", command=self._pick_output, style="Secondary.TButton").pack(side="left", padx=(8, 0))
 
         ttk.Checkbutton(
             setup_card,
@@ -331,12 +350,13 @@ class TicketQrGeneratorUI:
 
         button_row = ttk.Frame(setup_card, style="Card.TFrame")
         button_row.pack(fill="x", pady=(0, 2))
-        ttk.Button(button_row, text="Genera e Prenota QR", command=self._generate, style="Primary.TButton").pack(side="left")
+        ttk.Button(button_row, text="Genera e Prenota QR", command=self._generate, style="Primary.TButton").pack(anchor="w")
 
         result_card = self._build_card(
-            frame,
+            right_column,
             "Output QR",
             "Controlla JSON, hash e anteprima prima di distribuire il biglietto.",
+            expand=True,
         )
         ttk.Label(result_card, text="JSON generato", style="FieldLabel.TLabel").pack(anchor="w", pady=(0, 4))
         self.json_box = tk.Text(
@@ -360,7 +380,7 @@ class TicketQrGeneratorUI:
 
         ttk.Label(result_card, text="Anteprima QR", style="FieldLabel.TLabel").pack(anchor="w", pady=(8, 4))
         preview_container = ttk.Frame(result_card, style="Preview.TFrame", padding=8)
-        preview_container.pack(anchor="w")
+        preview_container.pack(fill="x", pady=4)
         self.qr_preview_label = ttk.Label(
             preview_container,
             text="Nessun QR generato",
@@ -368,7 +388,7 @@ class TicketQrGeneratorUI:
             anchor="center",
             padding=2,
         )
-        self.qr_preview_label.pack()
+        self.qr_preview_label.pack(fill="both", expand=True)
 
     def _pick_output(self) -> None:
         selected = filedialog.asksaveasfilename(
@@ -558,7 +578,11 @@ class TicketQrGeneratorUI:
             self.json_box.insert(tk.END, pretty_payload_json(payload))
             self.hash_var.set(payload_hash)
 
-            image = Image.open(output_path).resize((240, 240))
+            # Resize QR code to fit container while maintaining aspect ratio
+            image = Image.open(output_path)
+            # Calculate appropriate size based on container width
+            max_size = 250  # Larger size for two-column layout
+            image.thumbnail((max_size, max_size), Image.Resampling.LANCZOS)
             self.preview_image = ImageTk.PhotoImage(image)
             self.qr_preview_label.configure(image=self.preview_image, text="")
 

--- a/tools/ticket_qr_generator/ticket_qr_generator_ui.py
+++ b/tools/ticket_qr_generator/ticket_qr_generator_ui.py
@@ -11,9 +11,13 @@ from tkinter import filedialog, messagebox, ttk
 from PIL import Image, ImageTk
 
 from generate_ticket_qr import (
+    CalendarEvent,
     TicketPayload,
     canonical_payload_json,
+    default_ticket_circuit,
+    fetch_calendar_events,
     generate_qr_png,
+    get_calendar_api_key,
     pretty_payload_json,
     reserve_hash,
     sha256_hex,
@@ -24,19 +28,23 @@ class TicketQrGeneratorUI:
     def __init__(self, root: tk.Tk):
         self.root = root
         self.root.title("Turni di Palco - Generatore QR Biglietteria")
-        self.root.geometry("860x720")
+        self.root.geometry("900x760")
 
-        self.circuit_var = tk.StringVar(value="TicketOne")
-        self.event_name_var = tk.StringVar(value="Esempio")
-        self.event_id_var = tk.StringVar(value="1234567890")
+        self.circuit_var = tk.StringVar(value=default_ticket_circuit())
+        self.calendar_event_var = tk.StringVar(value="")
+        self.event_name_var = tk.StringVar(value="-")
+        self.event_id_var = tk.StringVar(value="-")
+        self.date_var = tk.StringVar(value="-")
         self.ticket_number_var = tk.StringVar(value="1234567890")
-        self.date_var = tk.StringVar(value="2026-02-11T11:54:00+01:00")
         self.skip_supabase_var = tk.BooleanVar(value=True)
         self.output_var = tk.StringVar(value=str(pathlib.Path("./out/ticket-qr.png").resolve()))
+        self.calendar_status_var = tk.StringVar(value="Calendario non caricato.")
+        self.calendar_events: list[CalendarEvent] = []
 
         self.preview_image: ImageTk.PhotoImage | None = None
 
         self._build_layout()
+        self.root.after(50, lambda: self._load_calendar_events(show_errors=False))
 
     def _build_layout(self) -> None:
         frame = ttk.Frame(self.root, padding=16)
@@ -44,23 +52,41 @@ class TicketQrGeneratorUI:
 
         ttk.Label(
             frame,
-            text="Compila i dati del biglietto e premi 'Genera QR'.",
+            text="Seleziona evento da calendario, inserisci il numero biglietto e genera il QR.",
             font=("Arial", 12, "bold"),
         ).pack(anchor="w", pady=(0, 12))
 
-        fields = [
+        event_row = ttk.Frame(frame)
+        event_row.pack(fill="x", pady=4)
+        ttk.Label(event_row, text="Evento", width=16).pack(side="left")
+        self.calendar_combo = ttk.Combobox(
+            event_row,
+            textvariable=self.calendar_event_var,
+            state="readonly",
+        )
+        self.calendar_combo.pack(side="left", fill="x", expand=True)
+        self.calendar_combo.bind("<<ComboboxSelected>>", self._on_calendar_selected)
+        ttk.Button(event_row, text="Aggiorna calendario", command=self._load_calendar_events).pack(side="left", padx=8)
+
+        ttk.Label(frame, textvariable=self.calendar_status_var).pack(anchor="w", pady=(2, 6))
+
+        readonly_fields = [
             ("Circuito", self.circuit_var),
             ("Nome evento", self.event_name_var),
             ("ID evento", self.event_id_var),
-            ("Numero biglietto", self.ticket_number_var),
             ("Data (ISO)", self.date_var),
         ]
 
-        for label, var in fields:
+        for label, var in readonly_fields:
             row = ttk.Frame(frame)
             row.pack(fill="x", pady=4)
             ttk.Label(row, text=label, width=16).pack(side="left")
-            ttk.Entry(row, textvariable=var).pack(side="left", fill="x", expand=True)
+            ttk.Entry(row, textvariable=var, state="readonly").pack(side="left", fill="x", expand=True)
+
+        ticket_row = ttk.Frame(frame)
+        ticket_row.pack(fill="x", pady=4)
+        ttk.Label(ticket_row, text="Numero biglietto", width=16).pack(side="left")
+        ttk.Entry(ticket_row, textvariable=self.ticket_number_var).pack(side="left", fill="x", expand=True)
 
         output_row = ttk.Frame(frame)
         output_row.pack(fill="x", pady=(8, 4))
@@ -70,7 +96,7 @@ class TicketQrGeneratorUI:
 
         ttk.Checkbutton(
             frame,
-            text="Modalità locale (non chiama Supabase)",
+            text="Modalita locale (non prenota hash su Supabase)",
             variable=self.skip_supabase_var,
         ).pack(anchor="w", pady=(8, 8))
 
@@ -99,13 +125,72 @@ class TicketQrGeneratorUI:
         if selected:
             self.output_var.set(selected)
 
+    def _load_calendar_events(self, show_errors: bool = True) -> None:
+        try:
+            supabase_url = os.getenv("SUPABASE_URL", "").strip()
+            api_key = get_calendar_api_key()
+            if not supabase_url or not api_key:
+                raise ValueError(
+                    "Imposta SUPABASE_URL e una chiave API Supabase "
+                    "(SUPABASE_SERVICE_ROLE_KEY o SUPABASE_ANON_KEY) per leggere il calendario."
+                )
+
+            current_event_id = self.event_id_var.get().strip()
+            events = fetch_calendar_events(supabase_url=supabase_url, api_key=api_key)
+            options = [
+                f"{event.event_date} {event.event_time} | {event.event_id} | {event.event_name}"
+                for event in events
+            ]
+            selected_index = next(
+                (index for index, event in enumerate(events) if event.event_id == current_event_id),
+                0,
+            )
+
+            self.calendar_events = events
+            self.calendar_combo.configure(values=options)
+            self.calendar_combo.current(selected_index)
+            self._set_selected_event(events[selected_index])
+            self.calendar_status_var.set(f"Calendario caricato: {len(events)} eventi.")
+        except Exception as error:
+            self.calendar_events = []
+            self.calendar_combo.configure(values=[])
+            self.calendar_event_var.set("")
+            self.event_name_var.set("-")
+            self.event_id_var.set("-")
+            self.date_var.set("-")
+            self.calendar_status_var.set("Calendario non disponibile.")
+            if show_errors:
+                messagebox.showerror("Errore calendario", str(error))
+
+    def _on_calendar_selected(self, _event: object | None = None) -> None:
+        if not self.calendar_events:
+            return
+        selected_index = self.calendar_combo.current()
+        if selected_index < 0 or selected_index >= len(self.calendar_events):
+            return
+        self._set_selected_event(self.calendar_events[selected_index])
+
+    def _set_selected_event(self, event: CalendarEvent) -> None:
+        self.event_name_var.set(event.event_name)
+        self.event_id_var.set(event.event_id)
+        self.date_var.set(event.event_datetime_iso)
+
+    def _selected_calendar_event(self) -> CalendarEvent:
+        if not self.calendar_events:
+            raise ValueError("Calendario eventi non caricato.")
+        selected_index = self.calendar_combo.current()
+        if selected_index < 0 or selected_index >= len(self.calendar_events):
+            raise ValueError("Seleziona un evento dal calendario.")
+        return self.calendar_events[selected_index]
+
     def _build_payload(self) -> TicketPayload:
+        selected_event = self._selected_calendar_event()
         payload = TicketPayload(
             circuit=self.circuit_var.get().strip(),
-            event_name=self.event_name_var.get().strip(),
-            event_id=self.event_id_var.get().strip(),
+            event_name=selected_event.event_name.strip(),
+            event_id=selected_event.event_id.strip(),
             ticket_number=self.ticket_number_var.get().strip(),
-            date=self.date_var.get().strip(),
+            date=selected_event.event_datetime_iso.strip(),
         )
         if not all([payload.circuit, payload.event_name, payload.event_id, payload.ticket_number, payload.date]):
             raise ValueError("Tutti i campi sono obbligatori.")
@@ -121,7 +206,9 @@ class TicketQrGeneratorUI:
                 supabase_url = os.getenv("SUPABASE_URL", "")
                 service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
                 if not supabase_url or not service_role_key:
-                    raise ValueError("Imposta SUPABASE_URL e SUPABASE_SERVICE_ROLE_KEY o abilita modalità locale.")
+                    raise ValueError(
+                        "Imposta SUPABASE_URL e SUPABASE_SERVICE_ROLE_KEY oppure abilita la modalita locale."
+                    )
 
                 reserved = reserve_hash(
                     supabase_url=supabase_url,
@@ -130,7 +217,7 @@ class TicketQrGeneratorUI:
                     payload_hash=payload_hash,
                 )
                 if not reserved:
-                    raise ValueError("Hash già presente su Supabase. Verifica i dati del ticket.")
+                    raise ValueError("Hash gia presente su Supabase. Verifica i dati del ticket.")
 
             qr_value = f"turni://ticket/{payload_hash}"
             output_path = pathlib.Path(self.output_var.get()).resolve()

--- a/tools/ticket_qr_generator/ticket_qr_generator_ui.py
+++ b/tools/ticket_qr_generator/ticket_qr_generator_ui.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import pathlib
 import tkinter as tk
@@ -28,17 +29,49 @@ from generate_ticket_qr import (
 )
 
 
+SETTINGS_PATH = pathlib.Path(os.getenv("TICKET_QR_UI_SETTINGS_PATH", "~/.turni_ticket_qr_ui.json")).expanduser()
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+DEFAULT_CIRCUIT_OPTIONS = [
+    "TicketOne",
+    "Vivaticket",
+    "Ciaotickets",
+    "DIY ticketing",
+]
+CIRCUIT_OPTIONS_PATH = pathlib.Path(
+    os.getenv("TICKET_QR_CIRCUITS_PATH", str(SCRIPT_DIR / "circuit_options.json"))
+).expanduser()
+
+ENV_CIRCUIT_OPTIONS = "TICKET_QR_CIRCUITS"
+CUSTOM_CIRCUIT_OPTION = "Altro (manuale)"
+
+COLOR_APP_BG = "#0f1320"
+COLOR_CARD_BG = "#161d2f"
+COLOR_INPUT_BG = "#1e2740"
+COLOR_BORDER = "#2c3654"
+COLOR_TEXT = "#f1f5ff"
+COLOR_TEXT_MUTED = "#aab4d3"
+COLOR_ACCENT = "#4c7dff"
+COLOR_ACCENT_HOVER = "#3a69e3"
+COLOR_SUCCESS = "#2ea97d"
+INPUT_FONT = ("Segoe UI", 10)
+TITLE_FONT = ("Segoe UI Semibold", 19)
+SUBTITLE_FONT = ("Segoe UI", 10)
+SECTION_TITLE_FONT = ("Segoe UI Semibold", 11)
+
+
 class TicketQrGeneratorUI:
     def __init__(self, root: tk.Tk):
         self.root = root
         self.root.title("Turni di Palco - Generatore QR Biglietteria")
-        self.root.geometry("900x760")
+        self.root.geometry("980x820")
+        self.root.minsize(920, 760)
 
         supabase_url = os.getenv("SUPABASE_URL", "").strip()
         service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "").strip()
         has_creds = bool(supabase_url and service_role_key)
+        self.circuit_options = self._load_circuit_options()
 
-        self.circuit_var = tk.StringVar(value=default_ticket_circuit())
+        self.circuit_var = tk.StringVar(value=self._initial_circuit())
         self.calendar_event_var = tk.StringVar(value="")
         self.event_name_var = tk.StringVar(value="-")
         self.event_id_var = tk.StringVar(value="-")
@@ -47,82 +80,295 @@ class TicketQrGeneratorUI:
         self.skip_supabase_var = tk.BooleanVar(value=not has_creds)
         self.output_var = tk.StringVar(value=str(pathlib.Path("./out/ticket-qr.png").resolve()))
         self.calendar_status_var = tk.StringVar(value="Calendario non caricato.")
+        self.hash_var = tk.StringVar(value="-")
         self.calendar_events: list[CalendarEvent] = []
 
         self.preview_image: ImageTk.PhotoImage | None = None
 
+        self._configure_theme()
         self._build_layout()
         self.root.after(50, lambda: self._load_calendar_events(show_errors=False))
 
+    def _normalize_circuit_options(self, values: list[object]) -> list[str]:
+        seen: set[str] = set()
+        normalized: list[str] = []
+        for raw_value in values:
+            value = str(raw_value).strip()
+            key = value.lower()
+            if not value or key in seen:
+                continue
+            seen.add(key)
+            normalized.append(value)
+        return normalized
+
+    def _load_circuit_options(self) -> list[str]:
+        env_value = os.getenv(ENV_CIRCUIT_OPTIONS, "").strip()
+        if env_value:
+            env_options = self._normalize_circuit_options(env_value.split(","))
+            if env_options:
+                return env_options
+
+        if CIRCUIT_OPTIONS_PATH.exists():
+            try:
+                raw = json.loads(CIRCUIT_OPTIONS_PATH.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                raw = None
+            if isinstance(raw, dict):
+                raw = raw.get("circuits")
+            if isinstance(raw, list):
+                file_options = self._normalize_circuit_options(raw)
+                if file_options:
+                    return file_options
+
+        return list(DEFAULT_CIRCUIT_OPTIONS)
+
+    def _configure_theme(self) -> None:
+        style = ttk.Style(self.root)
+        try:
+            style.theme_use("clam")
+        except tk.TclError:
+            pass
+
+        self.root.configure(bg=COLOR_APP_BG)
+        self.root.option_add("*Font", "Segoe UI 10")
+        self.root.option_add("*TCombobox*Listbox.background", COLOR_INPUT_BG)
+        self.root.option_add("*TCombobox*Listbox.foreground", COLOR_TEXT)
+        self.root.option_add("*TCombobox*Listbox.selectBackground", COLOR_ACCENT)
+        self.root.option_add("*TCombobox*Listbox.selectForeground", "#ffffff")
+
+        style.configure("App.TFrame", background=COLOR_APP_BG)
+        style.configure("Card.TFrame", background=COLOR_CARD_BG)
+        style.configure("Preview.TFrame", background=COLOR_INPUT_BG, borderwidth=1, relief="solid")
+
+        style.configure(
+            "HeaderKicker.TLabel",
+            background=COLOR_APP_BG,
+            foreground=COLOR_ACCENT,
+            font=("Segoe UI Semibold", 9),
+        )
+        style.configure("HeaderTitle.TLabel", background=COLOR_APP_BG, foreground=COLOR_TEXT, font=TITLE_FONT)
+        style.configure("HeaderSubtitle.TLabel", background=COLOR_APP_BG, foreground=COLOR_TEXT_MUTED, font=SUBTITLE_FONT)
+        style.configure("CardTitle.TLabel", background=COLOR_CARD_BG, foreground=COLOR_TEXT, font=SECTION_TITLE_FONT)
+        style.configure("CardHint.TLabel", background=COLOR_CARD_BG, foreground=COLOR_TEXT_MUTED, font=SUBTITLE_FONT)
+        style.configure("FieldLabel.TLabel", background=COLOR_CARD_BG, foreground=COLOR_TEXT_MUTED, font=INPUT_FONT)
+        style.configure("Status.TLabel", background=COLOR_CARD_BG, foreground=COLOR_SUCCESS, font=("Segoe UI", 9))
+        style.configure("Preview.TLabel", background=COLOR_INPUT_BG, foreground=COLOR_TEXT_MUTED, font=SUBTITLE_FONT)
+
+        style.configure(
+            "Primary.TButton",
+            background=COLOR_ACCENT,
+            foreground="#ffffff",
+            borderwidth=0,
+            relief="flat",
+            padding=(16, 9),
+            font=("Segoe UI Semibold", 10),
+        )
+        style.map(
+            "Primary.TButton",
+            background=[("active", COLOR_ACCENT_HOVER), ("pressed", COLOR_ACCENT_HOVER), ("disabled", "#5f6780")],
+            foreground=[("disabled", "#dde4ff")],
+        )
+        style.configure(
+            "Secondary.TButton",
+            background=COLOR_INPUT_BG,
+            foreground=COLOR_TEXT,
+            bordercolor=COLOR_BORDER,
+            lightcolor=COLOR_BORDER,
+            darkcolor=COLOR_BORDER,
+            padding=(12, 8),
+            font=("Segoe UI", 9),
+        )
+        style.map(
+            "Secondary.TButton",
+            background=[("active", "#273252"), ("pressed", "#273252")],
+            foreground=[("active", COLOR_TEXT), ("pressed", COLOR_TEXT)],
+        )
+        style.configure("Card.TCheckbutton", background=COLOR_CARD_BG, foreground=COLOR_TEXT, font=("Segoe UI", 9))
+
+        style.configure(
+            "Value.TEntry",
+            fieldbackground=COLOR_INPUT_BG,
+            foreground=COLOR_TEXT,
+            bordercolor=COLOR_BORDER,
+            lightcolor=COLOR_BORDER,
+            darkcolor=COLOR_BORDER,
+            padding=6,
+        )
+        style.map(
+            "Value.TEntry",
+            fieldbackground=[("readonly", COLOR_INPUT_BG)],
+            foreground=[("readonly", COLOR_TEXT)],
+        )
+        style.configure(
+            "Value.TCombobox",
+            fieldbackground=COLOR_INPUT_BG,
+            background=COLOR_INPUT_BG,
+            foreground=COLOR_TEXT,
+            bordercolor=COLOR_BORDER,
+            lightcolor=COLOR_BORDER,
+            darkcolor=COLOR_BORDER,
+            arrowsize=14,
+            padding=5,
+        )
+        style.map(
+            "Value.TCombobox",
+            fieldbackground=[("readonly", COLOR_INPUT_BG)],
+            foreground=[("readonly", COLOR_TEXT)],
+            selectbackground=[("readonly", COLOR_INPUT_BG)],
+            selectforeground=[("readonly", COLOR_TEXT)],
+        )
+
+    def _build_card(self, parent: ttk.Frame, title: str, hint: str | None = None) -> ttk.Frame:
+        card = ttk.Frame(parent, style="Card.TFrame", padding=16)
+        card.pack(fill="x", pady=(0, 12))
+        ttk.Label(card, text=title, style="CardTitle.TLabel").pack(anchor="w")
+        if hint:
+            ttk.Label(card, text=hint, style="CardHint.TLabel").pack(anchor="w", pady=(2, 10))
+        content = ttk.Frame(card, style="Card.TFrame")
+        content.pack(fill="x")
+        return content
+
+    def _build_field_row(self, parent: ttk.Frame, label: str) -> ttk.Frame:
+        row = ttk.Frame(parent, style="Card.TFrame")
+        row.pack(fill="x", pady=4)
+        ttk.Label(row, text=label, width=16, style="FieldLabel.TLabel").pack(side="left")
+        return row
+
+    def _initial_circuit(self) -> str:
+        configured = self._load_saved_circuit()
+        if configured:
+            return configured
+        return default_ticket_circuit()
+
+    def _load_saved_circuit(self) -> str:
+        if not SETTINGS_PATH.exists():
+            return ""
+        try:
+            payload = json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return ""
+        value = str(payload.get("default_circuit", "")).strip()
+        return value
+
+    def _save_circuit_setting(self, circuit: str) -> None:
+        SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        SETTINGS_PATH.write_text(
+            json.dumps({"default_circuit": circuit}, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
     def _build_layout(self) -> None:
-        frame = ttk.Frame(self.root, padding=16)
+        frame = ttk.Frame(self.root, padding=18, style="App.TFrame")
         frame.pack(fill="both", expand=True)
 
+        header = ttk.Frame(frame, style="App.TFrame")
+        header.pack(fill="x", pady=(0, 14))
+        ttk.Label(header, text="TURNI DI PALCO", style="HeaderKicker.TLabel").pack(anchor="w")
+        ttk.Label(header, text="Generatore QR Biglietteria", style="HeaderTitle.TLabel").pack(anchor="w", pady=(2, 0))
         ttk.Label(
-            frame,
-            text="Seleziona evento da calendario, inserisci il numero biglietto e genera il QR.",
-            font=("Arial", 12, "bold"),
-        ).pack(anchor="w", pady=(0, 12))
+            header,
+            text="Seleziona evento, inserisci il numero biglietto e genera il QR pronto per la scansione.",
+            style="HeaderSubtitle.TLabel",
+        ).pack(anchor="w", pady=(4, 0))
 
-        event_row = ttk.Frame(frame)
-        event_row.pack(fill="x", pady=4)
-        ttk.Label(event_row, text="Evento", width=16).pack(side="left")
+        setup_card = self._build_card(
+            frame,
+            "Dati ticket",
+            "Il circuito e predefinito. Evento e dati principali arrivano dal calendario.",
+        )
+
+        event_row = self._build_field_row(setup_card, "Evento")
         self.calendar_combo = ttk.Combobox(
             event_row,
             textvariable=self.calendar_event_var,
             state="readonly",
+            style="Value.TCombobox",
         )
         self.calendar_combo.pack(side="left", fill="x", expand=True)
         self.calendar_combo.bind("<<ComboboxSelected>>", self._on_calendar_selected)
-        ttk.Button(event_row, text="Aggiorna calendario", command=self._load_calendar_events).pack(side="left", padx=8)
+        ttk.Button(
+            event_row,
+            text="Aggiorna calendario",
+            command=self._load_calendar_events,
+            style="Secondary.TButton",
+        ).pack(side="left", padx=8)
 
-        ttk.Label(frame, textvariable=self.calendar_status_var).pack(anchor="w", pady=(2, 6))
+        ttk.Label(setup_card, textvariable=self.calendar_status_var, style="Status.TLabel").pack(anchor="w", pady=(2, 8))
+
+        circuit_row = self._build_field_row(setup_card, "Circuito")
+        ttk.Entry(circuit_row, textvariable=self.circuit_var, state="readonly", style="Value.TEntry").pack(
+            side="left", fill="x", expand=True
+        )
+        ttk.Button(
+            circuit_row,
+            text="Impostazioni circuito",
+            command=self._open_circuit_settings,
+            style="Secondary.TButton",
+        ).pack(side="left", padx=8)
 
         readonly_fields = [
-            ("Circuito", self.circuit_var),
             ("Nome evento", self.event_name_var),
             ("ID evento", self.event_id_var),
             ("Data (ISO)", self.date_var),
         ]
-
         for label, var in readonly_fields:
-            row = ttk.Frame(frame)
-            row.pack(fill="x", pady=4)
-            ttk.Label(row, text=label, width=16).pack(side="left")
-            ttk.Entry(row, textvariable=var, state="readonly").pack(side="left", fill="x", expand=True)
+            row = self._build_field_row(setup_card, label)
+            ttk.Entry(row, textvariable=var, state="readonly", style="Value.TEntry").pack(side="left", fill="x", expand=True)
 
-        ticket_row = ttk.Frame(frame)
-        ticket_row.pack(fill="x", pady=4)
-        ttk.Label(ticket_row, text="Numero biglietto", width=16).pack(side="left")
-        ttk.Entry(ticket_row, textvariable=self.ticket_number_var).pack(side="left", fill="x", expand=True)
+        ticket_row = self._build_field_row(setup_card, "Numero biglietto")
+        ttk.Entry(ticket_row, textvariable=self.ticket_number_var, style="Value.TEntry").pack(side="left", fill="x", expand=True)
 
-        output_row = ttk.Frame(frame)
-        output_row.pack(fill="x", pady=(8, 4))
-        ttk.Label(output_row, text="File output", width=16).pack(side="left")
-        ttk.Entry(output_row, textvariable=self.output_var).pack(side="left", fill="x", expand=True)
-        ttk.Button(output_row, text="Sfoglia", command=self._pick_output).pack(side="left", padx=8)
+        output_row = self._build_field_row(setup_card, "File output")
+        ttk.Entry(output_row, textvariable=self.output_var, style="Value.TEntry").pack(side="left", fill="x", expand=True)
+        ttk.Button(output_row, text="Sfoglia", command=self._pick_output, style="Secondary.TButton").pack(side="left", padx=8)
 
         ttk.Checkbutton(
-            frame,
-            text="Modalità locale (non prenota hash su Supabase)",
+            setup_card,
+            text="Modalita locale (non prenota hash su Supabase)",
             variable=self.skip_supabase_var,
+            style="Card.TCheckbutton",
         ).pack(anchor="w", pady=(8, 8))
 
-        button_row = ttk.Frame(frame)
-        button_row.pack(fill="x", pady=(0, 8))
-        ttk.Button(button_row, text="Genera e Prenota QR", command=self._generate).pack(side="left")
+        button_row = ttk.Frame(setup_card, style="Card.TFrame")
+        button_row.pack(fill="x", pady=(0, 2))
+        ttk.Button(button_row, text="Genera e Prenota QR", command=self._generate, style="Primary.TButton").pack(side="left")
 
-        ttk.Label(frame, text="JSON generato", font=("Arial", 10, "bold")).pack(anchor="w", pady=(8, 4))
-        self.json_box = tk.Text(frame, height=9, wrap="word")
+        result_card = self._build_card(
+            frame,
+            "Output QR",
+            "Controlla JSON, hash e anteprima prima di distribuire il biglietto.",
+        )
+        ttk.Label(result_card, text="JSON generato", style="FieldLabel.TLabel").pack(anchor="w", pady=(0, 4))
+        self.json_box = tk.Text(
+            result_card,
+            height=9,
+            wrap="word",
+            bd=0,
+            relief="flat",
+            bg=COLOR_INPUT_BG,
+            fg=COLOR_TEXT,
+            insertbackground=COLOR_TEXT,
+            selectbackground=COLOR_ACCENT,
+            padx=10,
+            pady=8,
+        )
         self.json_box.pack(fill="x")
+        self.json_box.configure(highlightthickness=1, highlightbackground=COLOR_BORDER, highlightcolor=COLOR_ACCENT)
 
-        ttk.Label(frame, text="Hash SHA-256", font=("Arial", 10, "bold")).pack(anchor="w", pady=(8, 4))
-        self.hash_var = tk.StringVar(value="-")
-        ttk.Entry(frame, textvariable=self.hash_var, state="readonly").pack(fill="x")
+        ttk.Label(result_card, text="Hash SHA-256", style="FieldLabel.TLabel").pack(anchor="w", pady=(8, 4))
+        ttk.Entry(result_card, textvariable=self.hash_var, state="readonly", style="Value.TEntry").pack(fill="x")
 
-        ttk.Label(frame, text="Anteprima QR", font=("Arial", 10, "bold")).pack(anchor="w", pady=(8, 4))
-        self.qr_preview_label = ttk.Label(frame, text="Nessun QR generato")
-        self.qr_preview_label.pack(anchor="w")
+        ttk.Label(result_card, text="Anteprima QR", style="FieldLabel.TLabel").pack(anchor="w", pady=(8, 4))
+        preview_container = ttk.Frame(result_card, style="Preview.TFrame", padding=8)
+        preview_container.pack(anchor="w")
+        self.qr_preview_label = ttk.Label(
+            preview_container,
+            text="Nessun QR generato",
+            style="Preview.TLabel",
+            anchor="center",
+            padding=2,
+        )
+        self.qr_preview_label.pack()
 
     def _pick_output(self) -> None:
         selected = filedialog.asksaveasfilename(
@@ -132,6 +378,79 @@ class TicketQrGeneratorUI:
         )
         if selected:
             self.output_var.set(selected)
+
+    def _open_circuit_settings(self) -> None:
+        dialog = tk.Toplevel(self.root)
+        dialog.title("Impostazioni circuito")
+        dialog.transient(self.root)
+        dialog.grab_set()
+        dialog.resizable(False, False)
+        dialog.configure(bg=COLOR_APP_BG)
+
+        content = ttk.Frame(dialog, padding=12, style="Card.TFrame")
+        content.pack(fill="both", expand=True)
+
+        ttk.Label(
+            content,
+            text="Seleziona il circuito di emissione da usare come default.",
+            style="CardHint.TLabel",
+        ).pack(anchor="w", pady=(0, 8))
+
+        selected_option_var = tk.StringVar(value="")
+        custom_value_var = tk.StringVar(value="")
+
+        options = [*self.circuit_options, CUSTOM_CIRCUIT_OPTION]
+        current_value = self.circuit_var.get().strip()
+        if current_value in self.circuit_options:
+            selected_option_var.set(current_value)
+        else:
+            selected_option_var.set(CUSTOM_CIRCUIT_OPTION)
+            custom_value_var.set(current_value)
+
+        option_row = ttk.Frame(content, style="Card.TFrame")
+        option_row.pack(fill="x", pady=4)
+        ttk.Label(option_row, text="Circuito", width=16, style="FieldLabel.TLabel").pack(side="left")
+        option_combo = ttk.Combobox(
+            option_row,
+            textvariable=selected_option_var,
+            values=options,
+            state="readonly",
+            style="Value.TCombobox",
+        )
+        option_combo.pack(side="left", fill="x", expand=True)
+
+        custom_row = ttk.Frame(content, style="Card.TFrame")
+        custom_row.pack(fill="x", pady=4)
+        ttk.Label(custom_row, text="Valore custom", width=16, style="FieldLabel.TLabel").pack(side="left")
+        custom_entry = ttk.Entry(custom_row, textvariable=custom_value_var, style="Value.TEntry")
+        custom_entry.pack(side="left", fill="x", expand=True)
+
+        def refresh_custom_state() -> None:
+            is_custom = selected_option_var.get() == CUSTOM_CIRCUIT_OPTION
+            custom_entry.configure(state="normal" if is_custom else "disabled")
+
+        def save_and_close() -> None:
+            selected_option = selected_option_var.get().strip()
+            selected_circuit = custom_value_var.get().strip() if selected_option == CUSTOM_CIRCUIT_OPTION else selected_option
+            if not selected_circuit:
+                messagebox.showerror("Errore", "Inserisci un circuito valido.", parent=dialog)
+                return
+            self.circuit_var.set(selected_circuit)
+            try:
+                self._save_circuit_setting(selected_circuit)
+            except OSError as error:
+                messagebox.showerror("Errore", f"Impossibile salvare le impostazioni:\n{error}", parent=dialog)
+                return
+            dialog.destroy()
+            messagebox.showinfo("Impostazioni salvate", "Circuito predefinito aggiornato.")
+
+        refresh_custom_state()
+        option_combo.bind("<<ComboboxSelected>>", lambda _event: refresh_custom_state())
+
+        button_row = ttk.Frame(content, style="Card.TFrame")
+        button_row.pack(fill="x", pady=(10, 0))
+        ttk.Button(button_row, text="Annulla", command=dialog.destroy, style="Secondary.TButton").pack(side="right")
+        ttk.Button(button_row, text="Salva", command=save_and_close, style="Primary.TButton").pack(side="right", padx=(0, 8))
 
     def _load_calendar_events(self, show_errors: bool = True) -> None:
         try:
@@ -219,7 +538,7 @@ class TicketQrGeneratorUI:
                 service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
                 if not supabase_url or not service_role_key:
                     raise ValueError(
-                        "Imposta SUPABASE_URL e SUPABASE_SERVICE_ROLE_KEY oppure abilita la modalità locale."
+                        "Imposta SUPABASE_URL e SUPABASE_SERVICE_ROLE_KEY oppure abilita la modalita locale."
                     )
 
                 reserved = reserve_hash(
@@ -229,7 +548,7 @@ class TicketQrGeneratorUI:
                     payload_hash=payload_hash,
                 )
                 if not reserved:
-                    raise ValueError("Hash già presente su Supabase. Verifica i dati del ticket (forse già generato).")
+                    raise ValueError("Hash gia presente su Supabase. Verifica i dati del ticket (forse gia generato).")
 
             qr_value = f"turni://ticket/{payload_hash}"
             output_path = pathlib.Path(self.output_var.get()).resolve()
@@ -246,21 +565,14 @@ class TicketQrGeneratorUI:
             success_msg = f"QR salvato in:\n{output_path}"
             if is_remote:
                 success_msg += "\n\nHash prenotato correttamente su Supabase."
-            
+
             messagebox.showinfo("Completato", success_msg)
         except Exception as error:
             messagebox.showerror("Errore", str(error))
 
 
-
 def main() -> None:
     root = tk.Tk()
-    style = ttk.Style(root)
-    try:
-        style.theme_use("clam")
-    except tk.TclError:
-        pass
-
     TicketQrGeneratorUI(root)
     root.mainloop()
 

--- a/tools/ticket_qr_generator/ticket_qr_generator_ui.py
+++ b/tools/ticket_qr_generator/ticket_qr_generator_ui.py
@@ -9,6 +9,10 @@ import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 
 from PIL import Image, ImageTk
+from dotenv import load_dotenv
+
+# Load local .env if present
+load_dotenv()
 
 from generate_ticket_qr import (
     CalendarEvent,

--- a/tools/ticket_qr_generator/ticket_qr_generator_ui.py
+++ b/tools/ticket_qr_generator/ticket_qr_generator_ui.py
@@ -30,13 +30,17 @@ class TicketQrGeneratorUI:
         self.root.title("Turni di Palco - Generatore QR Biglietteria")
         self.root.geometry("900x760")
 
+        supabase_url = os.getenv("SUPABASE_URL", "").strip()
+        service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "").strip()
+        has_creds = bool(supabase_url and service_role_key)
+
         self.circuit_var = tk.StringVar(value=default_ticket_circuit())
         self.calendar_event_var = tk.StringVar(value="")
         self.event_name_var = tk.StringVar(value="-")
         self.event_id_var = tk.StringVar(value="-")
         self.date_var = tk.StringVar(value="-")
-        self.ticket_number_var = tk.StringVar(value="1234567890")
-        self.skip_supabase_var = tk.BooleanVar(value=True)
+        self.ticket_number_var = tk.StringVar(value="")
+        self.skip_supabase_var = tk.BooleanVar(value=not has_creds)
         self.output_var = tk.StringVar(value=str(pathlib.Path("./out/ticket-qr.png").resolve()))
         self.calendar_status_var = tk.StringVar(value="Calendario non caricato.")
         self.calendar_events: list[CalendarEvent] = []
@@ -96,13 +100,13 @@ class TicketQrGeneratorUI:
 
         ttk.Checkbutton(
             frame,
-            text="Modalita locale (non prenota hash su Supabase)",
+            text="Modalità locale (non prenota hash su Supabase)",
             variable=self.skip_supabase_var,
         ).pack(anchor="w", pady=(8, 8))
 
         button_row = ttk.Frame(frame)
         button_row.pack(fill="x", pady=(0, 8))
-        ttk.Button(button_row, text="Genera QR", command=self._generate).pack(side="left")
+        ttk.Button(button_row, text="Genera e Prenota QR", command=self._generate).pack(side="left")
 
         ttk.Label(frame, text="JSON generato", font=("Arial", 10, "bold")).pack(anchor="w", pady=(8, 4))
         self.json_box = tk.Text(frame, height=9, wrap="word")
@@ -148,9 +152,12 @@ class TicketQrGeneratorUI:
 
             self.calendar_events = events
             self.calendar_combo.configure(values=options)
-            self.calendar_combo.current(selected_index)
-            self._set_selected_event(events[selected_index])
-            self.calendar_status_var.set(f"Calendario caricato: {len(events)} eventi.")
+            if options:
+                self.calendar_combo.current(selected_index)
+                self._set_selected_event(events[selected_index])
+                self.calendar_status_var.set(f"Calendario caricato: {len(events)} eventi.")
+            else:
+                self.calendar_status_var.set("Nessun evento trovato nel calendario.")
         except Exception as error:
             self.calendar_events = []
             self.calendar_combo.configure(values=[])
@@ -202,12 +209,13 @@ class TicketQrGeneratorUI:
             canonical_json = canonical_payload_json(payload)
             payload_hash = sha256_hex(canonical_json)
 
-            if not self.skip_supabase_var.get():
+            is_remote = not self.skip_supabase_var.get()
+            if is_remote:
                 supabase_url = os.getenv("SUPABASE_URL", "")
                 service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
                 if not supabase_url or not service_role_key:
                     raise ValueError(
-                        "Imposta SUPABASE_URL e SUPABASE_SERVICE_ROLE_KEY oppure abilita la modalita locale."
+                        "Imposta SUPABASE_URL e SUPABASE_SERVICE_ROLE_KEY oppure abilita la modalità locale."
                     )
 
                 reserved = reserve_hash(
@@ -217,7 +225,7 @@ class TicketQrGeneratorUI:
                     payload_hash=payload_hash,
                 )
                 if not reserved:
-                    raise ValueError("Hash gia presente su Supabase. Verifica i dati del ticket.")
+                    raise ValueError("Hash già presente su Supabase. Verifica i dati del ticket (forse già generato).")
 
             qr_value = f"turni://ticket/{payload_hash}"
             output_path = pathlib.Path(self.output_var.get()).resolve()
@@ -231,9 +239,14 @@ class TicketQrGeneratorUI:
             self.preview_image = ImageTk.PhotoImage(image)
             self.qr_preview_label.configure(image=self.preview_image, text="")
 
-            messagebox.showinfo("Completato", f"QR salvato in:\n{output_path}")
+            success_msg = f"QR salvato in:\n{output_path}"
+            if is_remote:
+                success_msg += "\n\nHash prenotato correttamente su Supabase."
+            
+            messagebox.showinfo("Completato", success_msg)
         except Exception as error:
             messagebox.showerror("Errore", str(error))
+
 
 
 def main() -> None:

--- a/tools/ticket_qr_generator/ticket_qr_generator_ui.py
+++ b/tools/ticket_qr_generator/ticket_qr_generator_ui.py
@@ -14,6 +14,7 @@ from generate_ticket_qr import (
     TicketPayload,
     canonical_payload_json,
     generate_qr_png,
+    pretty_payload_json,
     reserve_hash,
     sha256_hex,
 )
@@ -113,8 +114,8 @@ class TicketQrGeneratorUI:
     def _generate(self) -> None:
         try:
             payload = self._build_payload()
-            json_payload = canonical_payload_json(payload)
-            payload_hash = sha256_hex(json_payload)
+            canonical_json = canonical_payload_json(payload)
+            payload_hash = sha256_hex(canonical_json)
 
             if not self.skip_supabase_var.get():
                 supabase_url = os.getenv("SUPABASE_URL", "")
@@ -136,7 +137,7 @@ class TicketQrGeneratorUI:
             generate_qr_png(qr_value, output_path)
 
             self.json_box.delete("1.0", tk.END)
-            self.json_box.insert(tk.END, json_payload)
+            self.json_box.insert(tk.END, pretty_payload_json(payload))
             self.hash_var.set(payload_hash)
 
             image = Image.open(output_path).resize((240, 240))

--- a/tools/ticket_qr_generator/ticket_qr_generator_ui.py
+++ b/tools/ticket_qr_generator/ticket_qr_generator_ui.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Simple desktop UI for non-technical ticket-office operators."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+from PIL import Image, ImageTk
+
+from generate_ticket_qr import (
+    TicketPayload,
+    canonical_payload_json,
+    generate_qr_png,
+    reserve_hash,
+    sha256_hex,
+)
+
+
+class TicketQrGeneratorUI:
+    def __init__(self, root: tk.Tk):
+        self.root = root
+        self.root.title("Turni di Palco - Generatore QR Biglietteria")
+        self.root.geometry("860x720")
+
+        self.circuit_var = tk.StringVar(value="TicketOne")
+        self.event_name_var = tk.StringVar(value="Esempio")
+        self.event_id_var = tk.StringVar(value="1234567890")
+        self.ticket_number_var = tk.StringVar(value="1234567890")
+        self.date_var = tk.StringVar(value="2026-02-11T11:54:00+01:00")
+        self.skip_supabase_var = tk.BooleanVar(value=True)
+        self.output_var = tk.StringVar(value=str(pathlib.Path("./out/ticket-qr.png").resolve()))
+
+        self.preview_image: ImageTk.PhotoImage | None = None
+
+        self._build_layout()
+
+    def _build_layout(self) -> None:
+        frame = ttk.Frame(self.root, padding=16)
+        frame.pack(fill="both", expand=True)
+
+        ttk.Label(
+            frame,
+            text="Compila i dati del biglietto e premi 'Genera QR'.",
+            font=("Arial", 12, "bold"),
+        ).pack(anchor="w", pady=(0, 12))
+
+        fields = [
+            ("Circuito", self.circuit_var),
+            ("Nome evento", self.event_name_var),
+            ("ID evento", self.event_id_var),
+            ("Numero biglietto", self.ticket_number_var),
+            ("Data (ISO)", self.date_var),
+        ]
+
+        for label, var in fields:
+            row = ttk.Frame(frame)
+            row.pack(fill="x", pady=4)
+            ttk.Label(row, text=label, width=16).pack(side="left")
+            ttk.Entry(row, textvariable=var).pack(side="left", fill="x", expand=True)
+
+        output_row = ttk.Frame(frame)
+        output_row.pack(fill="x", pady=(8, 4))
+        ttk.Label(output_row, text="File output", width=16).pack(side="left")
+        ttk.Entry(output_row, textvariable=self.output_var).pack(side="left", fill="x", expand=True)
+        ttk.Button(output_row, text="Sfoglia", command=self._pick_output).pack(side="left", padx=8)
+
+        ttk.Checkbutton(
+            frame,
+            text="Modalità locale (non chiama Supabase)",
+            variable=self.skip_supabase_var,
+        ).pack(anchor="w", pady=(8, 8))
+
+        button_row = ttk.Frame(frame)
+        button_row.pack(fill="x", pady=(0, 8))
+        ttk.Button(button_row, text="Genera QR", command=self._generate).pack(side="left")
+
+        ttk.Label(frame, text="JSON generato", font=("Arial", 10, "bold")).pack(anchor="w", pady=(8, 4))
+        self.json_box = tk.Text(frame, height=9, wrap="word")
+        self.json_box.pack(fill="x")
+
+        ttk.Label(frame, text="Hash SHA-256", font=("Arial", 10, "bold")).pack(anchor="w", pady=(8, 4))
+        self.hash_var = tk.StringVar(value="-")
+        ttk.Entry(frame, textvariable=self.hash_var, state="readonly").pack(fill="x")
+
+        ttk.Label(frame, text="Anteprima QR", font=("Arial", 10, "bold")).pack(anchor="w", pady=(8, 4))
+        self.qr_preview_label = ttk.Label(frame, text="Nessun QR generato")
+        self.qr_preview_label.pack(anchor="w")
+
+    def _pick_output(self) -> None:
+        selected = filedialog.asksaveasfilename(
+            title="Salva QR come...",
+            defaultextension=".png",
+            filetypes=[("PNG", "*.png")],
+        )
+        if selected:
+            self.output_var.set(selected)
+
+    def _build_payload(self) -> TicketPayload:
+        payload = TicketPayload(
+            circuit=self.circuit_var.get().strip(),
+            event_name=self.event_name_var.get().strip(),
+            event_id=self.event_id_var.get().strip(),
+            ticket_number=self.ticket_number_var.get().strip(),
+            date=self.date_var.get().strip(),
+        )
+        if not all([payload.circuit, payload.event_name, payload.event_id, payload.ticket_number, payload.date]):
+            raise ValueError("Tutti i campi sono obbligatori.")
+        return payload
+
+    def _generate(self) -> None:
+        try:
+            payload = self._build_payload()
+            json_payload = canonical_payload_json(payload)
+            payload_hash = sha256_hex(json_payload)
+
+            if not self.skip_supabase_var.get():
+                supabase_url = os.getenv("SUPABASE_URL", "")
+                service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
+                if not supabase_url or not service_role_key:
+                    raise ValueError("Imposta SUPABASE_URL e SUPABASE_SERVICE_ROLE_KEY o abilita modalità locale.")
+
+                reserved = reserve_hash(
+                    supabase_url=supabase_url,
+                    service_role_key=service_role_key,
+                    payload=payload,
+                    payload_hash=payload_hash,
+                )
+                if not reserved:
+                    raise ValueError("Hash già presente su Supabase. Verifica i dati del ticket.")
+
+            qr_value = f"turni://ticket/{payload_hash}"
+            output_path = pathlib.Path(self.output_var.get()).resolve()
+            generate_qr_png(qr_value, output_path)
+
+            self.json_box.delete("1.0", tk.END)
+            self.json_box.insert(tk.END, json_payload)
+            self.hash_var.set(payload_hash)
+
+            image = Image.open(output_path).resize((240, 240))
+            self.preview_image = ImageTk.PhotoImage(image)
+            self.qr_preview_label.configure(image=self.preview_image, text="")
+
+            messagebox.showinfo("Completato", f"QR salvato in:\n{output_path}")
+        except Exception as error:
+            messagebox.showerror("Errore", str(error))
+
+
+def main() -> None:
+    root = tk.Tk()
+    style = ttk.Style(root)
+    try:
+        style.theme_use("clam")
+    except tk.TclError:
+        pass
+
+    TicketQrGeneratorUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ticket_qr_generator/ticket_qr_generator_ui.py
+++ b/tools/ticket_qr_generator/ticket_qr_generator_ui.py
@@ -570,7 +570,7 @@ class TicketQrGeneratorUI:
                 if not reserved:
                     raise ValueError("Hash gia presente su Supabase. Verifica i dati del ticket (forse gia generato).")
 
-            qr_value = f"turni://ticket/{payload_hash}"
+            qr_value = payload_hash
             output_path = pathlib.Path(self.output_var.get()).resolve()
             generate_qr_png(qr_value, output_path)
 


### PR DESCRIPTION
### Motivation
- Move the QR activation prototype from PWA scope into the mobile app flow so the feature can be validated in the mobile UX and integrated with existing mobile QR flows. 
- Provide a standalone evaluation tool for theatre box offices to generate QR payloads and hashes that can be packaged as a single binary for distribution. 
- Support a Supabase-backed reservation/activation flow with a local fallback for offline/demo scenarios. 

### Description
- Added a mobile prototype screen `ticket-qr-prototype` implementing (1) ticket-office generation (canonical JSON -> SHA-256 -> `turni://ticket/<hash>`) and (2) scan/one-shot activation plus a local in-memory records table: `apps/mobile/src/components/screens/TicketQrActivationPrototype.tsx`. 
- Implemented a mobile service `ticket-activation` that provides canonical JSON creation, stable stringify, SHA-256 hashing via Web Crypto, collision retry with a `salt`, QR parsing (`turni://ticket/<hash>`), one-shot activation with local fallback and optional Supabase Edge Function integration: `apps/mobile/src/services/ticket-activation.ts`. 
- Wired the prototype into the app navigation and Account Settings (new menu entry “Prototipo ticket QR”) and extended navigation types to include the new screen: `apps/mobile/src/App.tsx`, `apps/mobile/src/components/screens/AccountSettings.tsx`, and `apps/mobile/src/types/navigation.ts`. 
- Added a Python CLI prototype `generate_ticket_qr.py` to `tools/ticket_qr_generator/` that produces PNG QR files from ticket metadata and optionally calls the Supabase `ticket-activation` function to reserve hashes, plus `requirements.txt` and a README with usage and packaging notes. 

### Testing
- Built the mobile app with `npm --workspace apps/mobile run build` and the build completed successfully. 
- Type-checked / compiled the Python generator with `python -m py_compile tools/ticket_qr_generator/generate_ticket_qr.py` which succeeded. 
- Executed the Python generator locally in skip-backend mode and it produced a QR PNG and JSON output successfully with `python tools/ticket_qr_generator/generate_ticket_qr.py --ticket-code ATCL-LOCAL-001 --theatre-id demo --performance-iso 2026-01-01T18:00:00+01:00 --skip-supabase --output /tmp/atcl-local.png`. 
- Attempted an automated Playwright screenshot of the mobile prototype UI, but headless Chromium crashed (SIGSEGV) in this environment so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c5c9b4038832683716945a4780c53)