### PR TITLE
Fix control-plane SW reload shake

### DIFF
--- a/apps/mobile/src/services/feature-flags.ts
+++ b/apps/mobile/src/services/feature-flags.ts
@@ -40,7 +40,7 @@ export function isMobileFeatureFlagKey(value: string): value is MobileFeatureFla
 export function normalizeMobileFeatureFlags(rows: unknown): MobileFeatureFlagsState | null {
   if (!Array.isArray(rows)) return null;
 
-  const next: MobileFeatureFlagsState = { ...MOBILE_FEATURE_FLAGS_FAIL_CLOSED };
+  const next: MobileFeatureFlagsState = { ...MOBILE_FEATURE_FLAGS_ALL_ON };
   let hasKnownKey = false;
 
   for (const row of rows) {

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -12,7 +12,6 @@ import { formatErrorDetails, reportCriticalError } from '../services/error-handl
 import { withMobileWatchdog } from '../services/mobile-watchdog';
 import {
   MOBILE_FEATURE_FLAGS_ALL_ON,
-  MOBILE_FEATURE_FLAGS_FAIL_CLOSED,
   type MobileFeatureFlagKey,
   type MobileFeatureFlagsSource,
   type MobileFeatureFlagsState,
@@ -1480,9 +1479,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   const [remoteBadges, setRemoteBadges] = useState<Badge[]>([]);
   const [badgesLoading, setBadgesLoading] = useState(false);
   const [featureFlags, setFeatureFlags] = useState<MobileFeatureFlagsState>(() => (
-    isSupabaseConfigured ? { ...MOBILE_FEATURE_FLAGS_FAIL_CLOSED } : { ...MOBILE_FEATURE_FLAGS_ALL_ON }
+    { ...MOBILE_FEATURE_FLAGS_ALL_ON }
   ));
-  const [featureFlagsReady, setFeatureFlagsReady] = useState(!isSupabaseConfigured);
+  const [featureFlagsReady, setFeatureFlagsReady] = useState(true);
   const [featureFlagsSource, setFeatureFlagsSource] = useState<MobileFeatureFlagsSource>('default');
   const [followedEvents, setFollowedEvents] = useState<GameEvent[]>([]);
   const [followedEventsLoading, setFollowedEventsLoading] = useState(false);
@@ -2455,7 +2454,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         applyFeatureFlagsSnapshot(cachedFlags, 'cache');
         return;
       }
-      applyFeatureFlagsSnapshot(MOBILE_FEATURE_FLAGS_FAIL_CLOSED, 'default');
+      applyFeatureFlagsSnapshot(MOBILE_FEATURE_FLAGS_ALL_ON, 'default');
       return;
     }
 
@@ -2463,7 +2462,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       setFeatureFlags({ ...cachedFlags });
       setFeatureFlagsSource('cache');
     } else {
-      setFeatureFlags({ ...MOBILE_FEATURE_FLAGS_FAIL_CLOSED });
+      setFeatureFlags({ ...MOBILE_FEATURE_FLAGS_ALL_ON });
       setFeatureFlagsSource('default');
     }
     setFeatureFlagsReady(false);
@@ -2479,7 +2478,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             applyFeatureFlagsSnapshot(cachedFlags, 'cache');
             return;
           }
-          applyFeatureFlagsSnapshot(MOBILE_FEATURE_FLAGS_FAIL_CLOSED, 'default');
+          applyFeatureFlagsSnapshot(MOBILE_FEATURE_FLAGS_ALL_ON, 'default');
           return;
         }
 
@@ -2489,7 +2488,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             applyFeatureFlagsSnapshot(cachedFlags, 'cache');
             return;
           }
-          applyFeatureFlagsSnapshot(MOBILE_FEATURE_FLAGS_FAIL_CLOSED, 'default');
+          applyFeatureFlagsSnapshot(MOBILE_FEATURE_FLAGS_ALL_ON, 'default');
           return;
         }
 
@@ -2506,7 +2505,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         applyFeatureFlagsSnapshot(cachedFlags, 'cache');
         return;
       }
-      applyFeatureFlagsSnapshot(MOBILE_FEATURE_FLAGS_FAIL_CLOSED, 'default');
+      applyFeatureFlagsSnapshot(MOBILE_FEATURE_FLAGS_ALL_ON, 'default');
     });
   }, [applyFeatureFlagsSnapshot, authUserId]);
 
@@ -3754,11 +3753,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     setState(next);
     setPendingBoostRequests(0);
     setTurnSyncFeedback(null);
-    setFeatureFlags(
-      isSupabaseConfigured ? { ...MOBILE_FEATURE_FLAGS_FAIL_CLOSED } : { ...MOBILE_FEATURE_FLAGS_ALL_ON }
-    );
+    setFeatureFlags({ ...MOBILE_FEATURE_FLAGS_ALL_ON });
     setFeatureFlagsSource('default');
-    setFeatureFlagsReady(!isSupabaseConfigured);
+    setFeatureFlagsReady(true);
     const totalSlots = 3 + next.profile.extraActivitySlots;
     setActivitySlotsStatus({
       usedToday: 0,

--- a/apps/pwa/src/dev-plus/main.tsx
+++ b/apps/pwa/src/dev-plus/main.tsx
@@ -180,6 +180,10 @@ const MOBILE_FLAG_DEFAULTS: MobileFeatureFlagEntry[] = [
   { key: "mobile.action.shop_purchase", enabled: true, label: "Azione Acquisto Shop", description: "Abilita acquisti shop.", category: "action" },
 ];
 
+const MOBILE_FLAG_FALLBACK_ENTRIES: MobileFeatureFlagEntry[] = MOBILE_FLAG_DEFAULTS.map((entry) => ({
+  ...entry,
+}));
+
 function formatDateTime(value?: string) {
   if (!value) return "-";
   const date = new Date(value);
@@ -257,7 +261,7 @@ function App() {
     tone: "info",
     text: "Pronto. Seleziona un'azione, controlla e poi conferma.",
   });
-  const [mobileFlags, setMobileFlags] = useState<MobileFeatureFlagEntry[]>([]);
+  const [mobileFlags, setMobileFlags] = useState<MobileFeatureFlagEntry[]>(MOBILE_FLAG_FALLBACK_ENTRIES);
   const [mobileFlagsBusy, setMobileFlagsBusy] = useState(false);
   const [mobileFlagsFeedback, setMobileFlagsFeedback] = useState<FeedbackMessage>({
     tone: "info",
@@ -304,11 +308,15 @@ function App() {
 
   const loadMobileFlags = useCallback(async () => {
     if (!isSupabaseConfigured || !supabase) {
-      setMobileFlags([]);
+      setMobileFlags(MOBILE_FLAG_FALLBACK_ENTRIES);
       setMobileFlagsFeedback({ tone: "warn", text: "Supabase non configurato: impossibile leggere le mobile feature flags." });
       return;
     }
-    if (authState !== "authenticated") return;
+    if (authState !== "authenticated") {
+      setMobileFlags(MOBILE_FLAG_FALLBACK_ENTRIES);
+      setMobileFlagsFeedback({ tone: "info", text: "Preset locali visibili. Effettua login per leggere e modificare lo stato reale." });
+      return;
+    }
 
     setMobileFlagsBusy(true);
     const { data, error } = await supabase
@@ -319,6 +327,7 @@ function App() {
     setMobileFlagsBusy(false);
 
     if (error) {
+      setMobileFlags(MOBILE_FLAG_FALLBACK_ENTRIES);
       setMobileFlagsFeedback({ tone: "error", text: error.message || "Lettura feature flags fallita." });
       return;
     }
@@ -333,13 +342,17 @@ function App() {
       updatedBy: typeof row.updated_by === "string" ? row.updated_by : null,
     }));
 
+    if (!next.length) {
+      setMobileFlags(MOBILE_FLAG_FALLBACK_ENTRIES);
+      setMobileFlagsFeedback({
+        tone: "warn",
+        text: "Nessuna feature flag remota trovata: uso preset locali ON.",
+      });
+      return;
+    }
+
     setMobileFlags(next);
-    setMobileFlagsFeedback({
-      tone: "ok",
-      text: next.length
-        ? `${next.length} feature flags mobile caricate.`
-        : "Nessuna feature flag trovata: usa il reset per inizializzare.",
-    });
+    setMobileFlagsFeedback({ tone: "ok", text: `${next.length} feature flags mobile caricate.` });
   }, [authState]);
 
   useEffect(() => {
@@ -452,7 +465,7 @@ function App() {
     setValidation(null);
     setSnapshot(null);
     setCatalog([]);
-    setMobileFlags([]);
+    setMobileFlags(MOBILE_FLAG_FALLBACK_ENTRIES);
     setAuthState("anonymous");
     setPassword("");
     setCommandFeedback({ tone: "info", text: "Sessione chiusa." });

--- a/apps/pwa/src/dev-plus/main.tsx
+++ b/apps/pwa/src/dev-plus/main.tsx
@@ -8,7 +8,15 @@ import { createRoot } from "react-dom/client";
 import { promptServiceWorkerUpdate } from "../pwa/sw-update";
 import { registerServiceWorker } from "../pwa/register-sw";
 import { isSupabaseConfigured, supabase } from "../services/supabase";
-import { appConfig } from "../services/app-config";
+import {
+  appConfig,
+  clearStoredFeatureFlagOverrides,
+  getRuntimeFeatureFlagBaseline,
+  setStoredFeatureFlagOverride,
+  setStoredFeatureFlagOverrides,
+  type FeatureFlag,
+  type FeatureFlagConfig,
+} from "../services/app-config";
 import {
   buildControlPlaneUrl,
   getRoleAdaptiveQuickActions,
@@ -267,8 +275,14 @@ function App() {
     tone: "info",
     text: "Apri la sezione interruttori mobile per modificare le funzioni.",
   });
+  const [pwaFlags, setPwaFlags] = useState<FeatureFlagConfig>(() => ({ ...appConfig.featureFlags }));
+  const [pwaFlagsFeedback, setPwaFlagsFeedback] = useState<FeedbackMessage>({
+    tone: "info",
+    text: "Usa i toggle per attivare o disattivare le feature flags PWA.",
+  });
 
   const controlPlaneEndpoint = getControlPlaneEndpoint();
+  const pwaFlagBaseline = useMemo(() => getRuntimeFeatureFlagBaseline(), []);
 
   const commandOptions = useMemo(() => {
     const liveOptions = catalog.filter((entry) => entry.available);
@@ -708,11 +722,43 @@ function App() {
     });
   }, []);
 
+  const handleTogglePwaFlag = useCallback((flag: FeatureFlag, enabled: boolean) => {
+    setStoredFeatureFlagOverride(flag, enabled);
+    setPwaFlags((prev) => ({ ...prev, [flag]: enabled }));
+    setPwaFlagsFeedback({
+      tone: "ok",
+      text: `Flag aggiornata: ${flag} -> ${enabled ? "ON" : "OFF"}. Ricarica la pagina per applicarla ovunque.`,
+    });
+  }, []);
+
+  const handleSetAllPwaFlags = useCallback((enabled: boolean) => {
+    const keys = Object.keys(pwaFlags) as FeatureFlag[];
+    const next = keys.reduce((acc, key) => {
+      acc[key] = enabled;
+      return acc;
+    }, {} as FeatureFlagConfig);
+    setStoredFeatureFlagOverrides(next);
+    setPwaFlags(next);
+    setPwaFlagsFeedback({
+      tone: "ok",
+      text: `Feature flags PWA impostate su ${enabled ? "ON" : "OFF"}. Ricarica la pagina per applicarle ovunque.`,
+    });
+  }, [pwaFlags]);
+
+  const handleResetPwaFlags = useCallback(() => {
+    clearStoredFeatureFlagOverrides();
+    setPwaFlags({ ...pwaFlagBaseline });
+    setPwaFlagsFeedback({
+      tone: "info",
+      text: "Override locali rimossi. Ripristinato il baseline runtime delle flags PWA.",
+    });
+  }, [pwaFlagBaseline]);
+
   const auditRows: AuditEntry[] = snapshot?.audit ?? [];
   const renderRows: RenderServiceStatus[] = snapshot?.renderServices ?? [];
   const dbRows: DbOperationStatus[] = snapshot?.dbOperations ?? [];
   const currentUser = session?.user?.email || "anonymous";
-  const pwaFeatureFlags = Object.entries(appConfig.featureFlags);
+  const pwaFeatureFlags = Object.entries(pwaFlags) as [FeatureFlag, boolean][];
 
   return (
     <main className="cp-shell">
@@ -786,14 +832,35 @@ function App() {
       <section className="cp-grid cp-grid-2">
         <article className="cp-card">
           <h2>Feature flags PWA</h2>
-          <ul className="cp-list">
+          <div className="cp-inline-actions">
+            <button type="button" onClick={() => handleSetAllPwaFlags(true)}>
+              Tutte ON
+            </button>
+            <button type="button" className="ghost" onClick={() => handleSetAllPwaFlags(false)}>
+              Tutte OFF
+            </button>
+            <button type="button" className="ghost" onClick={handleResetPwaFlags}>
+              Reset
+            </button>
+          </div>
+          <p className={toFeedbackClass(pwaFlagsFeedback.tone)}>{pwaFlagsFeedback.text}</p>
+          <div className="cp-flag-list">
             {pwaFeatureFlags.map(([flagKey, enabled]) => (
-              <li key={flagKey}>
-                <strong>{flagKey}</strong>
-                <span className={enabled ? "cp-on" : "cp-off"}>{enabled ? "ON" : "OFF"}</span>
-              </li>
+              <article key={flagKey} className="cp-flag-item">
+                <div>
+                  <p>
+                    <strong>{flagKey}</strong>
+                  </p>
+                </div>
+                <div className="cp-inline-actions">
+                  <span className={enabled ? "cp-on" : "cp-off"}>{enabled ? "ON" : "OFF"}</span>
+                  <button type="button" onClick={() => handleTogglePwaFlag(flagKey, !enabled)}>
+                    {enabled ? "Disattiva" : "Attiva"}
+                  </button>
+                </div>
+              </article>
             ))}
-          </ul>
+          </div>
         </article>
 
         <article className="cp-card">

--- a/apps/pwa/src/pwa/sw-update.ts
+++ b/apps/pwa/src/pwa/sw-update.ts
@@ -1,5 +1,6 @@
 let activeToast: HTMLDivElement | null = null;
 let pendingRegistration: ServiceWorkerRegistration | null = null;
+let isReloadingForUpdate = false;
 
 function dismissToast() {
   if (activeToast) {
@@ -9,11 +10,17 @@ function dismissToast() {
 }
 
 function reloadWhenReady(registration: ServiceWorkerRegistration) {
-  const reload = () => window.location.reload();
+  const reloadOnce = () => {
+    if (isReloadingForUpdate) {
+      return;
+    }
+    isReloadingForUpdate = true;
+    window.location.reload();
+  };
 
   const onControllerChange = () => {
     navigator.serviceWorker.removeEventListener("controllerchange", onControllerChange);
-    reload();
+    reloadOnce();
   };
 
   navigator.serviceWorker.addEventListener("controllerchange", onControllerChange);
@@ -22,13 +29,10 @@ function reloadWhenReady(registration: ServiceWorkerRegistration) {
   if (waitingWorker) {
     waitingWorker.addEventListener("statechange", () => {
       if (waitingWorker.state === "activated") {
-        reload();
+        reloadOnce();
       }
     });
     waitingWorker.postMessage({ type: "SKIP_WAITING" });
-    waitingWorker.postMessage("skipWaiting");
-  } else {
-    reload();
   }
 }
 

--- a/apps/pwa/src/services/app-config.ts
+++ b/apps/pwa/src/services/app-config.ts
@@ -3,6 +3,7 @@ export type ServiceWorkerDevMode = "cleanup" | "register";
 export type RuntimeEnvironment = "development" | "production" | "test";
 
 export type FeatureFlagConfig = Record<FeatureFlag, boolean>;
+export type FeatureFlagOverride = Partial<FeatureFlagConfig>;
 
 export type RuntimeConfigOverride = {
   publicMode?: boolean;
@@ -48,6 +49,7 @@ export type AppConfig = {
 };
 
 const FEATURE_FLAG_KEYS: FeatureFlag[] = ["status-card", "permissions-card", "ai-support"];
+const FEATURE_FLAG_STORAGE_KEY = "tdp-pwa-feature-flags:v1";
 
 const DEFAULT_FEATURE_FLAGS: FeatureFlagConfig = {
   "status-card": true,
@@ -117,7 +119,8 @@ function resolveEnvironment(env: EnvSource): RuntimeEnvironment {
 
 function resolveFeatureFlags(
   env: EnvSource,
-  runtimeOverride?: Partial<FeatureFlagConfig>
+  runtimeOverride?: FeatureFlagOverride,
+  storedOverride?: FeatureFlagOverride
 ): FeatureFlagConfig {
   const enabled = new Set(parseList(env.VITE_FEATURE_FLAGS));
   const disabled = new Set(parseList(env.VITE_DISABLED_FEATURE_FLAGS));
@@ -127,6 +130,14 @@ function resolveFeatureFlags(
     if (enabled.has(flag)) resolved[flag] = true;
     if (disabled.has(flag)) resolved[flag] = false;
   });
+
+  if (storedOverride) {
+    FEATURE_FLAG_KEYS.forEach((flag) => {
+      if (typeof storedOverride[flag] === "boolean") {
+        resolved[flag] = storedOverride[flag] as boolean;
+      }
+    });
+  }
 
   if (runtimeOverride) {
     FEATURE_FLAG_KEYS.forEach((flag) => {
@@ -164,6 +175,72 @@ function readRuntimeOverride(): RuntimeConfigOverride | undefined {
   return window.__TDP_PWA_CONFIG__;
 }
 
+function sanitizeFeatureFlagOverride(value: unknown): FeatureFlagOverride | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const candidate = value as Record<string, unknown>;
+  const next: FeatureFlagOverride = {};
+
+  FEATURE_FLAG_KEYS.forEach((flag) => {
+    if (typeof candidate[flag] === "boolean") {
+      next[flag] = candidate[flag] as boolean;
+    }
+  });
+
+  return Object.keys(next).length ? next : undefined;
+}
+
+function readStoredFeatureFlagOverride(): FeatureFlagOverride | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const raw = window.localStorage.getItem(FEATURE_FLAG_STORAGE_KEY);
+    if (!raw) return undefined;
+    return sanitizeFeatureFlagOverride(JSON.parse(raw));
+  } catch {
+    return undefined;
+  }
+}
+
+function writeStoredFeatureFlagOverride(overrides: FeatureFlagOverride) {
+  if (typeof window === "undefined") return;
+  const sanitized = sanitizeFeatureFlagOverride(overrides);
+  if (!sanitized) {
+    window.localStorage.removeItem(FEATURE_FLAG_STORAGE_KEY);
+    return;
+  }
+  window.localStorage.setItem(FEATURE_FLAG_STORAGE_KEY, JSON.stringify(sanitized));
+}
+
+export function listFeatureFlagKeys(): FeatureFlag[] {
+  return [...FEATURE_FLAG_KEYS];
+}
+
+export function getRuntimeFeatureFlagBaseline(params?: {
+  env?: EnvSource;
+  runtimeOverride?: RuntimeConfigOverride;
+}): FeatureFlagConfig {
+  const env = params?.env ?? (import.meta.env as unknown as EnvSource);
+  const runtimeOverride = params?.runtimeOverride ?? readRuntimeOverride();
+  return resolveFeatureFlags(env, runtimeOverride?.featureFlags);
+}
+
+export function getStoredFeatureFlagOverrides(): FeatureFlagOverride {
+  return readStoredFeatureFlagOverride() ?? {};
+}
+
+export function setStoredFeatureFlagOverride(flag: FeatureFlag, enabled: boolean) {
+  const current = getStoredFeatureFlagOverrides();
+  writeStoredFeatureFlagOverride({ ...current, [flag]: enabled });
+}
+
+export function setStoredFeatureFlagOverrides(overrides: FeatureFlagOverride) {
+  writeStoredFeatureFlagOverride(overrides);
+}
+
+export function clearStoredFeatureFlagOverrides() {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(FEATURE_FLAG_STORAGE_KEY);
+}
+
 export function resolveAppConfig(params?: {
   env?: EnvSource;
   runtimeOverride?: RuntimeConfigOverride;
@@ -171,6 +248,7 @@ export function resolveAppConfig(params?: {
 }): AppConfig {
   const env = params?.env ?? (import.meta.env as unknown as EnvSource);
   const runtimeOverride = params?.runtimeOverride;
+  const storedFeatureFlags = params?.env ? undefined : readStoredFeatureFlagOverride();
   const origin =
     params?.origin ??
     (typeof window === "undefined" ? "" : window.location.origin);
@@ -236,7 +314,7 @@ export function resolveAppConfig(params?: {
           ? runtimeOverride.serviceWorker.devCleanupRegistrations
           : parseBoolean(env.VITE_SW_DEV_CLEANUP, true),
     },
-    featureFlags: resolveFeatureFlags(env, runtimeOverride?.featureFlags),
+    featureFlags: resolveFeatureFlags(env, runtimeOverride?.featureFlags, storedFeatureFlags),
   };
 }
 

--- a/apps/pwa/src/services/app-config.ts
+++ b/apps/pwa/src/services/app-config.ts
@@ -52,7 +52,7 @@ const FEATURE_FLAG_KEYS: FeatureFlag[] = ["status-card", "permissions-card", "ai
 const DEFAULT_FEATURE_FLAGS: FeatureFlagConfig = {
   "status-card": true,
   "permissions-card": true,
-  "ai-support": false,
+  "ai-support": true,
 };
 
 const DEFAULT_DEV_ACCESS_FUNCTION = "dev-access";


### PR DESCRIPTION
## Summary
- make SW update reload single-shot to avoid repeated rapid reloads
- remove duplicate skipWaiting message path
- keep control-plane update flow stable when applying a new service worker

## Validation
- npm run build:pwa
- npm run test:pwa *(fails in repo because @vitest/coverage-v8 is missing)*