### PR TITLE
Gate mobile support and ticket prototypes behind flags

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -103,8 +103,10 @@ function AppShell() {
       if (screen === 'shop') return tabFeatureFlags.shop;
       if (screen === 'career') return tabFeatureFlags.career;
       if (screen === 'earned-titles') return tabFeatureFlags.earnedTitles;
+      if (screen === 'support') return isFeatureEnabled('mobile.action.ai_support');
       if (screen === 'qr-scanner') return isFeatureEnabled('mobile.action.qr_scan');
       if (screen === 'event-confirmation') return isFeatureEnabled('mobile.action.turn_submit');
+      if (screen === 'ticket-qr-prototype') return isFeatureEnabled('mobile.dev.ticket_qr_prototype');
       return true;
     },
     [isFeatureEnabled, tabFeatureFlags]
@@ -220,6 +222,8 @@ function AppShell() {
     if (!newBadges.length) return null;
     return [...newBadges].sort((a, b) => (b.unlockedAt ?? 0) - (a.unlockedAt ?? 0))[0];
   }, [newBadges]);
+  const canViewAiSupport = isFeatureEnabled('mobile.action.ai_support');
+  const canViewTicketQrPrototype = isFeatureEnabled('mobile.dev.ticket_qr_prototype');
 
   const hasValidEmail = Boolean(state.profile.email && state.profile.email.includes('@'));
   const isAuthValid = useMemo(() => {
@@ -663,6 +667,22 @@ function AppShell() {
     setCurrentScreen('qr-scanner');
   }, [isFeatureEnabled, setCurrentScreen, showFeatureDisabledAlert]);
 
+  const openSupport = useCallback(() => {
+    if (!canViewAiSupport) {
+      showFeatureDisabledAlert('Il Supporto AI');
+      return;
+    }
+    setCurrentScreen('support');
+  }, [canViewAiSupport, setCurrentScreen, showFeatureDisabledAlert]);
+
+  const openTicketQrPrototype = useCallback(() => {
+    if (!canViewTicketQrPrototype) {
+      showFeatureDisabledAlert('La generazione ticket QR');
+      return;
+    }
+    setCurrentScreen('ticket-qr-prototype');
+  }, [canViewTicketQrPrototype, setCurrentScreen, showFeatureDisabledAlert]);
+
   const openTurns = useCallback(() => {
     if (!tabFeatureFlags.turns) {
       showFeatureDisabledAlert('La sezione turni');
@@ -716,6 +736,29 @@ function AppShell() {
     const selectedLeaderboardRole = selectedLeaderboardEntry
       ? roles.find((role) => role.id === selectedLeaderboardEntry.roleId)?.name ?? 'Ruolo'
       : 'Ruolo';
+    const accountSettingsScreen = (
+      <AccountSettings
+        userName={state.profile.name}
+        email={state.profile.email}
+        showAiSupport={canViewAiSupport}
+        showTicketPrototype={canViewTicketQrPrototype}
+        onBack={() => setCurrentScreen('profile')}
+        onViewTerms={() => openLegal('terms', 'account-settings')}
+        onViewPrivacy={() => openLegal('privacy', 'account-settings')}
+        onViewSupport={openSupport}
+        onViewTicketPrototype={openTicketQrPrototype}
+        onChangePassword={() => {
+          setIsPasswordRecovery(false);
+          setCurrentScreen('change-password');
+        }}
+        onResetProgress={async () => {
+          await resetProgress();
+          handleTabChange('home');
+          setCurrentScreen('role-selection');
+        }}
+        onLogout={handleLogout}
+      />
+    );
 
     switch (currentScreen) {
       case 'welcome': return <Welcome onStart={() => setCurrentScreen('signup')} onLogin={() => setCurrentScreen('login')} />;
@@ -945,14 +988,20 @@ function AppShell() {
         ) : (
           <Leaderboard onSelectEntry={openLeaderboardProfile} />
         );
-      case 'account-settings': return <AccountSettings userName={state.profile.name} email={state.profile.email} onBack={() => setCurrentScreen('profile')} onViewTerms={() => openLegal('terms', 'account-settings')} onViewPrivacy={() => openLegal('privacy', 'account-settings')} onViewSupport={() => setCurrentScreen('support')} onViewTicketPrototype={() => setCurrentScreen('ticket-qr-prototype')} onChangePassword={() => { setIsPasswordRecovery(false); setCurrentScreen('change-password'); }} onResetProgress={async () => { await resetProgress(); handleTabChange('home'); setCurrentScreen('role-selection'); }} onLogout={handleLogout} />;
-      case 'support': return <SupportChat userName={state.profile.name} onBack={() => setCurrentScreen('account-settings')} />;
+      case 'account-settings': return accountSettingsScreen;
+      case 'support':
+        return canViewAiSupport
+          ? <SupportChat userName={state.profile.name} onBack={() => setCurrentScreen('account-settings')} />
+          : accountSettingsScreen;
       case 'change-password': return <ChangePassword email={state.profile.email} mode={isPasswordRecovery ? 'recovery' : 'change'} onBack={() => { setIsPasswordRecovery(false); setCurrentScreen(isPasswordRecovery ? 'home' : 'account-settings'); }} onChangePassword={(current, next) => changePassword(next, current)} onSendResetEmail={() => sendPasswordResetEmail(state.profile.email)} />;
       case 'career': return <Career userRole={selectedRole?.name ?? 'Ruolo'} roleId={state.profile.roleId} roleStats={selectedRole?.stats ?? { presence: 0, precision: 0, leadership: 0, creativity: 0 }} turnStats={turnStats} badges={badges} turns={state.turns} roles={roles} level={state.profile.level} xp={state.profile.xp} xpToNextLevel={state.profile.xpToNextLevel} xpTotal={state.profile.xpTotal} xpSulCampo={state.profile.xpField} reputationGlobal={state.profile.reputation} onBack={() => setCurrentScreen('profile')} />;
       case 'terms': return <TermsAndConditions onBack={() => setCurrentScreen(legalReturnScreen)} />;
       case 'privacy': return <PrivacyPolicy onBack={() => setCurrentScreen(legalReturnScreen)} />;
       case 'earned-titles': return <EarnedTitles badges={badges} turnStats={turnStats} onBack={() => setCurrentScreen('profile')} onViewed={authReady && authUserId ? markBadgesSeen : undefined} />;
-      case 'ticket-qr-prototype': return <TicketQrActivationPrototype userId={authUserId ?? state.profile.email ?? 'guest-user'} onBack={() => setCurrentScreen('account-settings')} />;
+      case 'ticket-qr-prototype':
+        return canViewTicketQrPrototype
+          ? <TicketQrActivationPrototype userId={authUserId ?? state.profile.email ?? 'guest-user'} onBack={() => setCurrentScreen('account-settings')} />
+          : accountSettingsScreen;
       default: return null;
     }
   };

--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -28,6 +28,8 @@ import { checkAiSupportAvailability } from '../../services/ai';
 interface AccountSettingsProps {
   userName: string;
   email: string;
+  showAiSupport: boolean;
+  showTicketPrototype: boolean;
   onBack: () => void;
   onViewTerms: () => void;
   onViewPrivacy: () => void;
@@ -75,6 +77,8 @@ function formatPermissionStatus(status: PermissionStatus) {
 export function AccountSettings({
   userName,
   email,
+  showAiSupport,
+  showTicketPrototype,
   onBack,
   onViewTerms,
   onViewPrivacy,
@@ -164,6 +168,11 @@ export function AccountSettings({
     let mounted = true;
 
     const checkSupport = async () => {
+      if (!showAiSupport) {
+        if (!mounted) return;
+        setSupportStatus('unavailable');
+        return;
+      }
       const availability = await checkAiSupportAvailability();
       if (!mounted) return;
       setSupportStatus(availability);
@@ -174,7 +183,7 @@ export function AccountSettings({
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [showAiSupport]);
 
   useEffect(() => {
     let mounted = true;
@@ -572,61 +581,67 @@ export function AccountSettings({
           ) : null}
         </div>
 
-        <div className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] px-[12px] py-[12px] flex flex-col gap-[8px]">
-          <button
-            type="button"
-            onClick={onViewSupport}
-            disabled={supportUnavailable || supportChecking}
-            className="h-[51px] flex items-center justify-between disabled:opacity-60 disabled:cursor-not-allowed"
-          >
-            <div className="flex items-center gap-[12px]">
-              <MessageCircle className="text-[#f4bf4f]" size={24} />
-              <div className="text-left">
-                <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">
-                  Supporto
+        <div className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] px-[12px] py-[12px] flex flex-col gap-[14px]">
+          {showAiSupport ? (
+            <>
+              <button
+                type="button"
+                onClick={onViewSupport}
+                disabled={supportUnavailable || supportChecking}
+                className="min-h-[56px] py-[2px] flex items-center justify-between disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                <div className="flex items-center gap-[12px]">
+                  <MessageCircle className="text-[#f4bf4f]" size={24} />
+                  <div className="text-left">
+                    <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">
+                      Supporto
+                    </p>
+                    <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">
+                      Chat con Maxwell
+                    </p>
+                  </div>
+                </div>
+                <ChevronRight className="text-[#7a7577]" size={20} />
+              </button>
+              {supportUnavailable ? (
+                <p className="text-[14px] leading-[20px] text-[#ff4d4f]">
+                  Supporto AI attualmente non disponibile.
                 </p>
-                <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">
-                  Chat con Maxwell
+              ) : null}
+              {supportUnknown ? (
+                <p className="text-[14px] leading-[20px] text-[#f4bf4f]">
+                  Stato del supporto non verificabile. Puoi comunque provare ad aprire la chat.
                 </p>
-              </div>
-            </div>
-            <ChevronRight className="text-[#7a7577]" size={20} />
-          </button>
-          {supportUnavailable ? (
-            <p className="text-[14px] leading-[20px] text-[#ff4d4f]">
-              Supporto AI attualmente non disponibile.
-            </p>
-          ) : null}
-          {supportUnknown ? (
-            <p className="text-[14px] leading-[20px] text-[#f4bf4f]">
-              Stato del supporto non verificabile. Puoi comunque provare ad aprire la chat.
-            </p>
+              ) : null}
+            </>
           ) : null}
 
 
-          <button
-            type="button"
-            onClick={onViewTicketPrototype}
-            className="h-[51px] flex items-center justify-between"
-          >
-            <div className="flex items-center gap-[12px]">
-              <QrCode className="text-[#f4bf4f]" size={24} />
-              <div className="text-left">
-                <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">
-                  Prototipo ticket QR
-                </p>
-                <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">
-                  Generazione hash e attivazione one-shot
-                </p>
+          {showTicketPrototype ? (
+            <button
+              type="button"
+              onClick={onViewTicketPrototype}
+              className="min-h-[56px] py-[2px] flex items-center justify-between"
+            >
+              <div className="flex items-center gap-[12px]">
+                <QrCode className="text-[#f4bf4f]" size={24} />
+                <div className="text-left">
+                  <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">
+                    Prototipo ticket QR
+                  </p>
+                  <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">
+                    Generazione hash e attivazione one-shot
+                  </p>
+                </div>
               </div>
-            </div>
-            <ChevronRight className="text-[#7a7577]" size={20} />
-          </button>
+              <ChevronRight className="text-[#7a7577]" size={20} />
+            </button>
+          ) : null}
 
           <button
             type="button"
             onClick={onViewTerms}
-            className="h-[51px] flex items-center justify-between"
+            className="min-h-[56px] py-[2px] flex items-center justify-between"
           >
             <div className="flex items-center gap-[12px]">
               <FileText className="text-[#f4bf4f]" size={24} />
@@ -645,7 +660,7 @@ export function AccountSettings({
           <button
             type="button"
             onClick={onViewPrivacy}
-            className="h-[51px] flex items-center justify-between"
+            className="min-h-[56px] py-[2px] flex items-center justify-between"
           >
             <div className="flex items-center gap-[12px]">
               <Shield className="text-[#f4bf4f]" size={24} />

--- a/apps/mobile/src/services/feature-flags.ts
+++ b/apps/mobile/src/services/feature-flags.ts
@@ -23,6 +23,10 @@ const buildFlagState = (value: boolean): MobileFeatureFlagsState =>
 
 export const MOBILE_FEATURE_FLAGS_FAIL_CLOSED = buildFlagState(false);
 export const MOBILE_FEATURE_FLAGS_ALL_ON = buildFlagState(true);
+export const MOBILE_FEATURE_FLAGS_DEFAULTS: MobileFeatureFlagsState = {
+  ...MOBILE_FEATURE_FLAGS_ALL_ON,
+  "mobile.dev.ticket_qr_prototype": false,
+};
 
 export type MobileFeatureFlagRow = {
   key: string;
@@ -36,7 +40,7 @@ export function isMobileFeatureFlagKey(value: string): value is MobileFeatureFla
 export function normalizeMobileFeatureFlags(rows: unknown): MobileFeatureFlagsState | null {
   if (!Array.isArray(rows)) return null;
 
-  const next: MobileFeatureFlagsState = { ...MOBILE_FEATURE_FLAGS_ALL_ON };
+  const next: MobileFeatureFlagsState = { ...MOBILE_FEATURE_FLAGS_DEFAULTS };
   let hasKnownKey = false;
 
   for (const row of rows) {

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -12,7 +12,7 @@ import { formatErrorDetails, reportCriticalError } from '../services/error-handl
 import { withMobileWatchdog } from '../services/mobile-watchdog';
 import {
   applyMobileFeatureFlagOverrides,
-  MOBILE_FEATURE_FLAGS_ALL_ON,
+  MOBILE_FEATURE_FLAGS_DEFAULTS,
   readVercelMobileFeatureFlagOverrides,
   type MobileFeatureFlagKey,
   type MobileFeatureFlagsSource,
@@ -1530,7 +1530,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   const [remoteBadges, setRemoteBadges] = useState<Badge[]>([]);
   const [badgesLoading, setBadgesLoading] = useState(false);
   const [featureFlags, setFeatureFlags] = useState<MobileFeatureFlagsState>(() => (
-    { ...MOBILE_FEATURE_FLAGS_ALL_ON }
+    { ...MOBILE_FEATURE_FLAGS_DEFAULTS }
   ));
   const [featureFlagsReady, setFeatureFlagsReady] = useState(true);
   const [featureFlagsSource, setFeatureFlagsSource] = useState<MobileFeatureFlagsSource>('default');
@@ -2505,7 +2505,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
     if (!isSupabaseConfigured || !supabase) {
       applyFeatureFlagsSnapshot(
-        applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_ALL_ON),
+        applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_DEFAULTS),
         sourceWithVercel('default')
       );
       return;
@@ -2521,7 +2521,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         return;
       }
       applyFeatureFlagsSnapshot(
-        applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_ALL_ON),
+        applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_DEFAULTS),
         sourceWithVercel('default')
       );
       return;
@@ -2531,7 +2531,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       setFeatureFlags(applyRuntimeOverrides(cachedFlags));
       setFeatureFlagsSource(sourceWithVercel('cache'));
     } else {
-      setFeatureFlags(applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_ALL_ON));
+      setFeatureFlags(applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_DEFAULTS));
       setFeatureFlagsSource(sourceWithVercel('default'));
     }
     setFeatureFlagsReady(false);
@@ -2551,7 +2551,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             return;
           }
           applyFeatureFlagsSnapshot(
-            applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_ALL_ON),
+            applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_DEFAULTS),
             sourceWithVercel('default')
           );
           return;
@@ -2567,7 +2567,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             return;
           }
           applyFeatureFlagsSnapshot(
-            applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_ALL_ON),
+            applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_DEFAULTS),
             sourceWithVercel('default')
           );
           return;
@@ -2595,7 +2595,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         return;
       }
       applyFeatureFlagsSnapshot(
-        applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_ALL_ON),
+        applyRuntimeOverrides(MOBILE_FEATURE_FLAGS_DEFAULTS),
         sourceWithVercel('default')
       );
     });
@@ -3845,7 +3845,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     setState(next);
     setPendingBoostRequests(0);
     setTurnSyncFeedback(null);
-    setFeatureFlags({ ...MOBILE_FEATURE_FLAGS_ALL_ON });
+    setFeatureFlags({ ...MOBILE_FEATURE_FLAGS_DEFAULTS });
     setFeatureFlagsSource('default');
     setFeatureFlagsReady(true);
     const totalSlots = 3 + next.profile.extraActivitySlots;

--- a/apps/pwa/public/.well-known/vercel/flags
+++ b/apps/pwa/public/.well-known/vercel/flags
@@ -183,6 +183,20 @@
       ],
       "origin": "mobile-runtime"
     },
+    "mobile.action.ai_support": {
+      "description": "Abilita l'accesso al Supporto AI nelle impostazioni account dell'app mobile.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "mobile-runtime"
+    },
     "mobile.action.qr_scan": {
       "description": "Abilita la scansione QR nell'app mobile.",
       "options": [
@@ -227,6 +241,20 @@
     },
     "mobile.action.turn_submit": {
       "description": "Abilita la registrazione turni nell'app mobile.",
+      "options": [
+        {
+          "value": true,
+          "label": "On"
+        },
+        {
+          "value": false,
+          "label": "Off"
+        }
+      ],
+      "origin": "mobile-runtime"
+    },
+    "mobile.dev.ticket_qr_prototype": {
+      "description": "Abilita il prototipo developer per generazione e attivazione ticket QR nelle impostazioni account.",
       "options": [
         {
           "value": true,

--- a/apps/pwa/src/dev-plus/main.tsx
+++ b/apps/pwa/src/dev-plus/main.tsx
@@ -178,12 +178,14 @@ const MOBILE_FLAG_DEFAULTS: MobileFeatureFlagEntry[] = [
   { key: "mobile.section.shop", enabled: true, label: "Sezione Shop", description: "Mostra sezione shop e tab.", category: "section" },
   { key: "mobile.section.career", enabled: true, label: "Sezione Carriera", description: "Abilita schermata carriera.", category: "section" },
   { key: "mobile.section.earned_titles", enabled: true, label: "Sezione Titoli", description: "Abilita schermata titoli sbloccati.", category: "section" },
+  { key: "mobile.action.ai_support", enabled: true, label: "Supporto AI", description: "Abilita accesso al Supporto AI nelle impostazioni account.", category: "action" },
   { key: "mobile.action.qr_scan", enabled: true, label: "Azione Scansione QR", description: "Abilita scanner QR mobile.", category: "action" },
   { key: "mobile.action.turn_submit", enabled: true, label: "Azione Conferma Turno", description: "Abilita registrazione turni.", category: "action" },
   { key: "mobile.action.turn_boost", enabled: true, label: "Azione Boost Turno", description: "Abilita boost token su turno.", category: "action" },
   { key: "mobile.action.activity_start", enabled: true, label: "Azione Avvio Attivita", description: "Abilita avvio attivita.", category: "action" },
   { key: "mobile.action.activity_complete", enabled: true, label: "Azione Completamento Attivita", description: "Abilita completamento attivita.", category: "action" },
   { key: "mobile.action.shop_purchase", enabled: true, label: "Azione Acquisto Shop", description: "Abilita acquisti shop.", category: "action" },
+  { key: "mobile.dev.ticket_qr_prototype", enabled: false, label: "Prototipo ticket QR (dev)", description: "Abilita il prototipo developer per generazione e attivazione ticket QR.", category: "action" },
 ];
 
 const MOBILE_FLAG_FALLBACK_ENTRIES: MobileFeatureFlagEntry[] = MOBILE_FLAG_DEFAULTS.map((entry) => ({

--- a/shared/flags/catalog.ts
+++ b/shared/flags/catalog.ts
@@ -38,12 +38,14 @@ export const MOBILE_FEATURE_FLAG_KEYS = [
   "mobile.section.shop",
   "mobile.section.career",
   "mobile.section.earned_titles",
+  "mobile.action.ai_support",
   "mobile.action.qr_scan",
   "mobile.action.turn_submit",
   "mobile.action.turn_boost",
   "mobile.action.activity_start",
   "mobile.action.activity_complete",
   "mobile.action.shop_purchase",
+  "mobile.dev.ticket_qr_prototype",
 ] as const;
 export type MobileFeatureFlagKey = (typeof MOBILE_FEATURE_FLAG_KEYS)[number];
 
@@ -54,12 +56,15 @@ export const MOBILE_FEATURE_FLAG_DESCRIPTIONS: Record<MobileFeatureFlagKey, stri
   "mobile.section.shop": "Mostra la sezione Shop nell'app mobile.",
   "mobile.section.career": "Mostra la sezione Carriera nell'app mobile.",
   "mobile.section.earned_titles": "Mostra la sezione Titoli ottenuti nell'app mobile.",
+  "mobile.action.ai_support": "Abilita l'accesso al Supporto AI nelle impostazioni account dell'app mobile.",
   "mobile.action.qr_scan": "Abilita la scansione QR nell'app mobile.",
   "mobile.action.turn_submit": "Abilita la registrazione turni nell'app mobile.",
   "mobile.action.turn_boost": "Abilita il boost turno nell'app mobile.",
   "mobile.action.activity_start": "Abilita l'avvio attivita simulate nell'app mobile.",
   "mobile.action.activity_complete": "Abilita il completamento attivita simulate nell'app mobile.",
   "mobile.action.shop_purchase": "Abilita gli acquisti nello shop mobile.",
+  "mobile.dev.ticket_qr_prototype":
+    "Abilita il prototipo developer per generazione e attivazione ticket QR nelle impostazioni account.",
 };
 
 type FlagOption = {

--- a/supabase/migrations/20260304_mobile_ai_support_flag.sql
+++ b/supabase/migrations/20260304_mobile_ai_support_flag.sql
@@ -1,0 +1,14 @@
+insert into public.mobile_feature_flags (key, enabled, label, description, category)
+values (
+  'mobile.action.ai_support',
+  true,
+  'Supporto AI',
+  'Abilita accesso al Supporto AI nelle impostazioni account dell app mobile.',
+  'action'
+)
+on conflict (key) do update
+set
+  enabled = excluded.enabled,
+  label = excluded.label,
+  description = excluded.description,
+  category = excluded.category;

--- a/supabase/migrations/20260304_mobile_ticket_qr_prototype_flag.sql
+++ b/supabase/migrations/20260304_mobile_ticket_qr_prototype_flag.sql
@@ -1,0 +1,14 @@
+insert into public.mobile_feature_flags (key, enabled, label, description, category)
+values (
+  'mobile.dev.ticket_qr_prototype',
+  false,
+  'Prototipo ticket QR (dev)',
+  'Abilita il prototipo developer per generazione e attivazione ticket QR nelle impostazioni account.',
+  'action'
+)
+on conflict (key) do update
+set
+  enabled = excluded.enabled,
+  label = excluded.label,
+  description = excluded.description,
+  category = excluded.category;


### PR DESCRIPTION
## Summary
- add mobile runtime flags for AI support and the ticket QR prototype
- gate both account settings entries and their target screens in the mobile app
- expose the new flags in the control-plane catalog and seed them via Supabase migrations
- add spacing between account settings entries for better readability

## Testing
- npm --workspace apps/mobile run build
- npm --workspace apps/pwa run build