### PR TITLE
[render preview] Mobile ATCL promo feed prototype

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -15,6 +15,9 @@ VITE_ATCL_PROMO_FEED_URL=https://www.atcllazio.it/feed/
 VITE_ROSSELLINI_PROMO_FEED_URL=https://www.spaziorossellini.it/category/slide-evidenza/feed/
 VITE_ATCL_PROMO_REST_URL=https://www.atcllazio.it/wp-json/wp/v2/posts?categories=421&per_page=6&_fields=title,link,date,excerpt
 VITE_ROSSELLINI_PROMO_REST_URL=https://www.spaziorossellini.it/wp-json/wp/v2/posts?categories=21&per_page=6&_fields=title,link,date,excerpt
+VITE_ATCL_PROMO_PROXY_PATH=/api/promotions/proxy
+VITE_ATCL_PROMO_USE_LOCAL_PROXY=true
+VITE_ATCL_PROMO_ALLOW_EXTERNAL_FALLBACK=false
 VITE_ATCL_PROMO_CORS_PROXY_TEMPLATE=https://api.allorigins.win/raw?url={url}
 VITE_ATCL_PROMO_ALLOW_DIRECT_FETCH=false
 

--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -15,3 +15,10 @@ VITE_ATCL_PROMO_FEED_URL=https://www.atcllazio.it/feed/
 VITE_ROSSELLINI_PROMO_FEED_URL=https://www.spaziorossellini.it/category/slide-evidenza/feed/
 VITE_ATCL_PROMO_REST_URL=https://www.atcllazio.it/wp-json/wp/v2/posts?categories=421&per_page=6&_fields=title,link,date,excerpt
 VITE_ROSSELLINI_PROMO_REST_URL=https://www.spaziorossellini.it/wp-json/wp/v2/posts?categories=21&per_page=6&_fields=title,link,date,excerpt
+VITE_ATCL_PROMO_CORS_PROXY_TEMPLATE=https://api.allorigins.win/raw?url={url}
+VITE_ATCL_PROMO_ALLOW_DIRECT_FETCH=false
+
+# Optional offline sync server-log mirror controls
+# - Default behavior: auto-disabled on Render preview domains (turni-di-palco-pr-*)
+# - Set true/false to force behavior on every environment
+VITE_OFFLINE_SYNC_SERVER_LOG_MIRROR_ENABLED=

--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -9,3 +9,9 @@ VITE_AI_SUPPORT_ISSUE_ENDPOINT=https://localhost:8787/api/ai/issue
 
 # Vite dev/preview allowlist (comma-separated)
 VITE_ALLOWED_HOSTS=turni-di-palco-fq85.onrender.com
+
+# Optional ATCL promo feeds (mobile-only dynamic banner source)
+VITE_ATCL_PROMO_FEED_URL=https://www.atcllazio.it/feed/
+VITE_ROSSELLINI_PROMO_FEED_URL=https://www.spaziorossellini.it/category/slide-evidenza/feed/
+VITE_ATCL_PROMO_REST_URL=https://www.atcllazio.it/wp-json/wp/v2/posts?categories=421&per_page=6&_fields=title,link,date,excerpt
+VITE_ROSSELLINI_PROMO_REST_URL=https://www.spaziorossellini.it/wp-json/wp/v2/posts?categories=21&per_page=6&_fields=title,link,date,excerpt

--- a/apps/mobile/src/components/AtclPromoBanner.tsx
+++ b/apps/mobile/src/components/AtclPromoBanner.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { ArrowUpRight, Megaphone } from 'lucide-react';
+import type { AtclPromotion } from '../data/atcl_promotions';
+import { Button } from './ui/Button';
+import { Card } from './ui/Card';
+
+type AtclPromoBannerProps = {
+  promotion: AtclPromotion;
+};
+
+function formatPromotionRange(startsAt?: string, endsAt?: string): string | null {
+  const formatter = new Intl.DateTimeFormat('it-IT', { day: '2-digit', month: 'short' });
+  const startDate = startsAt ? new Date(startsAt) : null;
+  const endDate = endsAt ? new Date(endsAt) : null;
+  const isValidDate = (value: Date | null) => Boolean(value && !Number.isNaN(value.getTime()));
+
+  if (isValidDate(startDate) && isValidDate(endDate)) {
+    return `${formatter.format(startDate!)} - ${formatter.format(endDate!)}`;
+  }
+
+  if (isValidDate(startDate)) {
+    return `Dal ${formatter.format(startDate!)}`;
+  }
+
+  if (isValidDate(endDate)) {
+    return `Fino al ${formatter.format(endDate!)}`;
+  }
+
+  return null;
+}
+
+export function AtclPromoBanner({ promotion }: AtclPromoBannerProps) {
+  const canOpenCta = Boolean(promotion.ctaLabel && promotion.ctaUrl);
+  const rangeLabel = formatPromotionRange(promotion.startsAt, promotion.endsAt);
+
+  const handleOpenCta = () => {
+    if (!promotion.ctaUrl || typeof window === 'undefined') return;
+    window.open(promotion.ctaUrl, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <Card
+      animateOnMount
+      className="overflow-hidden border border-[#f4bf4f]/20 bg-gradient-to-br from-[#2d0a0f] via-[#4a0e1a] to-[#1a1617]"
+    >
+      <div className="space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="inline-flex items-center gap-2 rounded-full bg-[#f4bf4f]/15 px-3 py-1 text-[11px] uppercase tracking-wide text-[#f4bf4f]">
+            <Megaphone size={13} />
+            <span>{promotion.badgeLabel}</span>
+          </div>
+          {rangeLabel ? <span className="text-xs text-[#f5d9a8]">{rangeLabel}</span> : null}
+        </div>
+
+        <div className="space-y-1">
+          <h4 className="text-white leading-tight">{promotion.title}</h4>
+          <p className="text-sm text-[#f6ddd5] leading-relaxed">{promotion.description}</p>
+        </div>
+
+        {canOpenCta ? (
+          <Button
+            variant="secondary"
+            size="sm"
+            className="min-h-[40px] border-[#f4bf4f] bg-[#f4bf4f]/10 text-[#f4bf4f] hover:bg-[#f4bf4f]/20"
+            onClick={handleOpenCta}
+          >
+            {promotion.ctaLabel}
+            <ArrowUpRight size={14} />
+          </Button>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/apps/mobile/src/components/screens/ATCLTurns.tsx
+++ b/apps/mobile/src/components/screens/ATCLTurns.tsx
@@ -4,6 +4,8 @@ import { Button } from '../ui/Button';
 import { ScanQRCard } from '../ScanQRCard';
 import { QrCode, MapPin, Calendar, TrendingUp, Theater, Bookmark, Map, Award } from 'lucide-react';
 import { GameEvent } from '../../state/store';
+import { AtclPromoBanner } from '../AtclPromoBanner';
+import { getAtclPromotionBySlot } from '../../data/atcl_promotions';
 
 interface ATCLTurnsProps {
   events: GameEvent[];
@@ -49,6 +51,7 @@ export function ATCLTurns({
       return dateA >= now ? -1 : 1;
     });
   }, [events]);
+  const turnsPromotion = getAtclPromotionBySlot('turns');
 
   return (
     <div
@@ -62,6 +65,7 @@ export function ATCLTurns({
         </div>
 
         <ScanQRCard onScanQR={onScanQR} />
+        {turnsPromotion ? <AtclPromoBanner promotion={turnsPromotion} /> : null}
 
         <Card>
           <h4 className="text-white mb-4">Statistiche totali</h4>

--- a/apps/mobile/src/components/screens/ATCLTurns.tsx
+++ b/apps/mobile/src/components/screens/ATCLTurns.tsx
@@ -5,7 +5,7 @@ import { ScanQRCard } from '../ScanQRCard';
 import { QrCode, MapPin, Calendar, TrendingUp, Theater, Bookmark, Map, Award } from 'lucide-react';
 import { GameEvent } from '../../state/store';
 import { AtclPromoBanner } from '../AtclPromoBanner';
-import { getAtclPromotionBySlot } from '../../data/atcl_promotions';
+import { useAtclPromotion } from '../../hooks/useAtclPromotion';
 
 interface ATCLTurnsProps {
   events: GameEvent[];
@@ -51,7 +51,7 @@ export function ATCLTurns({
       return dateA >= now ? -1 : 1;
     });
   }, [events]);
-  const turnsPromotion = getAtclPromotionBySlot('turns');
+  const turnsPromotion = useAtclPromotion('turns');
 
   return (
     <div

--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -10,7 +10,7 @@ import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover';
 import { GameEvent } from '../../state/store';
 import { ScanQRCard } from '../ScanQRCard';
 import { AtclPromoBanner } from '../AtclPromoBanner';
-import { getAtclPromotionBySlot } from '../../data/atcl_promotions';
+import { useAtclPromotion } from '../../hooks/useAtclPromotion';
 
 type EventState = 'loading' | 'error' | 'empty' | 'ready';
 
@@ -85,7 +85,7 @@ export function Home({
   }, [hasNewBadges, newBadgesCount]);
 
   const eventState: EventState = eventError ? 'error' : eventLoading ? 'loading' : !upcomingEvent ? 'empty' : 'ready';
-  const homePromotion = getAtclPromotionBySlot('home');
+  const homePromotion = useAtclPromotion('home');
 
   return (
     <div

--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -9,6 +9,8 @@ import { Play, Calendar, TrendingUp, Award, ChevronRight, Navigation, CalendarPl
 import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover';
 import { GameEvent } from '../../state/store';
 import { ScanQRCard } from '../ScanQRCard';
+import { AtclPromoBanner } from '../AtclPromoBanner';
+import { getAtclPromotionBySlot } from '../../data/atcl_promotions';
 
 type EventState = 'loading' | 'error' | 'empty' | 'ready';
 
@@ -83,6 +85,7 @@ export function Home({
   }, [hasNewBadges, newBadgesCount]);
 
   const eventState: EventState = eventError ? 'error' : eventLoading ? 'loading' : !upcomingEvent ? 'empty' : 'ready';
+  const homePromotion = getAtclPromotionBySlot('home');
 
   return (
     <div
@@ -160,6 +163,7 @@ export function Home({
         </header>
 
         <ScanQRCard onScanQR={onScanQR} className="mt-5" />
+        {homePromotion ? <AtclPromoBanner promotion={homePromotion} /> : null}
 
         <section className="space-y-3">
           <div className="flex items-center justify-between">

--- a/apps/mobile/src/data/atcl_promotions.ts
+++ b/apps/mobile/src/data/atcl_promotions.ts
@@ -1,0 +1,63 @@
+export type AtclPromotionSlot = 'home' | 'turns';
+
+export type AtclPromotion = {
+  id: string;
+  slot: AtclPromotionSlot;
+  badgeLabel: string;
+  title: string;
+  description: string;
+  ctaLabel?: string;
+  ctaUrl?: string;
+  startsAt?: string;
+  endsAt?: string;
+};
+
+const PROMOTIONS: AtclPromotion[] = [
+  {
+    id: 'atcl-home-lab-backstage-2026',
+    slot: 'home',
+    badgeLabel: 'Novita ATCL',
+    title: 'Laboratorio backstage aperto',
+    description:
+      'Aperti nuovi incontri promozionali con i professionisti di palco nei teatri del circuito.',
+    ctaLabel: 'Scopri il programma',
+    ctaUrl: 'https://www.atcllazio.it/',
+    startsAt: '2026-02-01T00:00:00.000Z',
+    endsAt: '2026-06-30T23:59:59.000Z',
+  },
+  {
+    id: 'atcl-turns-under30-2026',
+    slot: 'turns',
+    badgeLabel: 'Promo under 30',
+    title: 'Biglietti ridotti su eventi selezionati',
+    description:
+      'Per un periodo limitato alcuni spettacoli ATCL hanno una promozione dedicata agli under 30.',
+    ctaLabel: 'Verifica disponibilita',
+    ctaUrl: 'https://www.atcllazio.it/',
+    startsAt: '2026-02-15T00:00:00.000Z',
+    endsAt: '2026-05-31T23:59:59.000Z',
+  },
+];
+
+function parseTimestamp(value?: string): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isActivePromotion(promotion: AtclPromotion, now: Date): boolean {
+  const nowMs = now.getTime();
+  const startsAt = parseTimestamp(promotion.startsAt);
+  const endsAt = parseTimestamp(promotion.endsAt);
+
+  if (startsAt !== null && nowMs < startsAt) return false;
+  if (endsAt !== null && nowMs > endsAt) return false;
+  return true;
+}
+
+export function getAtclPromotionBySlot(
+  slot: AtclPromotionSlot,
+  now: Date = new Date()
+): AtclPromotion | null {
+  return PROMOTIONS.find((promotion) => promotion.slot === slot && isActivePromotion(promotion, now)) ?? null;
+}

--- a/apps/mobile/src/data/atcl_promotions.ts
+++ b/apps/mobile/src/data/atcl_promotions.ts
@@ -45,7 +45,7 @@ function parseTimestamp(value?: string): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function isActivePromotion(promotion: AtclPromotion, now: Date): boolean {
+export function isAtclPromotionActive(promotion: AtclPromotion, now: Date = new Date()): boolean {
   const nowMs = now.getTime();
   const startsAt = parseTimestamp(promotion.startsAt);
   const endsAt = parseTimestamp(promotion.endsAt);
@@ -55,9 +55,16 @@ function isActivePromotion(promotion: AtclPromotion, now: Date): boolean {
   return true;
 }
 
+export function getLocalAtclPromotionBySlot(
+  slot: AtclPromotionSlot,
+  now: Date = new Date()
+): AtclPromotion | null {
+  return PROMOTIONS.find((promotion) => promotion.slot === slot && isAtclPromotionActive(promotion, now)) ?? null;
+}
+
 export function getAtclPromotionBySlot(
   slot: AtclPromotionSlot,
   now: Date = new Date()
 ): AtclPromotion | null {
-  return PROMOTIONS.find((promotion) => promotion.slot === slot && isActivePromotion(promotion, now)) ?? null;
+  return getLocalAtclPromotionBySlot(slot, now);
 }

--- a/apps/mobile/src/hooks/useAtclPromotion.ts
+++ b/apps/mobile/src/hooks/useAtclPromotion.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import type { AtclPromotion, AtclPromotionSlot } from '../data/atcl_promotions';
+import { getLocalAtclPromotionBySlot } from '../data/atcl_promotions';
+import { getAtclPromotionBySlotSmart } from '../services/atcl-promotions';
+
+export function useAtclPromotion(slot: AtclPromotionSlot) {
+  const [promotion, setPromotion] = useState<AtclPromotion | null>(() =>
+    getLocalAtclPromotionBySlot(slot)
+  );
+
+  useEffect(() => {
+    let active = true;
+    setPromotion(getLocalAtclPromotionBySlot(slot));
+
+    void getAtclPromotionBySlotSmart(slot).then((value) => {
+      if (!active) return;
+      setPromotion(value);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [slot]);
+
+  return promotion;
+}

--- a/apps/mobile/src/services/atcl-promotions.ts
+++ b/apps/mobile/src/services/atcl-promotions.ts
@@ -11,6 +11,8 @@ type RssItem = {
   categories: string[];
 };
 
+type PromoSourceKey = 'atcl-rss' | 'rossellini-rss' | 'atcl-rest' | 'rossellini-rest';
+
 const REMOTE_CACHE_TTL_MS = 15 * 60 * 1000;
 const RSS_ACCEPT_HEADER = 'application/rss+xml, application/xml;q=0.9, text/xml;q=0.8';
 
@@ -26,6 +28,12 @@ const ATCL_REST_PROMO_URL =
 const ROSSELLINI_REST_PROMO_URL =
   import.meta.env.VITE_ROSSELLINI_PROMO_REST_URL ??
   'https://www.spaziorossellini.it/wp-json/wp/v2/posts?categories=21&per_page=6&_fields=title,link,date,excerpt';
+const ATCL_PROMO_PROXY_PATH =
+  import.meta.env.VITE_ATCL_PROMO_PROXY_PATH ?? '/api/promotions/proxy';
+const ATCL_PROMO_USE_LOCAL_PROXY =
+  parseOptionalBooleanEnv(import.meta.env.VITE_ATCL_PROMO_USE_LOCAL_PROXY) ?? true;
+const ATCL_PROMO_ALLOW_EXTERNAL_FALLBACK =
+  parseOptionalBooleanEnv(import.meta.env.VITE_ATCL_PROMO_ALLOW_EXTERNAL_FALLBACK) ?? false;
 const ATCL_PROMO_CORS_PROXY_TEMPLATE =
   import.meta.env.VITE_ATCL_PROMO_CORS_PROXY_TEMPLATE ??
   'https://api.allorigins.win/raw?url={url}';
@@ -107,21 +115,21 @@ async function loadRemotePromotions(): Promise<PromotionBySlot> {
 }
 
 async function fetchAtclItems(): Promise<RssItem[]> {
-  const fromRss = await fetchRssItems(ATCL_FEED_URL);
+  const fromRss = await fetchRssItems(ATCL_FEED_URL, 'atcl-rss');
   if (fromRss.length > 0) return fromRss;
-  return fetchWordpressPosts(ATCL_REST_PROMO_URL);
+  return fetchWordpressPosts(ATCL_REST_PROMO_URL, 'atcl-rest');
 }
 
 async function fetchRosselliniItems(): Promise<RssItem[]> {
-  const fromRss = await fetchRssItems(ROSSELLINI_FEED_URL);
+  const fromRss = await fetchRssItems(ROSSELLINI_FEED_URL, 'rossellini-rss');
   if (fromRss.length > 0) return fromRss;
-  return fetchWordpressPosts(ROSSELLINI_REST_PROMO_URL);
+  return fetchWordpressPosts(ROSSELLINI_REST_PROMO_URL, 'rossellini-rest');
 }
 
-async function fetchRssItems(url: string): Promise<RssItem[]> {
+async function fetchRssItems(url: string, sourceKey: PromoSourceKey): Promise<RssItem[]> {
   if (typeof window === 'undefined' || typeof DOMParser === 'undefined') return [];
 
-  for (const candidateUrl of buildRemoteFetchCandidates(url)) {
+  for (const candidateUrl of buildRemoteFetchCandidates(url, sourceKey)) {
     try {
       const response = await fetch(candidateUrl, {
         method: 'GET',
@@ -159,8 +167,8 @@ async function fetchRssItems(url: string): Promise<RssItem[]> {
   return [];
 }
 
-async function fetchWordpressPosts(url: string): Promise<RssItem[]> {
-  for (const candidateUrl of buildRemoteFetchCandidates(url)) {
+async function fetchWordpressPosts(url: string, sourceKey: PromoSourceKey): Promise<RssItem[]> {
+  for (const candidateUrl of buildRemoteFetchCandidates(url, sourceKey)) {
     try {
       const response = await fetch(candidateUrl, {
         method: 'GET',
@@ -206,11 +214,16 @@ async function fetchWordpressPosts(url: string): Promise<RssItem[]> {
   return [];
 }
 
-function buildRemoteFetchCandidates(url: string): string[] {
-  const proxyUrl = buildProxyUrl(url);
-  const candidates = ATCL_PROMO_ALLOW_DIRECT_FETCH
-    ? [url, proxyUrl]
-    : [proxyUrl];
+function buildRemoteFetchCandidates(url: string, sourceKey: PromoSourceKey): string[] {
+  const localProxyUrl = buildLocalProxyUrl(sourceKey);
+  const externalProxyUrl = buildExternalProxyUrl(url);
+  const directUrlCandidates = ATCL_PROMO_ALLOW_DIRECT_FETCH ? [url] : [];
+  const externalCandidates = ATCL_PROMO_ALLOW_EXTERNAL_FALLBACK
+    ? [externalProxyUrl, ...directUrlCandidates]
+    : directUrlCandidates;
+  const candidates = ATCL_PROMO_USE_LOCAL_PROXY
+    ? [localProxyUrl, ...externalCandidates]
+    : externalCandidates;
 
   const unique: string[] = [];
   for (const candidate of candidates) {
@@ -221,7 +234,12 @@ function buildRemoteFetchCandidates(url: string): string[] {
   return unique;
 }
 
-function buildProxyUrl(url: string): string {
+function buildLocalProxyUrl(sourceKey: PromoSourceKey): string {
+  const separator = ATCL_PROMO_PROXY_PATH.includes('?') ? '&' : '?';
+  return `${ATCL_PROMO_PROXY_PATH}${separator}source=${encodeURIComponent(sourceKey)}`;
+}
+
+function buildExternalProxyUrl(url: string): string {
   const encodedTarget = encodeURIComponent(url);
   if (ATCL_PROMO_CORS_PROXY_TEMPLATE.includes('{url}')) {
     return ATCL_PROMO_CORS_PROXY_TEMPLATE.replace('{url}', encodedTarget);

--- a/apps/mobile/src/services/atcl-promotions.ts
+++ b/apps/mobile/src/services/atcl-promotions.ts
@@ -26,6 +26,11 @@ const ATCL_REST_PROMO_URL =
 const ROSSELLINI_REST_PROMO_URL =
   import.meta.env.VITE_ROSSELLINI_PROMO_REST_URL ??
   'https://www.spaziorossellini.it/wp-json/wp/v2/posts?categories=21&per_page=6&_fields=title,link,date,excerpt';
+const ATCL_PROMO_CORS_PROXY_TEMPLATE =
+  import.meta.env.VITE_ATCL_PROMO_CORS_PROXY_TEMPLATE ??
+  'https://api.allorigins.win/raw?url={url}';
+const ATCL_PROMO_ALLOW_DIRECT_FETCH =
+  parseOptionalBooleanEnv(import.meta.env.VITE_ATCL_PROMO_ALLOW_DIRECT_FETCH) ?? false;
 
 let remoteCacheExpiresAt = 0;
 let remoteCacheData: PromotionBySlot | null = null;
@@ -58,7 +63,12 @@ async function loadRemotePromotionsSafe(): Promise<PromotionBySlot> {
       remoteCacheExpiresAt = Date.now() + REMOTE_CACHE_TTL_MS;
       return data;
     })
-    .catch(() => remoteCacheData ?? {})
+    .catch(() => {
+      const fallback = remoteCacheData ?? {};
+      remoteCacheData = fallback;
+      remoteCacheExpiresAt = Date.now() + REMOTE_CACHE_TTL_MS;
+      return fallback;
+    })
     .finally(() => {
       inflightLoad = null;
     });
@@ -111,77 +121,113 @@ async function fetchRosselliniItems(): Promise<RssItem[]> {
 async function fetchRssItems(url: string): Promise<RssItem[]> {
   if (typeof window === 'undefined' || typeof DOMParser === 'undefined') return [];
 
-  try {
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        accept: RSS_ACCEPT_HEADER,
-      },
-    });
-    if (!response.ok) return [];
+  for (const candidateUrl of buildRemoteFetchCandidates(url)) {
+    try {
+      const response = await fetch(candidateUrl, {
+        method: 'GET',
+        headers: {
+          accept: RSS_ACCEPT_HEADER,
+        },
+      });
+      if (!response.ok) continue;
 
-    const xmlText = await response.text();
-    const parser = new DOMParser();
-    const xml = parser.parseFromString(xmlText, 'application/xml');
-    if (xml.querySelector('parsererror')) return [];
+      const xmlText = await response.text();
+      const parser = new DOMParser();
+      const xml = parser.parseFromString(xmlText, 'application/xml');
+      if (xml.querySelector('parsererror')) continue;
 
-    return Array.from(xml.querySelectorAll('channel > item'))
-      .map((item) => {
-        const title = collapseWhitespace(item.querySelector('title')?.textContent ?? '');
-        const link = collapseWhitespace(item.querySelector('link')?.textContent ?? '');
-        const pubDate = collapseWhitespace(item.querySelector('pubDate')?.textContent ?? '');
-        const description = sanitizeText(item.querySelector('description')?.textContent ?? '');
-        const categories = Array.from(item.querySelectorAll('category'))
-          .map((category) => collapseWhitespace(category.textContent ?? ''))
-          .filter(Boolean);
+      const items = Array.from(xml.querySelectorAll('channel > item'))
+        .map((item) => {
+          const title = collapseWhitespace(item.querySelector('title')?.textContent ?? '');
+          const link = collapseWhitespace(item.querySelector('link')?.textContent ?? '');
+          const pubDate = collapseWhitespace(item.querySelector('pubDate')?.textContent ?? '');
+          const description = sanitizeText(item.querySelector('description')?.textContent ?? '');
+          const categories = Array.from(item.querySelectorAll('category'))
+            .map((category) => collapseWhitespace(category.textContent ?? ''))
+            .filter(Boolean);
 
-        return { title, link, pubDate, description, categories };
-      })
-      .filter((item) => Boolean(item.title || item.link));
-  } catch {
-    return [];
+          return { title, link, pubDate, description, categories };
+        })
+        .filter((item) => Boolean(item.title || item.link));
+
+      if (items.length > 0) return items;
+    } catch {
+      // best effort: try next candidate URL
+    }
   }
+
+  return [];
 }
 
 async function fetchWordpressPosts(url: string): Promise<RssItem[]> {
-  try {
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        accept: 'application/json',
-      },
-    });
-    if (!response.ok) return [];
+  for (const candidateUrl of buildRemoteFetchCandidates(url)) {
+    try {
+      const response = await fetch(candidateUrl, {
+        method: 'GET',
+        headers: {
+          accept: 'application/json',
+        },
+      });
+      if (!response.ok) continue;
 
-    const payload = (await response.json()) as unknown;
-    if (!Array.isArray(payload)) return [];
+      const payload = (await response.json()) as unknown;
+      if (!Array.isArray(payload)) continue;
 
-    return payload
-      .map((entry) => {
-        const item = entry as {
-          link?: unknown;
-          date?: unknown;
-          title?: { rendered?: unknown };
-          excerpt?: { rendered?: unknown };
-        };
+      const items = payload
+        .map((entry) => {
+          const item = entry as {
+            link?: unknown;
+            date?: unknown;
+            title?: { rendered?: unknown };
+            excerpt?: { rendered?: unknown };
+          };
 
-        const title = sanitizeText(asString(item.title?.rendered));
-        const description = sanitizeText(asString(item.excerpt?.rendered));
-        const link = collapseWhitespace(asString(item.link));
-        const pubDate = collapseWhitespace(asString(item.date));
+          const title = sanitizeText(asString(item.title?.rendered));
+          const description = sanitizeText(asString(item.excerpt?.rendered));
+          const link = collapseWhitespace(asString(item.link));
+          const pubDate = collapseWhitespace(asString(item.date));
 
-        return {
-          title,
-          description,
-          link,
-          pubDate,
-          categories: [],
-        };
-      })
-      .filter((item) => Boolean(item.title || item.link));
-  } catch {
-    return [];
+          return {
+            title,
+            description,
+            link,
+            pubDate,
+            categories: [],
+          };
+        })
+        .filter((item) => Boolean(item.title || item.link));
+
+      if (items.length > 0) return items;
+    } catch {
+      // best effort: try next candidate URL
+    }
   }
+
+  return [];
+}
+
+function buildRemoteFetchCandidates(url: string): string[] {
+  const proxyUrl = buildProxyUrl(url);
+  const candidates = ATCL_PROMO_ALLOW_DIRECT_FETCH
+    ? [url, proxyUrl]
+    : [proxyUrl];
+
+  const unique: string[] = [];
+  for (const candidate of candidates) {
+    const trimmed = candidate.trim();
+    if (!trimmed || unique.includes(trimmed)) continue;
+    unique.push(trimmed);
+  }
+  return unique;
+}
+
+function buildProxyUrl(url: string): string {
+  const encodedTarget = encodeURIComponent(url);
+  if (ATCL_PROMO_CORS_PROXY_TEMPLATE.includes('{url}')) {
+    return ATCL_PROMO_CORS_PROXY_TEMPLATE.replace('{url}', encodedTarget);
+  }
+  const separator = ATCL_PROMO_CORS_PROXY_TEMPLATE.includes('?') ? '&' : '?';
+  return `${ATCL_PROMO_CORS_PROXY_TEMPLATE}${separator}url=${encodedTarget}`;
 }
 
 function mapItemToPromotion(
@@ -238,4 +284,12 @@ function truncate(value: string, maxLength: number): string {
 
 function asString(value: unknown): string {
   return typeof value === 'string' ? value : '';
+}
+
+function parseOptionalBooleanEnv(value: unknown): boolean | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return null;
 }

--- a/apps/mobile/src/services/atcl-promotions.ts
+++ b/apps/mobile/src/services/atcl-promotions.ts
@@ -1,0 +1,241 @@
+import type { AtclPromotion, AtclPromotionSlot } from '../data/atcl_promotions';
+import { getLocalAtclPromotionBySlot, isAtclPromotionActive } from '../data/atcl_promotions';
+
+type PromotionBySlot = Partial<Record<AtclPromotionSlot, AtclPromotion>>;
+
+type RssItem = {
+  title: string;
+  link: string;
+  description: string;
+  pubDate: string;
+  categories: string[];
+};
+
+const REMOTE_CACHE_TTL_MS = 15 * 60 * 1000;
+const RSS_ACCEPT_HEADER = 'application/rss+xml, application/xml;q=0.9, text/xml;q=0.8';
+
+const ATCL_FEED_URL =
+  import.meta.env.VITE_ATCL_PROMO_FEED_URL ?? 'https://www.atcllazio.it/feed/';
+const ROSSELLINI_FEED_URL =
+  import.meta.env.VITE_ROSSELLINI_PROMO_FEED_URL ??
+  'https://www.spaziorossellini.it/category/slide-evidenza/feed/';
+
+const ATCL_REST_PROMO_URL =
+  import.meta.env.VITE_ATCL_PROMO_REST_URL ??
+  'https://www.atcllazio.it/wp-json/wp/v2/posts?categories=421&per_page=6&_fields=title,link,date,excerpt';
+const ROSSELLINI_REST_PROMO_URL =
+  import.meta.env.VITE_ROSSELLINI_PROMO_REST_URL ??
+  'https://www.spaziorossellini.it/wp-json/wp/v2/posts?categories=21&per_page=6&_fields=title,link,date,excerpt';
+
+let remoteCacheExpiresAt = 0;
+let remoteCacheData: PromotionBySlot | null = null;
+let inflightLoad: Promise<PromotionBySlot> | null = null;
+
+export async function getAtclPromotionBySlotSmart(
+  slot: AtclPromotionSlot,
+  now: Date = new Date()
+): Promise<AtclPromotion | null> {
+  const remotePromotions = await loadRemotePromotionsSafe();
+  const remote = remotePromotions[slot];
+  if (remote && isAtclPromotionActive(remote, now)) {
+    return remote;
+  }
+  return getLocalAtclPromotionBySlot(slot, now);
+}
+
+async function loadRemotePromotionsSafe(): Promise<PromotionBySlot> {
+  const now = Date.now();
+  if (remoteCacheData && remoteCacheExpiresAt > now) {
+    return remoteCacheData;
+  }
+  if (inflightLoad) {
+    return inflightLoad;
+  }
+
+  inflightLoad = loadRemotePromotions()
+    .then((data) => {
+      remoteCacheData = data;
+      remoteCacheExpiresAt = Date.now() + REMOTE_CACHE_TTL_MS;
+      return data;
+    })
+    .catch(() => remoteCacheData ?? {})
+    .finally(() => {
+      inflightLoad = null;
+    });
+
+  return inflightLoad;
+}
+
+async function loadRemotePromotions(): Promise<PromotionBySlot> {
+  const [atclItems, rosselliniItems] = await Promise.all([
+    fetchAtclItems(),
+    fetchRosselliniItems(),
+  ]);
+
+  const atclTop =
+    atclItems.find((item) =>
+      item.categories.some((category) => /promo|news|novit/i.test(category))
+    ) ?? atclItems[0];
+  const rosselliniTop = rosselliniItems[0];
+
+  const promotions: PromotionBySlot = {};
+  if (atclTop) {
+    promotions.home = mapItemToPromotion(atclTop, {
+      slot: 'home',
+      badgeLabel: 'Novita ATCL',
+      ctaLabel: 'Apri notizia',
+    });
+  }
+  if (rosselliniTop) {
+    promotions.turns = mapItemToPromotion(rosselliniTop, {
+      slot: 'turns',
+      badgeLabel: 'Spazio Rossellini',
+      ctaLabel: 'Dettagli evento',
+    });
+  }
+  return promotions;
+}
+
+async function fetchAtclItems(): Promise<RssItem[]> {
+  const fromRss = await fetchRssItems(ATCL_FEED_URL);
+  if (fromRss.length > 0) return fromRss;
+  return fetchWordpressPosts(ATCL_REST_PROMO_URL);
+}
+
+async function fetchRosselliniItems(): Promise<RssItem[]> {
+  const fromRss = await fetchRssItems(ROSSELLINI_FEED_URL);
+  if (fromRss.length > 0) return fromRss;
+  return fetchWordpressPosts(ROSSELLINI_REST_PROMO_URL);
+}
+
+async function fetchRssItems(url: string): Promise<RssItem[]> {
+  if (typeof window === 'undefined' || typeof DOMParser === 'undefined') return [];
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        accept: RSS_ACCEPT_HEADER,
+      },
+    });
+    if (!response.ok) return [];
+
+    const xmlText = await response.text();
+    const parser = new DOMParser();
+    const xml = parser.parseFromString(xmlText, 'application/xml');
+    if (xml.querySelector('parsererror')) return [];
+
+    return Array.from(xml.querySelectorAll('channel > item'))
+      .map((item) => {
+        const title = collapseWhitespace(item.querySelector('title')?.textContent ?? '');
+        const link = collapseWhitespace(item.querySelector('link')?.textContent ?? '');
+        const pubDate = collapseWhitespace(item.querySelector('pubDate')?.textContent ?? '');
+        const description = sanitizeText(item.querySelector('description')?.textContent ?? '');
+        const categories = Array.from(item.querySelectorAll('category'))
+          .map((category) => collapseWhitespace(category.textContent ?? ''))
+          .filter(Boolean);
+
+        return { title, link, pubDate, description, categories };
+      })
+      .filter((item) => Boolean(item.title || item.link));
+  } catch {
+    return [];
+  }
+}
+
+async function fetchWordpressPosts(url: string): Promise<RssItem[]> {
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+      },
+    });
+    if (!response.ok) return [];
+
+    const payload = (await response.json()) as unknown;
+    if (!Array.isArray(payload)) return [];
+
+    return payload
+      .map((entry) => {
+        const item = entry as {
+          link?: unknown;
+          date?: unknown;
+          title?: { rendered?: unknown };
+          excerpt?: { rendered?: unknown };
+        };
+
+        const title = sanitizeText(asString(item.title?.rendered));
+        const description = sanitizeText(asString(item.excerpt?.rendered));
+        const link = collapseWhitespace(asString(item.link));
+        const pubDate = collapseWhitespace(asString(item.date));
+
+        return {
+          title,
+          description,
+          link,
+          pubDate,
+          categories: [],
+        };
+      })
+      .filter((item) => Boolean(item.title || item.link));
+  } catch {
+    return [];
+  }
+}
+
+function mapItemToPromotion(
+  item: RssItem,
+  config: { slot: AtclPromotionSlot; badgeLabel: string; ctaLabel: string }
+): AtclPromotion {
+  const slug = (item.link || item.title || config.slot)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+
+  return {
+    id: `${config.slot}-${slug || 'news'}`,
+    slot: config.slot,
+    badgeLabel: config.badgeLabel,
+    title: truncate(collapseWhitespace(item.title) || 'Novita in evidenza', 120),
+    description:
+      truncate(item.description || 'Consulta i dettagli sul sito ufficiale.', 220),
+    ctaLabel: config.ctaLabel,
+    ctaUrl: item.link || undefined,
+    startsAt: toIsoDate(item.pubDate),
+  };
+}
+
+function toIsoDate(value: string): string | undefined {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return undefined;
+  return new Date(parsed).toISOString();
+}
+
+function sanitizeText(value: string): string {
+  const withoutBoilerplate = value.replace(/The post[\s\S]*$/i, '');
+  return collapseWhitespace(stripHtml(withoutBoilerplate));
+}
+
+function stripHtml(value: string): string {
+  if (typeof window === 'undefined' || typeof DOMParser === 'undefined') {
+    return value.replace(/<[^>]+>/g, ' ');
+  }
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(value, 'text/html');
+  return doc.body?.textContent ?? '';
+}
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -218,6 +218,9 @@ const OFFLINE_SYNC_SERVER_LOG_BATCH_SIZE = 60;
 const OFFLINE_SYNC_SERVER_LOG_MAX_ITEMS = 2500;
 const OFFLINE_SYNC_SERVER_LOG_RETRY_INTERVAL_MS = 8000;
 const OFFLINE_SYNC_SERVER_LOG_FUNCTION = 'mobile-logs';
+const OFFLINE_SYNC_SERVER_LOG_MIRROR_ENV =
+  import.meta.env.VITE_OFFLINE_SYNC_SERVER_LOG_MIRROR_ENABLED;
+const OFFLINE_SYNC_SERVER_LOG_PREVIEW_HOST_RE = /^turni-di-palco-pr-\d+\.onrender\.com$/i;
 const OFFLINE_SYNC_LOG_PREFIX = '[TDP Offline Sync]';
 const MOBILE_WATCHDOG_TIMEOUTS = {
   refreshTurnStats: 10000,
@@ -358,7 +361,7 @@ function serializeMirroredLogDetails(details: unknown): unknown {
 }
 
 function readMirroredClientLogs(): MirroredClientLogEntry[] {
-  if (typeof window === 'undefined' || !isSupabaseConfigured) return [];
+  if (typeof window === 'undefined' || !isSupabaseConfigured || !shouldMirrorOfflineSyncLogsToServer()) return [];
   try {
     const raw = window.localStorage.getItem(OFFLINE_SYNC_SERVER_LOG_QUEUE_KEY);
     if (!raw) return [];
@@ -397,7 +400,7 @@ function readMirroredClientLogs(): MirroredClientLogEntry[] {
 }
 
 function writeMirroredClientLogs(queue: MirroredClientLogEntry[]) {
-  if (typeof window === 'undefined' || !isSupabaseConfigured) return;
+  if (typeof window === 'undefined' || !isSupabaseConfigured || !shouldMirrorOfflineSyncLogsToServer()) return;
   try {
     if (!queue.length) {
       window.localStorage.removeItem(OFFLINE_SYNC_SERVER_LOG_QUEUE_KEY);
@@ -413,7 +416,7 @@ function writeMirroredClientLogs(queue: MirroredClientLogEntry[]) {
 }
 
 function enqueueMirroredClientLog(message: string, level: OfflineSyncLogLevel, details?: unknown) {
-  if (typeof window === 'undefined' || !isSupabaseConfigured) return;
+  if (typeof window === 'undefined' || !isSupabaseConfigured || !shouldMirrorOfflineSyncLogsToServer()) return;
   const trimmedMessage = message.trim();
   if (!trimmedMessage) return;
   const queue = readMirroredClientLogs();
@@ -547,6 +550,21 @@ function isQueuedMutationKind(value: unknown): value is QueuedMutationKind {
 
 function isNavigatorOffline() {
   return typeof navigator !== 'undefined' && navigator.onLine === false;
+}
+
+function parseOptionalBooleanEnv(value: unknown): boolean | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return null;
+}
+
+function shouldMirrorOfflineSyncLogsToServer() {
+  const envOverride = parseOptionalBooleanEnv(OFFLINE_SYNC_SERVER_LOG_MIRROR_ENV);
+  if (envOverride !== null) return envOverride;
+  if (typeof window === 'undefined') return true;
+  return !OFFLINE_SYNC_SERVER_LOG_PREVIEW_HOST_RE.test(window.location.hostname);
 }
 
 function createOfflineMutationId() {
@@ -1321,7 +1339,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const flushMirroredClientLogsToServer = useCallback(async () => {
-    if (!isSupabaseConfigured || !supabase) return;
+    if (!isSupabaseConfigured || !supabase || !shouldMirrorOfflineSyncLogsToServer()) return;
     if (offlineServerLogSyncInFlightRef.current) return;
     if (isNavigatorOffline()) return;
 
@@ -1790,12 +1808,12 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   }, [authUserId, flushQueuedSupabaseMutations]);
 
   useEffect(() => {
-    if (!isSupabaseConfigured || !supabase) return;
+    if (!isSupabaseConfigured || !supabase || !shouldMirrorOfflineSyncLogsToServer()) return;
     void flushMirroredClientLogsToServer();
   }, [authUserId, authReady, flushMirroredClientLogsToServer]);
 
   useEffect(() => {
-    if (!isSupabaseConfigured || !supabase) return;
+    if (!isSupabaseConfigured || !supabase || !shouldMirrorOfflineSyncLogsToServer()) return;
     if (typeof window === 'undefined') return;
     console.info(`${OFFLINE_SYNC_LOG_PREFIX} Server log mirror listeners started`, {
       retryIntervalMs: OFFLINE_SYNC_SERVER_LOG_RETRY_INTERVAL_MS,

--- a/render.yaml
+++ b/render.yaml
@@ -19,6 +19,8 @@ services:
   startCommand: npm --workspace apps/pwa run preview:https -- --host 0.0.0.0 --port
     $PORT --strictPort --clearScreen false
   autoDeployTrigger: commit
+  previews:
+    generation: manual
 - type: web
   name: Maxwell-AI-Support
   runtime: node
@@ -36,6 +38,8 @@ services:
   buildCommand: npm ci && npm install -g @openai/codex && npm install -g gh
   startCommand: npm run ai:support
   autoDeployTrigger: commit
+  previews:
+    generation: manual
 - type: web
   name: Turni-di-Palco-Control-Plane
   runtime: node
@@ -65,6 +69,8 @@ services:
   buildCommand: npm ci
   startCommand: npm run start:control-plane
   autoDeployTrigger: commit
+  previews:
+    generation: manual
 - type: web
   name: Turni-di-Palco-Badges
   runtime: docker
@@ -77,3 +83,5 @@ services:
   region: frankfurt
   dockerfilePath: tools/shields/Dockerfile
   autoDeployTrigger: commit
+  previews:
+    generation: manual

--- a/tools/serve-dist.js
+++ b/tools/serve-dist.js
@@ -3,6 +3,96 @@ const http = require('http');
 const https = require('https');
 const os = require('os');
 const path = require('path');
+const { URL } = require('url');
+
+const PROMO_PROXY_SOURCES = Object.freeze({
+  'atcl-rss': {
+    url: 'https://www.atcllazio.it/feed/',
+    defaultContentType: 'application/rss+xml; charset=utf-8',
+  },
+  'rossellini-rss': {
+    url: 'https://www.spaziorossellini.it/category/slide-evidenza/feed/',
+    defaultContentType: 'application/rss+xml; charset=utf-8',
+  },
+  'atcl-rest': {
+    url: 'https://www.atcllazio.it/wp-json/wp/v2/posts?categories=421&per_page=6&_fields=title,link,date,excerpt',
+    defaultContentType: 'application/json; charset=utf-8',
+  },
+  'rossellini-rest': {
+    url: 'https://www.spaziorossellini.it/wp-json/wp/v2/posts?categories=21&per_page=6&_fields=title,link,date,excerpt',
+    defaultContentType: 'application/json; charset=utf-8',
+  },
+});
+const PROMO_PROXY_MAX_AGE_SECONDS = 300;
+
+function safeJsonResponse(res, statusCode, payload) {
+  res.statusCode = statusCode;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.end(JSON.stringify(payload));
+}
+
+async function handlePromoProxyRequest(req, res) {
+  const method = (req.method || 'GET').toUpperCase();
+  if (method !== 'GET') {
+    safeJsonResponse(res, 405, { ok: false, error: 'Method Not Allowed' });
+    return;
+  }
+
+  const url = new URL(req.url || '/', 'http://localhost');
+  const source = (url.searchParams.get('source') || '').trim();
+  const sourceConfig = PROMO_PROXY_SOURCES[source];
+  if (!sourceConfig) {
+    safeJsonResponse(res, 400, {
+      ok: false,
+      error: 'Invalid promo source',
+      allowedSources: Object.keys(PROMO_PROXY_SOURCES),
+    });
+    return;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 8000);
+
+  try {
+    const upstream = await fetch(sourceConfig.url, {
+      method: 'GET',
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: {
+        'user-agent': 'Turni-di-Palco/1.0 (+https://turni-di-palco.onrender.com)',
+        accept: '*/*',
+      },
+    });
+
+    if (!upstream.ok) {
+      safeJsonResponse(res, 502, {
+        ok: false,
+        error: 'Upstream request failed',
+        source,
+        upstreamStatus: upstream.status,
+      });
+      return;
+    }
+
+    const payload = await upstream.arrayBuffer();
+    const contentType = upstream.headers.get('content-type') || sourceConfig.defaultContentType;
+
+    res.statusCode = 200;
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Cache-Control', `public, max-age=${PROMO_PROXY_MAX_AGE_SECONDS}`);
+    res.setHeader('X-TDP-Promo-Source', source);
+    res.end(Buffer.from(payload));
+  } catch (error) {
+    safeJsonResponse(res, 502, {
+      ok: false,
+      error: 'Promo proxy unavailable',
+      source,
+      detail: error instanceof Error ? error.message : 'Unknown error',
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
 
 function resolveHttpsOptions() {
   const httpsEnv = process.env.HTTPS;
@@ -157,6 +247,20 @@ function resolveCacheControl(distDir, filePath) {
 
 function createHandler(distDir) {
   return (req, res) => {
+    const requestUrl = req.url || '/';
+    const parsedPath = (() => {
+      try {
+        return new URL(requestUrl, 'http://localhost').pathname;
+      } catch {
+        return '/';
+      }
+    })();
+
+    if (parsedPath === '/api/promotions/proxy' || parsedPath === '/mobile/api/promotions/proxy') {
+      void handlePromoProxyRequest(req, res);
+      return;
+    }
+
     // Health check endpoint per keep-alive incrociato
     if (req.url === '/health' && req.method === 'GET') {
       res.statusCode = 200;


### PR DESCRIPTION
## Summary\n- implement mobile-only ATCL promo banner loading with smart remote source selection\n- fetch ATCL + Spazio Rossellini news from RSS feeds with WordPress REST fallback\n- keep local static promo fallback to avoid empty states\n- wire Home and ATCL Turns screens through a dedicated promo hook\n- add mobile env vars for feed/rest endpoints\n\n## Verification\n- npm --prefix apps/mobile run build\n