### PR TITLE
[render preview] Prototype banner promo ATCL (mobile)

### DIFF
--- a/apps/mobile/src/components/AtclPromoBanner.tsx
+++ b/apps/mobile/src/components/AtclPromoBanner.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { ArrowUpRight, Megaphone } from 'lucide-react';
+import type { AtclPromotion } from '../data/atcl_promotions';
+import { Button } from './ui/Button';
+import { Card } from './ui/Card';
+
+type AtclPromoBannerProps = {
+  promotion: AtclPromotion;
+};
+
+function formatPromotionRange(startsAt?: string, endsAt?: string): string | null {
+  const formatter = new Intl.DateTimeFormat('it-IT', { day: '2-digit', month: 'short' });
+  const startDate = startsAt ? new Date(startsAt) : null;
+  const endDate = endsAt ? new Date(endsAt) : null;
+  const isValidDate = (value: Date | null) => Boolean(value && !Number.isNaN(value.getTime()));
+
+  if (isValidDate(startDate) && isValidDate(endDate)) {
+    return `${formatter.format(startDate!)} - ${formatter.format(endDate!)}`;
+  }
+
+  if (isValidDate(startDate)) {
+    return `Dal ${formatter.format(startDate!)}`;
+  }
+
+  if (isValidDate(endDate)) {
+    return `Fino al ${formatter.format(endDate!)}`;
+  }
+
+  return null;
+}
+
+export function AtclPromoBanner({ promotion }: AtclPromoBannerProps) {
+  const canOpenCta = Boolean(promotion.ctaLabel && promotion.ctaUrl);
+  const rangeLabel = formatPromotionRange(promotion.startsAt, promotion.endsAt);
+
+  const handleOpenCta = () => {
+    if (!promotion.ctaUrl || typeof window === 'undefined') return;
+    window.open(promotion.ctaUrl, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <Card
+      animateOnMount
+      className="overflow-hidden border border-[#f4bf4f]/20 bg-gradient-to-br from-[#2d0a0f] via-[#4a0e1a] to-[#1a1617]"
+    >
+      <div className="space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="inline-flex items-center gap-2 rounded-full bg-[#f4bf4f]/15 px-3 py-1 text-[11px] uppercase tracking-wide text-[#f4bf4f]">
+            <Megaphone size={13} />
+            <span>{promotion.badgeLabel}</span>
+          </div>
+          {rangeLabel ? <span className="text-xs text-[#f5d9a8]">{rangeLabel}</span> : null}
+        </div>
+
+        <div className="space-y-1">
+          <h4 className="text-white leading-tight">{promotion.title}</h4>
+          <p className="text-sm text-[#f6ddd5] leading-relaxed">{promotion.description}</p>
+        </div>
+
+        {canOpenCta ? (
+          <Button
+            variant="secondary"
+            size="sm"
+            className="min-h-[40px] border-[#f4bf4f] bg-[#f4bf4f]/10 text-[#f4bf4f] hover:bg-[#f4bf4f]/20"
+            onClick={handleOpenCta}
+          >
+            {promotion.ctaLabel}
+            <ArrowUpRight size={14} />
+          </Button>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/apps/mobile/src/components/screens/ATCLTurns.tsx
+++ b/apps/mobile/src/components/screens/ATCLTurns.tsx
@@ -4,6 +4,8 @@ import { Button } from '../ui/Button';
 import { ScanQRCard } from '../ScanQRCard';
 import { QrCode, MapPin, Calendar, TrendingUp, Theater, Bookmark, Map, Award } from 'lucide-react';
 import { GameEvent } from '../../state/store';
+import { AtclPromoBanner } from '../AtclPromoBanner';
+import { getAtclPromotionBySlot } from '../../data/atcl_promotions';
 
 interface ATCLTurnsProps {
   events: GameEvent[];
@@ -49,6 +51,7 @@ export function ATCLTurns({
       return dateA >= now ? -1 : 1;
     });
   }, [events]);
+  const turnsPromotion = getAtclPromotionBySlot('turns');
 
   return (
     <div
@@ -62,6 +65,7 @@ export function ATCLTurns({
         </div>
 
         <ScanQRCard onScanQR={onScanQR} />
+        {turnsPromotion ? <AtclPromoBanner promotion={turnsPromotion} /> : null}
 
         <Card>
           <h4 className="text-white mb-4">Statistiche totali</h4>

--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -9,6 +9,8 @@ import { Play, Calendar, TrendingUp, Award, ChevronRight, Navigation, CalendarPl
 import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover';
 import { GameEvent } from '../../state/store';
 import { ScanQRCard } from '../ScanQRCard';
+import { AtclPromoBanner } from '../AtclPromoBanner';
+import { getAtclPromotionBySlot } from '../../data/atcl_promotions';
 
 type EventState = 'loading' | 'error' | 'empty' | 'ready';
 
@@ -83,6 +85,7 @@ export function Home({
   }, [hasNewBadges, newBadgesCount]);
 
   const eventState: EventState = eventError ? 'error' : eventLoading ? 'loading' : !upcomingEvent ? 'empty' : 'ready';
+  const homePromotion = getAtclPromotionBySlot('home');
 
   return (
     <div
@@ -160,6 +163,7 @@ export function Home({
         </header>
 
         <ScanQRCard onScanQR={onScanQR} className="mt-5" />
+        {homePromotion ? <AtclPromoBanner promotion={homePromotion} /> : null}
 
         <section className="space-y-3">
           <div className="flex items-center justify-between">

--- a/apps/mobile/src/data/atcl_promotions.ts
+++ b/apps/mobile/src/data/atcl_promotions.ts
@@ -1,0 +1,63 @@
+export type AtclPromotionSlot = 'home' | 'turns';
+
+export type AtclPromotion = {
+  id: string;
+  slot: AtclPromotionSlot;
+  badgeLabel: string;
+  title: string;
+  description: string;
+  ctaLabel?: string;
+  ctaUrl?: string;
+  startsAt?: string;
+  endsAt?: string;
+};
+
+const PROMOTIONS: AtclPromotion[] = [
+  {
+    id: 'atcl-home-lab-backstage-2026',
+    slot: 'home',
+    badgeLabel: 'Novita ATCL',
+    title: 'Laboratorio backstage aperto',
+    description:
+      'Aperti nuovi incontri promozionali con i professionisti di palco nei teatri del circuito.',
+    ctaLabel: 'Scopri il programma',
+    ctaUrl: 'https://www.atcllazio.it/',
+    startsAt: '2026-02-01T00:00:00.000Z',
+    endsAt: '2026-06-30T23:59:59.000Z',
+  },
+  {
+    id: 'atcl-turns-under30-2026',
+    slot: 'turns',
+    badgeLabel: 'Promo under 30',
+    title: 'Biglietti ridotti su eventi selezionati',
+    description:
+      'Per un periodo limitato alcuni spettacoli ATCL hanno una promozione dedicata agli under 30.',
+    ctaLabel: 'Verifica disponibilita',
+    ctaUrl: 'https://www.atcllazio.it/',
+    startsAt: '2026-02-15T00:00:00.000Z',
+    endsAt: '2026-05-31T23:59:59.000Z',
+  },
+];
+
+function parseTimestamp(value?: string): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isActivePromotion(promotion: AtclPromotion, now: Date): boolean {
+  const nowMs = now.getTime();
+  const startsAt = parseTimestamp(promotion.startsAt);
+  const endsAt = parseTimestamp(promotion.endsAt);
+
+  if (startsAt !== null && nowMs < startsAt) return false;
+  if (endsAt !== null && nowMs > endsAt) return false;
+  return true;
+}
+
+export function getAtclPromotionBySlot(
+  slot: AtclPromotionSlot,
+  now: Date = new Date()
+): AtclPromotion | null {
+  return PROMOTIONS.find((promotion) => promotion.slot === slot && isActivePromotion(promotion, now)) ?? null;
+}


### PR DESCRIPTION
## Obiettivo\nPrototipo di spazi promozionali first-party ATCL nell'app mobile (no AdSense/no ad network esterni).\n\n## Modifiche\n- aggiunto dataset promo locale con slot e finestra temporale in pps/mobile/src/data/atcl_promotions.ts\n- aggiunto componente riusabile AtclPromoBanner in pps/mobile/src/components/AtclPromoBanner.tsx\n- integrazione banner in Home (pps/mobile/src/components/screens/Home.tsx)\n- integrazione banner in Eventi ATCL (pps/mobile/src/components/screens/ATCLTurns.tsx)\n\n## Verifica\n- 
pm --prefix apps/mobile run build\n\n## Note\nQuesto è un prototipo UI/data locale, utile per validare layout e UX prima del collegamento a Supabase.