### PR TITLE
Add per-flag descriptions and remove grouped controls

### DIFF
--- a/apps/pwa/src/dev-plus/dev-plus.css
+++ b/apps/pwa/src/dev-plus/dev-plus.css
@@ -262,6 +262,13 @@ button:disabled {
   margin: 0;
 }
 
+.cp-flag-description {
+  margin-top: 0.2rem !important;
+  color: var(--cp-muted);
+  font-size: 0.86rem;
+  line-height: 1.35;
+}
+
 .cp-feedback {
   margin: 0.55rem 0 0;
   border-radius: 10px;

--- a/apps/pwa/src/dev-plus/main.tsx
+++ b/apps/pwa/src/dev-plus/main.tsx
@@ -10,10 +10,8 @@ import { registerServiceWorker } from "../pwa/register-sw";
 import { isSupabaseConfigured, supabase } from "../services/supabase";
 import {
   appConfig,
-  clearStoredFeatureFlagOverrides,
-  getRuntimeFeatureFlagBaseline,
+  getFeatureFlagDescription,
   setStoredFeatureFlagOverride,
-  setStoredFeatureFlagOverrides,
   type FeatureFlag,
   type FeatureFlagConfig,
 } from "../services/app-config";
@@ -315,7 +313,6 @@ function App() {
   });
 
   const controlPlaneEndpoint = getControlPlaneEndpoint();
-  const pwaFlagBaseline = useMemo(() => getRuntimeFeatureFlagBaseline(), []);
 
   const commandOptions = useMemo(() => {
     const liveOptions = catalog.filter((entry) => entry.available);
@@ -579,74 +576,6 @@ function App() {
     [authState, loadMobileFlags, session]
   );
 
-  const handleBulkSetMobileFlags = useCallback(
-    async (enabled: boolean) => {
-      if (!supabase || authState !== "authenticated") {
-        setMobileFlagsFeedback({ tone: "error", text: "Sessione non valida per modificare le feature flags." });
-        return;
-      }
-      if (!mobileFlags.length) {
-        setMobileFlagsFeedback({ tone: "warn", text: "Nessuna flag disponibile per bulk update." });
-        return;
-      }
-
-      setMobileFlagsBusy(true);
-      const rows = mobileFlags.map((entry) => {
-        const fallback = MOBILE_FLAG_DEFAULTS_BY_KEY.get(entry.key);
-        return {
-          key: entry.key,
-          enabled,
-          label: entry.label || fallback?.label || entry.key,
-          description: entry.description || fallback?.description || "",
-          category: entry.category || fallback?.category || "action",
-        };
-      });
-      const { error } = await supabase
-        .from("mobile_feature_flags")
-        .upsert(rows, { onConflict: "key" });
-      setMobileFlagsBusy(false);
-
-      if (error) {
-        setMobileFlagsFeedback({ tone: "error", text: error.message || "Bulk update feature flags fallito." });
-        return;
-      }
-
-      setMobileFlagsFeedback({ tone: "ok", text: `Aggiornamento bulk completato: ${enabled ? "tutte ON" : "tutte OFF"}.` });
-      await loadMobileFlags(session);
-    },
-    [authState, loadMobileFlags, mobileFlags, session]
-  );
-
-  const handleResetMobileFlags = useCallback(async () => {
-    if (!supabase || authState !== "authenticated") {
-      setMobileFlagsFeedback({ tone: "error", text: "Sessione non valida per il reset feature flags." });
-      return;
-    }
-
-    setMobileFlagsBusy(true);
-    const { error } = await supabase
-      .from("mobile_feature_flags")
-      .upsert(
-        MOBILE_FLAG_DEFAULTS.map((entry) => ({
-          key: entry.key,
-          enabled: true,
-          label: entry.label,
-          description: entry.description,
-          category: entry.category,
-        })),
-        { onConflict: "key" }
-      );
-    setMobileFlagsBusy(false);
-
-    if (error) {
-      setMobileFlagsFeedback({ tone: "error", text: error.message || "Reset feature flags fallito." });
-      return;
-    }
-
-    setMobileFlagsFeedback({ tone: "ok", text: "Reset feature flags completato (seed ON)." });
-    await loadMobileFlags(session);
-  }, [authState, loadMobileFlags, session]);
-
   useEffect(() => {
     setPreparedCommand(null);
     setConfirmText("");
@@ -787,29 +716,6 @@ function App() {
     });
   }, []);
 
-  const handleSetAllPwaFlags = useCallback((enabled: boolean) => {
-    const keys = Object.keys(pwaFlags) as FeatureFlag[];
-    const next = keys.reduce((acc, key) => {
-      acc[key] = enabled;
-      return acc;
-    }, {} as FeatureFlagConfig);
-    setStoredFeatureFlagOverrides(next);
-    setPwaFlags(next);
-    setPwaFlagsFeedback({
-      tone: "ok",
-      text: `Feature flags PWA impostate su ${enabled ? "ON" : "OFF"}. Ricarica la pagina per applicarle ovunque.`,
-    });
-  }, [pwaFlags]);
-
-  const handleResetPwaFlags = useCallback(() => {
-    clearStoredFeatureFlagOverrides();
-    setPwaFlags({ ...pwaFlagBaseline });
-    setPwaFlagsFeedback({
-      tone: "info",
-      text: "Override locali rimossi. Ripristinato il baseline runtime delle flags PWA.",
-    });
-  }, [pwaFlagBaseline]);
-
   const isPwaFlagEnabled = useCallback(
     (flag: FeatureFlag) => Boolean(pwaFlags[flag]),
     [pwaFlags]
@@ -907,17 +813,6 @@ function App() {
         {showPwaFlagsSection ? (
         <article className="cp-card">
           <h2>Feature flags PWA</h2>
-          <div className="cp-inline-actions">
-            <button type="button" onClick={() => handleSetAllPwaFlags(true)}>
-              Tutte ON
-            </button>
-            <button type="button" className="ghost" onClick={() => handleSetAllPwaFlags(false)}>
-              Tutte OFF
-            </button>
-            <button type="button" className="ghost" onClick={handleResetPwaFlags}>
-              Reset
-            </button>
-          </div>
           <p className={toFeedbackClass(pwaFlagsFeedback.tone)}>{pwaFlagsFeedback.text}</p>
           <div className="cp-flag-list">
             {pwaFeatureFlags.map(([flagKey, enabled]) => (
@@ -926,6 +821,7 @@ function App() {
                   <p>
                     <strong>{flagKey}</strong>
                   </p>
+                  <p className="cp-flag-description">{getFeatureFlagDescription(flagKey)}</p>
                 </div>
                 <div className="cp-inline-actions">
                   <span className={enabled ? "cp-on" : "cp-off"}>{enabled ? "ON" : "OFF"}</span>
@@ -1055,15 +951,6 @@ function App() {
           <button type="button" onClick={() => void loadMobileFlags(session)} disabled={mobileFlagsBusy || authState !== "authenticated"}>
             {mobileFlagsBusy ? "Sync..." : "Ricarica"}
           </button>
-          <button type="button" onClick={() => void handleBulkSetMobileFlags(true)} disabled={mobileFlagsBusy || authState !== "authenticated"}>
-            Tutte ON
-          </button>
-          <button type="button" className="ghost" onClick={() => void handleBulkSetMobileFlags(false)} disabled={mobileFlagsBusy || authState !== "authenticated"}>
-            Tutte OFF
-          </button>
-          <button type="button" className="ghost" onClick={() => void handleResetMobileFlags()} disabled={mobileFlagsBusy || authState !== "authenticated"}>
-            Reset default
-          </button>
         </div>
 
         <p className={toFeedbackClass(mobileFlagsFeedback.tone)}>{mobileFlagsFeedback.text}</p>
@@ -1076,8 +963,9 @@ function App() {
                   <p>
                     <strong>{flag.label}</strong>
                   </p>
+                  <p className="cp-flag-description">{flag.description || "Descrizione non disponibile."}</p>
                   <p className="cp-muted">
-                    <code>{flag.key}</code> | {flag.category}
+                    <code>{flag.key}</code>
                   </p>
                 </div>
                 <div className="cp-inline-actions">

--- a/apps/pwa/src/main.ts
+++ b/apps/pwa/src/main.ts
@@ -1,5 +1,5 @@
 ﻿import "../../../shared/styles/main.css";
-import { appConfig, getConfigWarnings } from "./services/app-config";
+import { appConfig, getConfigWarnings, getFeatureFlagDescription, type FeatureFlag } from "./services/app-config";
 import { buildControlPlaneUrl } from "./services/ops-sdk";
 import { enforceDesktopOnly } from "./utils/desktop-only";
 
@@ -40,10 +40,16 @@ function renderActions() {
 }
 
 function renderFeatureFlags() {
-  return Object.entries(appConfig.featureFlags)
+  return (Object.entries(appConfig.featureFlags) as [FeatureFlag, boolean][])
     .map(
       ([key, enabled]) =>
-        `<li><strong>${key}</strong><span class="${enabled ? "tdp-flag-on" : "tdp-flag-off"}">${enabled ? "ON" : "OFF"}</span></li>`
+        `<li>
+          <div class="tdp-flag-meta">
+            <strong>${key}</strong>
+            <p class="tdp-flag-description">${getFeatureFlagDescription(key)}</p>
+          </div>
+          <span class="${enabled ? "tdp-flag-on" : "tdp-flag-off"}">${enabled ? "ON" : "OFF"}</span>
+        </li>`
     )
     .join("");
 }

--- a/apps/pwa/src/services/app-config.ts
+++ b/apps/pwa/src/services/app-config.ts
@@ -17,6 +17,10 @@ export type RuntimeEnvironment = "development" | "production" | "test";
 
 export type FeatureFlagConfig = Record<FeatureFlag, boolean>;
 export type FeatureFlagOverride = Partial<FeatureFlagConfig>;
+export type FeatureFlagDescriptor = {
+  key: FeatureFlag;
+  description: string;
+};
 
 export type RuntimeConfigOverride = {
   publicMode?: boolean;
@@ -92,6 +96,22 @@ const DEFAULT_FEATURE_FLAGS: FeatureFlagConfig = {
   "cp.audit-overview": true,
   "cp.db-overview": true,
   "cp.footer-status": true,
+};
+
+const FEATURE_FLAG_DESCRIPTIONS: Record<FeatureFlag, string> = {
+  "status-card": "Mostra i messaggi di stato ed errori sintetici nella dashboard.",
+  "permissions-card": "Mostra i ruoli/permessi della sessione utente nel control-plane.",
+  "ai-support": "Abilita i preset rapidi legati al supporto operativo assistito.",
+  "home.main-actions": "Mostra il blocco 'Azioni principali' nella home PWA.",
+  "home.pwa-flags": "Mostra il riepilogo delle feature flag nella home PWA.",
+  "cp.pwa-flags": "Abilita la sezione toggle delle feature flag PWA nel control-plane.",
+  "cp.quick-presets": "Abilita la sezione preset rapidi nel control-plane.",
+  "cp.command-wizard": "Abilita il wizard comandi Step 1/2 nel control-plane.",
+  "cp.mobile-flags": "Abilita la sezione toggle delle feature flag mobile nel control-plane.",
+  "cp.render-overview": "Mostra la card panoramica rilasci/servizi Render.",
+  "cp.audit-overview": "Mostra la card registro operazioni recenti.",
+  "cp.db-overview": "Mostra la card panoramica operazioni database.",
+  "cp.footer-status": "Mostra il footer con last refresh e data source.",
 };
 
 const DEFAULT_DEV_ACCESS_FUNCTION = "dev-access";
@@ -249,6 +269,17 @@ function writeStoredFeatureFlagOverride(overrides: FeatureFlagOverride) {
 
 export function listFeatureFlagKeys(): FeatureFlag[] {
   return [...FEATURE_FLAG_KEYS];
+}
+
+export function getFeatureFlagDescription(flag: FeatureFlag): string {
+  return FEATURE_FLAG_DESCRIPTIONS[flag] ?? "Descrizione non disponibile.";
+}
+
+export function listFeatureFlagDescriptors(): FeatureFlagDescriptor[] {
+  return FEATURE_FLAG_KEYS.map((key) => ({
+    key,
+    description: getFeatureFlagDescription(key),
+  }));
 }
 
 export function getRuntimeFeatureFlagBaseline(params?: {

--- a/apps/pwa/src/style.css
+++ b/apps/pwa/src/style.css
@@ -129,6 +129,18 @@ body {
   background: var(--tdp-surface-2);
 }
 
+.tdp-flag-meta {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.tdp-flag-description {
+  margin: 0;
+  color: var(--tdp-muted);
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
 .tdp-flag-on {
   color: var(--tdp-success);
   font-weight: 700;


### PR DESCRIPTION
## Summary
- add explicit descriptions for every PWA feature flag
- show those descriptions in home and control-plane feature flag lists
- remove grouped flag controls (all on/off/reset) and keep only per-flag toggles

## Validation
- npm --workspace apps/pwa run build