### PR TITLE
Set JSON default formatter in VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -222,5 +222,8 @@
         "supabase/functions"
     ],
     "deno.unstable": true,
-    "deno.lint": true
+    "deno.lint": true,
+    "[json]": {
+        "editor.defaultFormatter": "vscode.json-language-features"
+    }
 }


### PR DESCRIPTION
Add a VS Code workspace setting to use the built-in JSON formatter (vscode.json-language-features) for [json] files. This ensures consistent formatting for .json files across the project.