### PR TITLE
Migrate feature flags to Vercel Flags Explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ Variabili principali:
 - `RENDER_API_KEY`
 - `RENDER_SERVICE_IDS_JSON`
 
+### Flags Explorer (Vercel Toolbar)
+
+La PWA espone il discovery endpoint richiesto dal Toolbar:
+
+- `/.well-known/vercel/flags`
+
+Note operative:
+
+- È configurato `overrideEncryptionMode: plaintext` (setup custom): gli override arrivano dal cookie `vercel-flag-overrides`.
+- Gli override Toolbar hanno priorità alta in runtime su PWA e mobile web.
+- In assenza del cookie Toolbar il comportamento resta invariato:
+  - PWA: env + override locali/runtime.
+  - Mobile: Supabase/cache/default.
+
 Esempi deeplink Control Plane:
 
 - `/control-plane.html?view=commands&command=render.deployments.trigger&dryRun=true`

--- a/apps/mobile/src/services/feature-flags.ts
+++ b/apps/mobile/src/services/feature-flags.ts
@@ -1,23 +1,19 @@
-export const MOBILE_FEATURE_FLAG_KEYS = [
-  'mobile.section.turns',
-  'mobile.section.leaderboard',
-  'mobile.section.activities',
-  'mobile.section.shop',
-  'mobile.section.career',
-  'mobile.section.earned_titles',
-  'mobile.action.qr_scan',
-  'mobile.action.turn_submit',
-  'mobile.action.turn_boost',
-  'mobile.action.activity_start',
-  'mobile.action.activity_complete',
-  'mobile.action.shop_purchase',
-] as const;
+import {
+  MOBILE_FEATURE_FLAG_KEYS as SHARED_MOBILE_FEATURE_FLAG_KEYS,
+  type MobileFeatureFlagKey,
+} from "../../../../shared/flags/catalog";
+import {
+  pickBooleanOverrides,
+  readVercelFlagOverridesFromDocument,
+} from "../../../../shared/flags/vercel-overrides";
 
-export type MobileFeatureFlagKey = (typeof MOBILE_FEATURE_FLAG_KEYS)[number];
+export const MOBILE_FEATURE_FLAG_KEYS = SHARED_MOBILE_FEATURE_FLAG_KEYS;
+
+export type { MobileFeatureFlagKey };
 export type MobileFeatureFlagsState = Record<MobileFeatureFlagKey, boolean>;
-export type MobileFeatureFlagsSource = 'remote' | 'cache' | 'default';
+export type MobileFeatureFlagsSource = "remote" | "cache" | "default" | "vercel";
 
-const MOBILE_FEATURE_FLAG_CACHE_KEY = 'tdp-mobile-feature-flags:v1';
+const MOBILE_FEATURE_FLAG_CACHE_KEY = "tdp-mobile-feature-flags:v1";
 
 const buildFlagState = (value: boolean): MobileFeatureFlagsState =>
   MOBILE_FEATURE_FLAG_KEYS.reduce((acc, key) => {
@@ -44,9 +40,9 @@ export function normalizeMobileFeatureFlags(rows: unknown): MobileFeatureFlagsSt
   let hasKnownKey = false;
 
   for (const row of rows) {
-    if (!row || typeof row !== 'object') continue;
+    if (!row || typeof row !== "object") continue;
     const rowData = row as Partial<MobileFeatureFlagRow>;
-    if (typeof rowData.key !== 'string' || !isMobileFeatureFlagKey(rowData.key)) continue;
+    if (typeof rowData.key !== "string" || !isMobileFeatureFlagKey(rowData.key)) continue;
 
     next[rowData.key] = Boolean(rowData.enabled);
     hasKnownKey = true;
@@ -55,8 +51,24 @@ export function normalizeMobileFeatureFlags(rows: unknown): MobileFeatureFlagsSt
   return hasKnownKey ? next : null;
 }
 
+export function readVercelMobileFeatureFlagOverrides(): Partial<MobileFeatureFlagsState> {
+  const rawOverrides = readVercelFlagOverridesFromDocument();
+  return pickBooleanOverrides(MOBILE_FEATURE_FLAG_KEYS, rawOverrides);
+}
+
+export function applyMobileFeatureFlagOverrides(
+  baseline: MobileFeatureFlagsState,
+  overrides: Partial<MobileFeatureFlagsState>
+): MobileFeatureFlagsState {
+  if (!Object.keys(overrides).length) return { ...baseline };
+  return {
+    ...baseline,
+    ...overrides,
+  };
+}
+
 export function readMobileFeatureFlagsCache(): MobileFeatureFlagsState | null {
-  if (typeof window === 'undefined') return null;
+  if (typeof window === "undefined") return null;
   try {
     const raw = window.localStorage.getItem(MOBILE_FEATURE_FLAG_CACHE_KEY);
     if (!raw) return null;
@@ -68,7 +80,7 @@ export function readMobileFeatureFlagsCache(): MobileFeatureFlagsState | null {
 }
 
 export function writeMobileFeatureFlagsCache(flags: MobileFeatureFlagsState) {
-  if (typeof window === 'undefined') return;
+  if (typeof window === "undefined") return;
   try {
     const rows = MOBILE_FEATURE_FLAG_KEYS.map((key) => ({ key, enabled: Boolean(flags[key]) }));
     window.localStorage.setItem(MOBILE_FEATURE_FLAG_CACHE_KEY, JSON.stringify(rows));
@@ -78,7 +90,7 @@ export function writeMobileFeatureFlagsCache(flags: MobileFeatureFlagsState) {
 }
 
 export function clearMobileFeatureFlagsCache() {
-  if (typeof window === 'undefined') return;
+  if (typeof window === "undefined") return;
   try {
     window.localStorage.removeItem(MOBILE_FEATURE_FLAG_CACHE_KEY);
   } catch {

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -11,7 +11,9 @@ import { resolveDisplayName } from '../lib/profile-utils';
 import { formatErrorDetails, reportCriticalError } from '../services/error-handler';
 import { withMobileWatchdog } from '../services/mobile-watchdog';
 import {
+  applyMobileFeatureFlagOverrides,
   MOBILE_FEATURE_FLAGS_ALL_ON,
+  readVercelMobileFeatureFlagOverrides,
   type MobileFeatureFlagKey,
   type MobileFeatureFlagsSource,
   type MobileFeatureFlagsState,
@@ -2430,40 +2432,57 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     (
       nextFlags: MobileFeatureFlagsState,
       source: MobileFeatureFlagsSource,
-      persistCache = false
+      persistCache = false,
+      cacheSnapshot?: MobileFeatureFlagsState
     ) => {
       setFeatureFlags({ ...nextFlags });
       setFeatureFlagsSource(source);
       setFeatureFlagsReady(true);
       if (persistCache) {
-        writeMobileFeatureFlagsCache(nextFlags);
+        writeMobileFeatureFlagsCache(cacheSnapshot ?? nextFlags);
       }
     },
     []
   );
 
   const refreshFeatureFlags = useCallback(async () => {
+    const vercelOverrides = readVercelMobileFeatureFlagOverrides();
+    const hasVercelOverrides = Object.keys(vercelOverrides).length > 0;
+    const sourceWithVercel = (baseSource: Exclude<MobileFeatureFlagsSource, 'vercel'>): MobileFeatureFlagsSource =>
+      hasVercelOverrides ? 'vercel' : baseSource;
+    const applyRuntimeOverrides = (baseline: MobileFeatureFlagsState): MobileFeatureFlagsState =>
+      applyMobileFeatureFlagOverrides(baseline, vercelOverrides);
+
     if (!isSupabaseConfigured || !supabase) {
-      applyFeatureFlagsSnapshot(MOBILE_FEATURE_FLAGS_ALL_ON, 'default');
+      applyFeatureFlagsSnapshot(
+        applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_ALL_ON),
+        sourceWithVercel('default')
+      );
       return;
     }
 
     const cachedFlags = readMobileFeatureFlagsCache();
     if (!authUserId) {
       if (cachedFlags) {
-        applyFeatureFlagsSnapshot(cachedFlags, 'cache');
+        applyFeatureFlagsSnapshot(
+          applyRuntimeOverrides(cachedFlags),
+          sourceWithVercel('cache')
+        );
         return;
       }
-      applyFeatureFlagsSnapshot(MOBILE_FEATURE_FLAGS_ALL_ON, 'default');
+      applyFeatureFlagsSnapshot(
+        applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_ALL_ON),
+        sourceWithVercel('default')
+      );
       return;
     }
 
     if (cachedFlags) {
-      setFeatureFlags({ ...cachedFlags });
-      setFeatureFlagsSource('cache');
+      setFeatureFlags(applyRuntimeOverrides(cachedFlags));
+      setFeatureFlagsSource(sourceWithVercel('cache'));
     } else {
-      setFeatureFlags({ ...MOBILE_FEATURE_FLAGS_ALL_ON });
-      setFeatureFlagsSource('default');
+      setFeatureFlags(applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_ALL_ON));
+      setFeatureFlagsSource(sourceWithVercel('default'));
     }
     setFeatureFlagsReady(false);
 
@@ -2475,24 +2494,41 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         if (error) {
           console.warn('Supabase feature flags fetch failed', error);
           if (cachedFlags) {
-            applyFeatureFlagsSnapshot(cachedFlags, 'cache');
+            applyFeatureFlagsSnapshot(
+              applyRuntimeOverrides(cachedFlags),
+              sourceWithVercel('cache')
+            );
             return;
           }
-          applyFeatureFlagsSnapshot(MOBILE_FEATURE_FLAGS_ALL_ON, 'default');
+          applyFeatureFlagsSnapshot(
+            applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_ALL_ON),
+            sourceWithVercel('default')
+          );
           return;
         }
 
         const parsed = normalizeMobileFeatureFlags(data);
         if (!parsed) {
           if (cachedFlags) {
-            applyFeatureFlagsSnapshot(cachedFlags, 'cache');
+            applyFeatureFlagsSnapshot(
+              applyRuntimeOverrides(cachedFlags),
+              sourceWithVercel('cache')
+            );
             return;
           }
-          applyFeatureFlagsSnapshot(MOBILE_FEATURE_FLAGS_ALL_ON, 'default');
+          applyFeatureFlagsSnapshot(
+            applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_ALL_ON),
+            sourceWithVercel('default')
+          );
           return;
         }
 
-        applyFeatureFlagsSnapshot(parsed, 'remote', true);
+        applyFeatureFlagsSnapshot(
+          applyRuntimeOverrides(parsed),
+          sourceWithVercel('remote'),
+          true,
+          parsed
+        );
       },
       {
         operation: 'loadFeatureFlags',
@@ -2502,10 +2538,16 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       }
     ).catch(() => {
       if (cachedFlags) {
-        applyFeatureFlagsSnapshot(cachedFlags, 'cache');
+        applyFeatureFlagsSnapshot(
+          applyRuntimeOverrides(cachedFlags),
+          sourceWithVercel('cache')
+        );
         return;
       }
-      applyFeatureFlagsSnapshot(MOBILE_FEATURE_FLAGS_ALL_ON, 'default');
+      applyFeatureFlagsSnapshot(
+        applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_ALL_ON),
+        sourceWithVercel('default')
+      );
     });
   }, [applyFeatureFlagsSnapshot, authUserId]);
 

--- a/apps/pwa/public/.well-known/vercel/flags
+++ b/apps/pwa/public/.well-known/vercel/flags
@@ -1,0 +1,355 @@
+{
+  "overrideEncryptionMode": "plaintext",
+  "definitions": {
+    "ai-support": {
+      "description": "Abilita i preset rapidi legati al supporto operativo assistito.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "pwa-runtime"
+    },
+    "cp.audit-overview": {
+      "description": "Mostra la card registro operazioni recenti.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "pwa-runtime"
+    },
+    "cp.command-wizard": {
+      "description": "Abilita il wizard comandi Step 1/2 nel control-plane.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "pwa-runtime"
+    },
+    "cp.db-overview": {
+      "description": "Mostra la card panoramica operazioni database.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "pwa-runtime"
+    },
+    "cp.footer-status": {
+      "description": "Mostra il footer con last refresh e data source.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "pwa-runtime"
+    },
+    "cp.mobile-flags": {
+      "description": "Abilita la sezione toggle delle feature flag mobile nel control-plane.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "pwa-runtime"
+    },
+    "cp.pwa-flags": {
+      "description": "Abilita la sezione toggle delle feature flag PWA nel control-plane.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "pwa-runtime"
+    },
+    "cp.quick-presets": {
+      "description": "Abilita la sezione preset rapidi nel control-plane.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "pwa-runtime"
+    },
+    "cp.render-overview": {
+      "description": "Mostra la card panoramica rilasci e servizi Render.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "pwa-runtime"
+    },
+    "home.main-actions": {
+      "description": "Mostra il blocco Azioni principali nella home PWA.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "pwa-runtime"
+    },
+    "home.pwa-flags": {
+      "description": "Mostra il riepilogo delle feature flag nella home PWA.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "pwa-runtime"
+    },
+    "mobile.action.activity_complete": {
+      "description": "Abilita il completamento attivita simulate nell'app mobile.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "mobile-runtime"
+    },
+    "mobile.action.activity_start": {
+      "description": "Abilita l'avvio attivita simulate nell'app mobile.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "mobile-runtime"
+    },
+    "mobile.action.qr_scan": {
+      "description": "Abilita la scansione QR nell'app mobile.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "mobile-runtime"
+    },
+    "mobile.action.shop_purchase": {
+      "description": "Abilita gli acquisti nello shop mobile.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "mobile-runtime"
+    },
+    "mobile.action.turn_boost": {
+      "description": "Abilita il boost turno nell'app mobile.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "mobile-runtime"
+    },
+    "mobile.action.turn_submit": {
+      "description": "Abilita la registrazione turni nell'app mobile.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "mobile-runtime"
+    },
+    "mobile.section.activities": {
+      "description": "Mostra la sezione Attivita nell'app mobile.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "mobile-runtime"
+    },
+    "mobile.section.career": {
+      "description": "Mostra la sezione Carriera nell'app mobile.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "mobile-runtime"
+    },
+    "mobile.section.earned_titles": {
+      "description": "Mostra la sezione Titoli ottenuti nell'app mobile.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "mobile-runtime"
+    },
+    "mobile.section.leaderboard": {
+      "description": "Mostra la sezione Classifica nell'app mobile.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "mobile-runtime"
+    },
+    "mobile.section.shop": {
+      "description": "Mostra la sezione Shop nell'app mobile.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "mobile-runtime"
+    },
+    "mobile.section.turns": {
+      "description": "Mostra la sezione Turni ATCL nell'app mobile.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "mobile-runtime"
+    },
+    "permissions-card": {
+      "description": "Mostra i ruoli e permessi della sessione utente nel control-plane.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "pwa-runtime"
+    },
+    "status-card": {
+      "description": "Mostra i messaggi di stato ed errori sintetici nella dashboard.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "pwa-runtime"
+    }
+  }
+}

--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -49,9 +49,13 @@ const TILE_HOSTS = new Set([
   "c.tile.openstreetmap.org",
 ]);
 const CORE_ASSET_PATHS = new Set(CORE_ASSETS);
+const NEVER_CACHE_PATHS = new Set(["/.well-known/vercel/flags"]);
 
 const isNonPublicPath = (url) => !isDevEnvironment && NON_PUBLIC_PATHS.has(url.pathname);
-const shouldCacheRequest = (url) => url.origin === self.location.origin && !isNonPublicPath(url);
+const shouldCacheRequest = (url) =>
+  url.origin === self.location.origin &&
+  !isNonPublicPath(url) &&
+  !NEVER_CACHE_PATHS.has(url.pathname);
 
 const getRequestUrl = (requestOrUrl) =>
   typeof requestOrUrl === "string"

--- a/apps/pwa/src/services/app-config.ts
+++ b/apps/pwa/src/services/app-config.ts
@@ -1,3 +1,8 @@
+import {
+  pickBooleanOverrides,
+  readVercelFlagOverridesFromDocument,
+} from "../../../../shared/flags/vercel-overrides";
+
 export type FeatureFlag =
   | "status-card"
   | "permissions-card"
@@ -177,7 +182,8 @@ function resolveEnvironment(env: EnvSource): RuntimeEnvironment {
 function resolveFeatureFlags(
   env: EnvSource,
   runtimeOverride?: FeatureFlagOverride,
-  storedOverride?: FeatureFlagOverride
+  storedOverride?: FeatureFlagOverride,
+  vercelOverride?: FeatureFlagOverride
 ): FeatureFlagConfig {
   const enabled = new Set(parseList(env.VITE_FEATURE_FLAGS));
   const disabled = new Set(parseList(env.VITE_DISABLED_FEATURE_FLAGS));
@@ -200,6 +206,14 @@ function resolveFeatureFlags(
     FEATURE_FLAG_KEYS.forEach((flag) => {
       if (typeof runtimeOverride[flag] === "boolean") {
         resolved[flag] = runtimeOverride[flag] as boolean;
+      }
+    });
+  }
+
+  if (vercelOverride) {
+    FEATURE_FLAG_KEYS.forEach((flag) => {
+      if (typeof vercelOverride[flag] === "boolean") {
+        resolved[flag] = vercelOverride[flag] as boolean;
       }
     });
   }
@@ -255,6 +269,14 @@ function readStoredFeatureFlagOverride(): FeatureFlagOverride | undefined {
   } catch {
     return undefined;
   }
+}
+
+function readVercelFeatureFlagOverride(): FeatureFlagOverride | undefined {
+  const rawOverrides = readVercelFlagOverridesFromDocument();
+  const overrides = pickBooleanOverrides(FEATURE_FLAG_KEYS, rawOverrides);
+  return Object.keys(overrides).length
+    ? (overrides as FeatureFlagOverride)
+    : undefined;
 }
 
 function writeStoredFeatureFlagOverride(overrides: FeatureFlagOverride) {
@@ -313,10 +335,13 @@ export function resolveAppConfig(params?: {
   env?: EnvSource;
   runtimeOverride?: RuntimeConfigOverride;
   origin?: string;
+  vercelOverride?: FeatureFlagOverride;
 }): AppConfig {
   const env = params?.env ?? (import.meta.env as unknown as EnvSource);
   const runtimeOverride = params?.runtimeOverride;
   const storedFeatureFlags = params?.env ? undefined : readStoredFeatureFlagOverride();
+  const vercelFeatureFlags =
+    params?.vercelOverride ?? (params?.env ? undefined : readVercelFeatureFlagOverride());
   const origin =
     params?.origin ??
     (typeof window === "undefined" ? "" : window.location.origin);
@@ -382,7 +407,12 @@ export function resolveAppConfig(params?: {
           ? runtimeOverride.serviceWorker.devCleanupRegistrations
           : parseBoolean(env.VITE_SW_DEV_CLEANUP, true),
     },
-    featureFlags: resolveFeatureFlags(env, runtimeOverride?.featureFlags, storedFeatureFlags),
+    featureFlags: resolveFeatureFlags(
+      env,
+      runtimeOverride?.featureFlags,
+      storedFeatureFlags,
+      vercelFeatureFlags
+    ),
   };
 }
 

--- a/shared/flags/catalog.ts
+++ b/shared/flags/catalog.ts
@@ -1,0 +1,120 @@
+export const PWA_FEATURE_FLAG_KEYS = [
+  "status-card",
+  "permissions-card",
+  "ai-support",
+  "home.main-actions",
+  "home.pwa-flags",
+  "cp.pwa-flags",
+  "cp.quick-presets",
+  "cp.command-wizard",
+  "cp.mobile-flags",
+  "cp.render-overview",
+  "cp.audit-overview",
+  "cp.db-overview",
+  "cp.footer-status",
+] as const;
+export type PwaFeatureFlagKey = (typeof PWA_FEATURE_FLAG_KEYS)[number];
+
+export const PWA_FEATURE_FLAG_DESCRIPTIONS: Record<PwaFeatureFlagKey, string> = {
+  "status-card": "Mostra i messaggi di stato ed errori sintetici nella dashboard.",
+  "permissions-card": "Mostra i ruoli e permessi della sessione utente nel control-plane.",
+  "ai-support": "Abilita i preset rapidi legati al supporto operativo assistito.",
+  "home.main-actions": "Mostra il blocco Azioni principali nella home PWA.",
+  "home.pwa-flags": "Mostra il riepilogo delle feature flag nella home PWA.",
+  "cp.pwa-flags": "Abilita la sezione toggle delle feature flag PWA nel control-plane.",
+  "cp.quick-presets": "Abilita la sezione preset rapidi nel control-plane.",
+  "cp.command-wizard": "Abilita il wizard comandi Step 1/2 nel control-plane.",
+  "cp.mobile-flags": "Abilita la sezione toggle delle feature flag mobile nel control-plane.",
+  "cp.render-overview": "Mostra la card panoramica rilasci e servizi Render.",
+  "cp.audit-overview": "Mostra la card registro operazioni recenti.",
+  "cp.db-overview": "Mostra la card panoramica operazioni database.",
+  "cp.footer-status": "Mostra il footer con last refresh e data source.",
+};
+
+export const MOBILE_FEATURE_FLAG_KEYS = [
+  "mobile.section.turns",
+  "mobile.section.leaderboard",
+  "mobile.section.activities",
+  "mobile.section.shop",
+  "mobile.section.career",
+  "mobile.section.earned_titles",
+  "mobile.action.qr_scan",
+  "mobile.action.turn_submit",
+  "mobile.action.turn_boost",
+  "mobile.action.activity_start",
+  "mobile.action.activity_complete",
+  "mobile.action.shop_purchase",
+] as const;
+export type MobileFeatureFlagKey = (typeof MOBILE_FEATURE_FLAG_KEYS)[number];
+
+export const MOBILE_FEATURE_FLAG_DESCRIPTIONS: Record<MobileFeatureFlagKey, string> = {
+  "mobile.section.turns": "Mostra la sezione Turni ATCL nell'app mobile.",
+  "mobile.section.leaderboard": "Mostra la sezione Classifica nell'app mobile.",
+  "mobile.section.activities": "Mostra la sezione Attivita nell'app mobile.",
+  "mobile.section.shop": "Mostra la sezione Shop nell'app mobile.",
+  "mobile.section.career": "Mostra la sezione Carriera nell'app mobile.",
+  "mobile.section.earned_titles": "Mostra la sezione Titoli ottenuti nell'app mobile.",
+  "mobile.action.qr_scan": "Abilita la scansione QR nell'app mobile.",
+  "mobile.action.turn_submit": "Abilita la registrazione turni nell'app mobile.",
+  "mobile.action.turn_boost": "Abilita il boost turno nell'app mobile.",
+  "mobile.action.activity_start": "Abilita l'avvio attivita simulate nell'app mobile.",
+  "mobile.action.activity_complete": "Abilita il completamento attivita simulate nell'app mobile.",
+  "mobile.action.shop_purchase": "Abilita gli acquisti nello shop mobile.",
+};
+
+type FlagOption = {
+  value: boolean;
+  label: "On" | "Off";
+};
+
+type VercelFlagDefinition = {
+  description: string;
+  origin?: string;
+  options: readonly FlagOption[];
+};
+
+const BOOLEAN_OPTIONS: readonly FlagOption[] = [
+  { value: true, label: "On" },
+  { value: false, label: "Off" },
+];
+
+function buildVercelFlagDefinitionRecord<K extends string>(
+  keys: readonly K[],
+  descriptions: Record<K, string>,
+  origin: string
+): Record<K, VercelFlagDefinition> {
+  return Object.fromEntries(
+    keys.map((key) => [
+      key,
+      {
+        description: descriptions[key],
+        origin,
+        options: BOOLEAN_OPTIONS,
+      },
+    ])
+  ) as Record<K, VercelFlagDefinition>;
+}
+
+export const PWA_VERCEL_FLAG_DEFINITIONS = buildVercelFlagDefinitionRecord(
+  PWA_FEATURE_FLAG_KEYS,
+  PWA_FEATURE_FLAG_DESCRIPTIONS,
+  "pwa-runtime"
+);
+
+export const MOBILE_VERCEL_FLAG_DEFINITIONS = buildVercelFlagDefinitionRecord(
+  MOBILE_FEATURE_FLAG_KEYS,
+  MOBILE_FEATURE_FLAG_DESCRIPTIONS,
+  "mobile-runtime"
+);
+
+export type VercelFlagKey = PwaFeatureFlagKey | MobileFeatureFlagKey;
+
+export const VERCEL_FLAG_DEFINITIONS: Record<VercelFlagKey, VercelFlagDefinition> = {
+  ...PWA_VERCEL_FLAG_DEFINITIONS,
+  ...MOBILE_VERCEL_FLAG_DEFINITIONS,
+};
+
+export const VERCEL_FLAGS_DISCOVERY_RESPONSE = {
+  overrideEncryptionMode: "plaintext",
+  definitions: VERCEL_FLAG_DEFINITIONS,
+} as const;

--- a/shared/flags/vercel-overrides.ts
+++ b/shared/flags/vercel-overrides.ts
@@ -1,0 +1,90 @@
+const OVERRIDES_COOKIE_KEY = "vercel-flag-overrides";
+const SECURE_SUFFIX = ":secure";
+
+function parseBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+    return undefined;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true" || normalized === "1" || normalized === "on" || normalized === "yes")
+      return true;
+    if (normalized === "false" || normalized === "0" || normalized === "off" || normalized === "no")
+      return false;
+  }
+  return undefined;
+}
+
+function readCookieValue(name: string, cookieString: string): string | null {
+  if (!cookieString.trim()) return null;
+  const prefix = `${name}=`;
+  const segments = cookieString.split(";");
+  for (const segment of segments) {
+    const part = segment.trim();
+    if (!part.startsWith(prefix)) continue;
+    return part.slice(prefix.length);
+  }
+  return null;
+}
+
+function decodeCookieValue(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+type RawVercelOverrides = Record<string, unknown>;
+
+export function parseVercelFlagOverridesCookieValue(rawValue: string | null): RawVercelOverrides {
+  if (!rawValue) return {};
+  const decoded = decodeCookieValue(rawValue);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decoded);
+  } catch {
+    return {};
+  }
+  if (!parsed || typeof parsed !== "object") return {};
+
+  const values = parsed as Record<string, unknown>;
+  const normalized: RawVercelOverrides = {};
+
+  for (const [key, value] of Object.entries(values)) {
+    if (!key.startsWith("$")) continue;
+    if (key.endsWith(SECURE_SUFFIX)) continue;
+    const flagKey = key.slice(1).trim();
+    if (!flagKey) continue;
+    normalized[flagKey] = value;
+  }
+
+  return normalized;
+}
+
+export function parseVercelFlagOverridesCookieHeader(cookieHeader: string): RawVercelOverrides {
+  const rawCookieValue = readCookieValue(OVERRIDES_COOKIE_KEY, cookieHeader);
+  return parseVercelFlagOverridesCookieValue(rawCookieValue);
+}
+
+export function readVercelFlagOverridesFromDocument(): RawVercelOverrides {
+  if (typeof document === "undefined") return {};
+  return parseVercelFlagOverridesCookieHeader(document.cookie ?? "");
+}
+
+export function pickBooleanOverrides<K extends string>(
+  keys: readonly K[],
+  source: RawVercelOverrides
+): Partial<Record<K, boolean>> {
+  const next: Partial<Record<K, boolean>> = {};
+  for (const key of keys) {
+    const boolValue = parseBoolean(source[key]);
+    if (typeof boolValue === "boolean") {
+      next[key] = boolValue;
+    }
+  }
+  return next;
+}


### PR DESCRIPTION
## Summary
- add shared PWA/mobile feature-flag catalog and Vercel toolbar cookie override parser
- wire Vercel override precedence into PWA app config and mobile feature-flag refresh flow
- add /.well-known/vercel/flags discovery endpoint for Vercel Flags Explorer and exclude it from SW cache
- document runtime precedence and toolbar setup in README

## Validation
- 
pm --workspace apps/mobile run build ✅
- 
pm --workspace apps/pwa run build ✅
- 
pm --workspace apps/pwa run test ❌ missing dependency @vitest/coverage-v8 (pre-existing)

Closes #272