### PR TITLE
[render preview] Remove redundant UI copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Template developed by [Heartran](https://github.com/heartran)
 
 - `apps/pwa`: Vite PWA multipage (`src/` TypeScript shell, `public/` static assets incl. `public/mobile/`, `public/sw.js`, manifest/icons; HTML entry points in package root).
 
-- `UI` (submodule): Mobile UI React/Vite source; build output va copiato in `apps/pwa/public/mobile/`.
+- `apps/mobile`: App mobile React/Vite.
 
 - `apps/reactbricks`: CMS sources (da ripulire; integrare come workspace separato).
 
@@ -19,7 +19,7 @@ Template developed by [Heartran](https://github.com/heartran)
 
 - PWA: `npm run dev:pwa` / `npm run dev:pwa:https`, build `npm run build:pwa`, preview `npm run preview:pwa`, test `npm run test:pwa` (setup in `apps/pwa/src/test/setup.ts`).
 
-- Mobile UI (submodule `UI`): `npm --prefix UI run dev|build`; `npm run build:mobile` esegue build+copy in `apps/pwa/public/mobile/` (solo copia: `npm run sync:mobile`).
+- Mobile (`apps/mobile`): `npm run dev:mobile`, `npm run build:mobile`, `npm run sync:mobile`.
 
 - Keep lockfiles committed. Prefer deterministic scripts (fixed seeds, headless-friendly).
 
@@ -35,7 +35,7 @@ Template developed by [Heartran](https://github.com/heartran)
 
 - Aim for fast unit coverage on gameplay logic and smoke tests on critical flows. Document manual verification steps for interactive features.
 
-- If adding integration/UI tests, ensure they are headless-friendly for CI.
+- If adding integration tests for the interface, ensure they are headless-friendly for CI.
 
 ## Commit & Pull Request Guidelines
 
@@ -52,7 +52,6 @@ Template developed by [Heartran](https://github.com/heartran)
 
 - Never delete branches (no `--delete-branch` on merges) unless explicitly instructed.
 
-- You should always commits submodules **before** the main repository
 
 - **Merge policy (MANDATORY for all agents): unless explicitly specified otherwise by the user, the merge target is ALWAYS `main`.**
   - If the target branch is not written clearly in the request, assume `main`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ Use private disclosure only.
 
 1. Open a private report from this repository's **Security** tab using **Report a vulnerability**.
 2. Include:
-   - affected component (for example `apps/pwa`, `UI`, `supabase/functions`, `tools/*`)
+   - affected component (for example `apps/pwa`, `apps/mobile`, `supabase/functions`, `tools/*`)
    - reproducible steps and prerequisites
    - impact and attack scenario
    - proof of concept and logs/screenshots when available

--- a/TECHNICAL_NOTES.md
+++ b/TECHNICAL_NOTES.md
@@ -3,7 +3,7 @@
 ## Struttura repo (high level)
 
 - `apps/pwa`: PWA Vite multipage (entry HTML nella root del package). Asset statici in `apps/pwa/public/` (incl. `public/sw.js` e `public/mobile/`).
-- `apps/mobile`: Mobile UI (React/Vite). Build in `apps/mobile/build`, copiato in `apps/pwa/public/mobile/` tramite script di sync (`build:mobile`, `sync:mobile`).
+- `apps/mobile`: App mobile React/Vite.
 - `shared/`: stili e utilità condivise.
 - `tools/`: script di automazione build/copy/cache.
   - `tools/serve-dist.js` serve `apps/pwa/dist` e risolve le richieste `/mobile/*` su `apps/pwa/dist/public/mobile/*`.
@@ -16,10 +16,11 @@
   - Build: `npm run build:pwa`
   - Preview: `npm run preview:pwa`
 - Mobile:
-  - Dev/build: `npm --workspace apps/mobile run dev|build`
+  - Dev: `npm run dev:mobile`
+  - Build: `npm run build:mobile`
+  - Sync only: `npm run sync:mobile`
   - AI support server (local): `npm run ai:support` (default port 8787)
   - Dev + AI support together: `npm --workspace apps/mobile run dev:with-ai`
-  - Build+sync in PWA: `npm run build:mobile`
   - Allowlist host Vite (dev/preview): `VITE_ALLOWED_HOSTS` (comma-separated)
 
 ## AI support (mobile)
@@ -51,7 +52,7 @@
 
 ## Routing `/mobile` (produzione)
 
-- La Mobile UI ha `base: /mobile/` e viene copiata in `apps/pwa/public/mobile/` prima della build PWA.
+- L'app mobile usa `base: /mobile/`.
 - In produzione, `tools/serve-dist.js` risolve `/mobile/*` su `apps/pwa/dist/public/mobile/*`.
 - Se si usa hosting statico esterno, garantire che `/mobile` punti a `dist/public/mobile` (o aggiungere rewrite equivalente), altrimenti `/mobile` va in 404.
 
@@ -86,7 +87,7 @@ Flusso proposto:
 
 ## QR: scansione in app (stato attuale)
 
-- UI/Camera scan: `apps/mobile/src/components/screens/QRScanner.tsx`
+- Camera scan: `apps/mobile/src/components/screens/QRScanner.tsx`
   - Usa `navigator.mediaDevices.getUserMedia` + decoding con `jsqr`.
   - La fotocamera funziona solo in **secure context** (HTTPS o `localhost`).
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,7 +1,5 @@
 
-# Mobile UI for Turni di Palco
-
-Code bundle for the Turni di Palco mobile experience.
+# Mobile app for Turni di Palco
 
 ## Running the code
 

--- a/apps/mobile/build/manifest.webmanifest
+++ b/apps/mobile/build/manifest.webmanifest
@@ -12,7 +12,7 @@
     {
       "name": "Scansiona QR",
       "short_name": "QR",
-      "description": "Apri lo scanner QR",
+      "description": "Scanner QR",
       "url": "/mobile/index.html?shortcut=qr",
       "icons": [
         {
@@ -25,7 +25,7 @@
     {
       "name": "Turni ATCL",
       "short_name": "Turni",
-      "description": "Apri la lista eventi",
+      "description": "Eventi",
       "url": "/mobile/index.html?shortcut=turni",
       "icons": [
         {

--- a/apps/mobile/public/manifest.webmanifest
+++ b/apps/mobile/public/manifest.webmanifest
@@ -12,7 +12,7 @@
     {
       "name": "Scansiona QR",
       "short_name": "QR",
-      "description": "Apri lo scanner QR",
+      "description": "Scanner QR",
       "url": "/mobile/index.html?shortcut=qr",
       "icons": [
         {
@@ -25,7 +25,7 @@
     {
       "name": "Turni ATCL",
       "short_name": "Turni",
-      "description": "Apri la lista eventi",
+      "description": "Eventi",
       "url": "/mobile/index.html?shortcut=turni",
       "icons": [
         {

--- a/apps/mobile/src/components/screens/ActivityDetail.tsx
+++ b/apps/mobile/src/components/screens/ActivityDetail.tsx
@@ -36,7 +36,6 @@ export function ActivityDetail({ activity, onStart, onClose }: ActivityDetailPro
         </div>
 
         <Card>
-          <h4 className="text-white mb-2">Descrizione</h4>
           <p className="text-[#b8b2b3]">{activity.description}</p>
         </Card>
 
@@ -64,12 +63,7 @@ export function ActivityDetail({ activity, onStart, onClose }: ActivityDetailPro
         <Card className="border border-[#f4bf4f]/30">
           <div className="flex gap-3">
             <AlertCircle className="text-[#f4bf4f] flex-shrink-0" size={20} />
-            <div className="space-y-1">
-              <p className="text-sm text-[#b8b2b3]">
-                Minigioco disponibile: <span className="text-white">{minigame.title}</span>
-              </p>
-              <p className="text-xs text-[#7a7577]">{minigame.subtitle}</p>
-            </div>
+            <p className="text-sm text-white">{minigame.title}</p>
           </div>
         </Card>
 

--- a/apps/mobile/src/components/screens/ActivityMinigame.tsx
+++ b/apps/mobile/src/components/screens/ActivityMinigame.tsx
@@ -30,7 +30,6 @@ interface ActivityMinigameProps {
 
 interface MinigameShellProps {
   title: string;
-  subtitle: string;
   activityTitle: string;
   roundLabel: string;
   icon: React.ReactNode;
@@ -40,7 +39,6 @@ interface MinigameShellProps {
 
 function MinigameShell({
   title,
-  subtitle,
   activityTitle,
   roundLabel,
   icon,
@@ -70,7 +68,6 @@ function MinigameShell({
           </div>
           <div>
             <h2 className="text-white">{title}</h2>
-            <p className="text-sm text-[#b8b2b3]">{subtitle}</p>
           </div>
         </div>
 
@@ -201,7 +198,6 @@ function TimingMinigame({ config, activityTitle, onComplete, onCancel }: TimingM
   return (
     <MinigameShell
       title={config.title}
-      subtitle={config.subtitle}
       activityTitle={activityTitle}
       roundLabel={roundLabel}
       icon={<Timer className="text-[#f4bf4f]" size={24} />}
@@ -217,7 +213,6 @@ function TimingMinigame({ config, activityTitle, onComplete, onCancel }: TimingM
         <div className="flex items-center justify-between mb-4">
           <div>
             <p className="text-white font-semibold">{round.label}</p>
-            <p className="text-xs text-[#7a7577]">Blocca il cursore sul target</p>
           </div>
           <Tag size="sm" variant="outline">
             Target {round.target}%
@@ -264,14 +259,6 @@ function TimingMinigame({ config, activityTitle, onComplete, onCancel }: TimingM
           </div>
         ) : null}
       </Card>
-
-      {phase === 'intro' ? (
-        <Card className="border border-[#f4bf4f]/20">
-          <p className="text-sm text-[#b8b2b3]">
-            Segui il cursore e premi "Blocca" (o tocca il pannello) quando raggiunge il target.
-          </p>
-        </Card>
-      ) : null}
 
       <div className="space-y-3">
         {phase === 'intro' ? (
@@ -366,7 +353,6 @@ function AudioMinigame({ config, activityTitle, onComplete, onCancel }: AudioMin
   return (
     <MinigameShell
       title={config.title}
-      subtitle={config.subtitle}
       activityTitle={activityTitle}
       roundLabel={roundLabel}
       icon={<SlidersHorizontal className="text-[#f4bf4f]" size={22} />}
@@ -376,7 +362,6 @@ function AudioMinigame({ config, activityTitle, onComplete, onCancel }: AudioMin
         <div className="flex items-center justify-between mb-4">
           <div>
             <p className="text-white font-semibold">{round.label}</p>
-            <p className="text-xs text-[#7a7577]">Regola il livello richiesto</p>
           </div>
           <Tag size="sm" variant="outline">
             Target {round.target}%
@@ -446,14 +431,6 @@ function AudioMinigame({ config, activityTitle, onComplete, onCancel }: AudioMin
           </div>
         ) : null}
       </Card>
-
-      {phase === 'intro' ? (
-        <Card className="border border-[#f4bf4f]/20">
-          <p className="text-sm text-[#b8b2b3]">
-            Usa lo slider o i pulsanti +/- per allineare il livello al target indicato.
-          </p>
-        </Card>
-      ) : null}
 
       <div className="space-y-3">
         {phase === 'intro' ? (

--- a/apps/mobile/src/components/screens/EventConfirmation.tsx
+++ b/apps/mobile/src/components/screens/EventConfirmation.tsx
@@ -173,7 +173,6 @@ export function EventConfirmation({
       <div className="app-content px-6 space-y-6 pt-6">
         <div>
           <h2 className="text-white mb-2">Conferma turno</h2>
-          <p className="text-[#b8b2b3]">Verifica i dettagli dell&apos;evento</p>
         </div>
 
         <Card>

--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -127,7 +127,6 @@ export function Home({
       <div className="w-full app-content px-6 pt-6 pb-8 space-y-6">
         <header className="space-y-4 mobile-hero-reveal" style={{ marginBottom: '20px' }}>
           <div className="min-w-0">
-            <p className="text-sm text-[#b8b2b3]">Benvenuto,</p>
             <div className="mt-2 flex items-center gap-3">
               <h2 className="min-w-0 flex-1 text-2xl text-white font-semibold leading-tight break-words">
                 {userName || 'Profilo'}
@@ -190,7 +189,6 @@ export function Home({
             <MetricTile
               label="Reputazione ATCL"
               value={reputation}
-              helper="Su 100"
               progress={{ value: reputation, max: 100, color: 'burgundy' }}
             />
           </div>
@@ -206,7 +204,6 @@ export function Home({
                   <Coins size={14} className="text-[#f4bf4f]" />
                 </div>
                 <p className="text-white text-lg font-semibold mt-1">{cachet}</p>
-                <p className="text-[11px] text-[#7a7577] mt-1">Valuta base attivita e turni</p>
               </div>
               <div className="rounded-xl bg-[#241f20] border border-[#3d3a3b] p-3">
                 <div className="flex items-center justify-between gap-2">
@@ -214,7 +211,6 @@ export function Home({
                   <Zap size={14} className="text-[#f4bf4f]" />
                 </div>
                 <p className="text-[#f4bf4f] text-lg font-semibold mt-1">{tokenAtcl}</p>
-                <p className="text-[11px] text-[#7a7577] mt-1">Boost e futuri riscatti reali</p>
               </div>
             </div>
           </Card>
@@ -394,7 +390,6 @@ export function Home({
               </div>
               <div className="flex-1">
                 <h4 className="text-white mb-1">{activitiesCount} attività disponibili</h4>
-                <p className="text-sm text-[#b8b2b3]">Guadagna XP e migliora le tue skill</p>
               </div>
               <ChevronRight className="text-[#7a7577]" size={20} />
             </div>

--- a/apps/mobile/src/components/screens/InstallApp.tsx
+++ b/apps/mobile/src/components/screens/InstallApp.tsx
@@ -11,7 +11,6 @@ function detectPlatform(userAgent: string): Platform {
   return 'desktop';
 }
 
-
 type InstallAppProps = {
   onContinue: () => void;
   onDismiss: () => void;
@@ -41,21 +40,21 @@ export function InstallApp({ onContinue, onDismiss }: InstallAppProps) {
     if (platform === 'ios') {
       return [
         'Apri questo link in Safari.',
-        'Tocca il pulsante Condividi (quadrato con freccia).',
-        'Seleziona “Aggiungi a Home”.',
+        'Tocca il pulsante Condividi.',
+        'Seleziona Aggiungi a Home.',
       ];
     }
     if (platform === 'android') {
       return [
         'Apri questo link in Chrome.',
-        'Tocca il menu ⋮ in alto a destra.',
-        'Seleziona “Installa app” oppure “Aggiungi a schermata Home”.',
+        'Tocca il menu in alto a destra.',
+        'Seleziona Installa app o Aggiungi a schermata Home.',
       ];
     }
     return [
       'Apri questo link dal tuo telefono.',
-      'Scansiona il QR qui sotto per aprire l’app.',
-      'Usa il menu del browser per installare o aggiungere alla Home.',
+      'Scansiona il QR qui sotto.',
+      'Installa dal menu del browser.',
     ];
   }, [platform]);
 
@@ -63,14 +62,10 @@ export function InstallApp({ onContinue, onDismiss }: InstallAppProps) {
     <Screen withBottomNavPadding={false} className="justify-start" contentClassName="pt-10">
       <div className="space-y-3">
         <h1 className="text-[22px] leading-[28px] font-semibold text-white">Installa Turni di Palco</h1>
-        <p className="text-[#b8b2b3]">
-          Aggiungendo l’app alla schermata Home avrai un’esperienza più simile a un’app nativa
-          (full-screen, avvio rapido).
-        </p>
       </div>
 
       <div className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-4 space-y-2">
-        <p className="text-white font-semibold">Istruzioni ({platform === 'ios' ? 'iOS' : platform === 'android' ? 'Android' : 'Desktop'})</p>
+        <p className="text-white font-semibold">Installazione ({platform === 'ios' ? 'iOS' : platform === 'android' ? 'Android' : 'Desktop'})</p>
         <ol className="list-decimal pl-5 space-y-1 text-[#b8b2b3]">
           {steps.map((step) => (
             <li key={step}>{step}</li>
@@ -80,23 +75,19 @@ export function InstallApp({ onContinue, onDismiss }: InstallAppProps) {
 
       {platform === 'desktop' ? (
         <div className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-4 flex flex-col items-center gap-3">
-          <p className="text-white font-semibold">QR per telefono</p>
+          <p className="text-white font-semibold">QR</p>
           <img
             src={qrSrc}
             alt="QR per aprire Turni di Palco su mobile"
             className="w-[220px] h-[220px] rounded-[12px] bg-white p-2"
             loading="lazy"
           />
-          <p className="text-[#b8b2b3] text-sm text-center">
-            Inquadra il QR con la fotocamera per aprire la versione mobile.
-          </p>
         </div>
       ) : null}
 
       {standalone ? (
         <div className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-4">
-          <p className="text-white font-semibold">Già installata</p>
-          <p className="text-[#b8b2b3]">Sembra che tu stia già usando la versione installata.</p>
+          <p className="text-white font-semibold">Gia installata</p>
         </div>
       ) : null}
 
@@ -106,7 +97,7 @@ export function InstallApp({ onContinue, onDismiss }: InstallAppProps) {
           onClick={onContinue}
           className="w-full bg-gradient-to-b from-[#8c1c38] to-[#a82847] rounded-[16.4px] h-[54px] flex items-center justify-center text-white font-semibold active:scale-[0.99] transition-transform"
         >
-          Apri l’app
+          Apri l'app
         </button>
         <button
           type="button"
@@ -119,4 +110,3 @@ export function InstallApp({ onContinue, onDismiss }: InstallAppProps) {
     </Screen>
   );
 }
-

--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -19,7 +19,6 @@ import {
   Drawer,
   DrawerClose,
   DrawerContent,
-  DrawerDescription,
   DrawerFooter,
   DrawerHeader,
   DrawerTitle,
@@ -627,9 +626,6 @@ export function SupportChat({ userName, onBack }: SupportChatProps) {
             <DrawerTitle className="text-left text-[18px] text-white">
               Cronologia chat
             </DrawerTitle>
-            <DrawerDescription className="text-left text-[#b8b2b3]">
-              Riprendi una conversazione oppure apri una nuova sessione.
-            </DrawerDescription>
             {isLoading ? (
               <p className="mt-2 text-left text-[12px] text-[#f4bf4f]">
                 Attendi la risposta di Maxwell prima di cambiare sessione.

--- a/apps/pwa/control-plane.html
+++ b/apps/pwa/control-plane.html
@@ -9,7 +9,7 @@
     <title>Turni di Palco - Dashboard comandi</title>
     <meta
       name="description"
-      content="Dashboard comandi semplificata con preset, registro, rilasci, database e feature flags."
+      content="Dashboard comandi PWA."
     />
     <meta name="theme-color" content="#10161f" />
     <link rel="manifest" href="/manifest.webmanifest" />

--- a/apps/pwa/public/mobile/manifest.webmanifest
+++ b/apps/pwa/public/mobile/manifest.webmanifest
@@ -12,7 +12,7 @@
     {
       "name": "Scansiona QR",
       "short_name": "QR",
-      "description": "Apri lo scanner QR",
+      "description": "Scanner QR",
       "url": "/mobile/index.html?shortcut=qr",
       "icons": [
         {
@@ -25,7 +25,7 @@
     {
       "name": "Turni ATCL",
       "short_name": "Turni",
-      "description": "Apri la lista eventi",
+      "description": "Eventi",
       "url": "/mobile/index.html?shortcut=turni",
       "icons": [
         {

--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -33,7 +33,7 @@ const CORE_ASSETS = [
 const NON_PUBLIC_PATHS = new Set(CORE_ASSETS_BY_ENV.dev);
 const OFFLINE_URL = "/index.html";
 
-const CORE_CACHE_VERSION = "v41a8af89";
+const CORE_CACHE_VERSION = "vc425325e";
 const CACHE_VERSION_TAG = "v5";
 const CORE_CACHE_NAME = `turni-di-palco-core-${CORE_CACHE_VERSION}-${CACHE_VERSION_TAG}`;
 const TILE_CACHE_NAME = `turni-di-palco-tiles-${CORE_CACHE_VERSION}-${CACHE_VERSION_TAG}`;

--- a/apps/pwa/src/components/leaderboard.ts
+++ b/apps/pwa/src/components/leaderboard.ts
@@ -87,7 +87,7 @@ export function renderLeaderboard(options: LeaderboardComponentOptions): string 
 
       ${entries.length === 0 ? `
         <div class="leaderboard-empty">
-          <p class="muted">Nessun giocatore nella classifica.</p>
+          <p class="muted">Classifica vuota.</p>
         </div>
       ` : ""}
     </div>

--- a/apps/pwa/src/dev-plus/dev-plus.css
+++ b/apps/pwa/src/dev-plus/dev-plus.css
@@ -224,10 +224,6 @@ button:disabled {
   gap: 0.2rem;
 }
 
-.cp-preset-button small {
-  color: var(--cp-muted);
-}
-
 .cp-review {
   margin-top: 0.75rem;
   border: 1px solid var(--cp-border);
@@ -260,13 +256,6 @@ button:disabled {
 
 .cp-flag-item p {
   margin: 0;
-}
-
-.cp-flag-description {
-  margin-top: 0.2rem !important;
-  color: var(--cp-muted);
-  font-size: 0.86rem;
-  line-height: 1.35;
 }
 
 .cp-feedback {

--- a/apps/pwa/src/dev-plus/main.tsx
+++ b/apps/pwa/src/dev-plus/main.tsx
@@ -10,7 +10,6 @@ import { registerServiceWorker } from "../pwa/register-sw";
 import { isSupabaseConfigured, supabase } from "../services/supabase";
 import {
   appConfig,
-  getFeatureFlagDescription,
   setStoredFeatureFlagOverride,
   type FeatureFlag,
   type FeatureFlagConfig,
@@ -53,7 +52,6 @@ type FeedbackMessage = {
 type CommandPreset = {
   id: string;
   label: string;
-  note: string;
   commandId: string;
   target?: string;
   reason: string;
@@ -132,7 +130,6 @@ const COMMAND_PRESETS: CommandPreset[] = [
   {
     id: "health-check",
     label: "Check servizi",
-    note: "Stato rapido servizi Render",
     commandId: "render.services.health",
     target: "all",
     reason: "Verifica salute servizi prima del controllo giornaliero.",
@@ -142,7 +139,6 @@ const COMMAND_PRESETS: CommandPreset[] = [
   {
     id: "deployments-last24h",
     label: "Ultimi rilasci",
-    note: "Rilasci ultime 24 ore",
     commandId: "render.deployments.list",
     target: "all",
     reason: "Verifica storico rilasci per controllo versioni online.",
@@ -152,7 +148,6 @@ const COMMAND_PRESETS: CommandPreset[] = [
   {
     id: "db-read-events",
     label: "Leggi eventi",
-    note: "Lettura tabella eventi",
     commandId: "supabase.db.read",
     target: "events",
     reason: "Controllo rapido record eventi da dashboard.",
@@ -162,7 +157,6 @@ const COMMAND_PRESETS: CommandPreset[] = [
   {
     id: "cleanup-preview",
     label: "Pulizia eventi (preview)",
-    note: "Simulazione pulizia dati storici",
     commandId: "supabase.events.cleanup",
     target: "events",
     reason: "Valutazione impatto pulizia eventi piu vecchi.",
@@ -737,8 +731,7 @@ function App() {
       <header className="cp-card cp-header">
         <div>
           <p className="cp-kicker">Turni di Palco</p>
-          <h1>Dashboard comandi semplice</h1>
-          <p className="cp-muted">Una pagina, flusso lineare, preset pronti.</p>
+          <h1>Dashboard comandi</h1>
         </div>
         <div className="cp-links">
           <a href="/">Dashboard</a>
@@ -814,7 +807,6 @@ function App() {
                   <p>
                     <strong>{flagKey}</strong>
                   </p>
-                  <p className="cp-flag-description">{getFeatureFlagDescription(flagKey)}</p>
                 </div>
                 <div className="cp-inline-actions">
                   <span className={enabled ? "cp-on" : "cp-off"}>{enabled ? "ON" : "OFF"}</span>
@@ -835,13 +827,11 @@ function App() {
             {roleActions.map((action) => (
               <button key={action.id} type="button" className="cp-preset-button" onClick={() => applyQuickAction(action)}>
                 <strong>{action.label}</strong>
-                <small>{action.note}</small>
               </button>
             ))}
             {COMMAND_PRESETS.map((preset) => (
               <button key={preset.id} type="button" className="cp-preset-button" onClick={() => applyCommandPreset(preset)}>
                 <strong>{preset.label}</strong>
-                <small>{preset.note}</small>
               </button>
             ))}
           </div>
@@ -852,8 +842,7 @@ function App() {
 
       {showCommandWizard ? (
       <section className="cp-card" id="section-commands">
-        <h2>Comando guidato</h2>
-        <p className="cp-muted">Compila i campi, poi usa Step 1 e Step 2.</p>
+        <h2>Comando</h2>
 
         <div className="cp-command-grid">
           <label>
@@ -956,7 +945,6 @@ function App() {
                   <p>
                     <strong>{flag.label}</strong>
                   </p>
-                  <p className="cp-flag-description">{flag.description || "Descrizione non disponibile."}</p>
                   <p className="cp-muted">
                     <code>{flag.key}</code>
                   </p>

--- a/apps/pwa/src/features/permissions-card.ts
+++ b/apps/pwa/src/features/permissions-card.ts
@@ -4,8 +4,7 @@ export function renderPermissionsCard() {
     return `
       <article class="card" id="permissions">
         <h2>Permission check</h2>
-        <p>Richiedi i permessi comuni (notifiche, geolocalizzazione, fotocamera) e controlla l'esito in tempo reale.</p>
-        <p class="muted">Nota: su iOS/Safari le notifiche funzionano solo dopo l'installazione come PWA e su connessione sicura (HTTPS). Geolocalizzazione e fotocamera richiedono contesto sicuro.</p>
+        <p class="muted">Notifiche su iOS disponibili solo dopo l'installazione come PWA.</p>
         <div class="cta-row">
           <button class="button primary" type="button" data-action="notify-permission">
             Richiedi notifiche

--- a/apps/pwa/src/features/status-card.ts
+++ b/apps/pwa/src/features/status-card.ts
@@ -15,7 +15,6 @@ export function renderStatusCard() {
           <dd data-sw-status>Waiting for registration...</dd>
         </div>
       </dl>
-      <p class="muted">Toggle rete per test offline. Se c'e un update SW usa il pulsante reload.</p>
       <div class="status-log" data-sw-error-box hidden>
         <p class="eyebrow">Log SW</p>
         <ul class="status-log-list" data-sw-errors></ul>

--- a/apps/pwa/src/main.ts
+++ b/apps/pwa/src/main.ts
@@ -1,29 +1,25 @@
 ﻿import "../../../shared/styles/main.css";
-import { appConfig, getConfigWarnings, getFeatureFlagDescription, type FeatureFlag } from "./services/app-config";
+import { appConfig, getConfigWarnings, type FeatureFlag } from "./services/app-config";
 import { buildControlPlaneUrl } from "./services/ops-sdk";
 import { enforceDesktopOnly } from "./utils/desktop-only";
 
 type MainAction = {
   id: "commands" | "render" | "audit";
   label: string;
-  description: string;
 };
 
 const MAIN_ACTIONS: MainAction[] = [
   {
     id: "commands",
-    label: "Esegui comando guidato",
-    description: "Apri il flusso con controllo prima dell'esecuzione.",
+    label: "Apri comandi",
   },
   {
     id: "render",
     label: "Controlla rilasci",
-    description: "Verifica rapidamente lo stato dei servizi online.",
   },
   {
     id: "audit",
     label: "Apri registro operazioni",
-    description: "Vedi le azioni recenti e i relativi esiti.",
   },
 ];
 
@@ -33,7 +29,6 @@ function renderActions() {
     return `
       <li class="tdp-action-item">
         <a class="tdp-btn tdp-btn-primary" href="${href}">${action.label}</a>
-        <p>${action.description}</p>
       </li>
     `;
   }).join("");
@@ -46,7 +41,6 @@ function renderFeatureFlags() {
         `<li>
           <div class="tdp-flag-meta">
             <strong>${key}</strong>
-            <p class="tdp-flag-description">${getFeatureFlagDescription(key)}</p>
           </div>
           <span class="${enabled ? "tdp-flag-on" : "tdp-flag-off"}">${enabled ? "ON" : "OFF"}</span>
         </li>`
@@ -68,8 +62,7 @@ const start = () => {
     <main class="tdp-shell">
       <header class="tdp-hero">
         <p class="tdp-kicker">Turni di Palco</p>
-        <h1>Dashboard PWA ricostruita</h1>
-        <p>Interfaccia semplificata: poche azioni chiare e feature flags sempre visibili.</p>
+        <h1>Dashboard PWA</h1>
         <div class="tdp-hero-actions">
           <a class="tdp-btn tdp-btn-primary" href="/mobile/">Apri app mobile</a>
           <a class="tdp-btn tdp-btn-ghost" href="/control-plane.html?view=commands&source=home-hero">Apri dashboard comandi</a>
@@ -103,7 +96,7 @@ const start = () => {
             <li><strong>Supabase</strong><span>${appConfig.supabase.configured ? "OK" : "MANCANTE"}</span></li>
             <li><strong>Control plane</strong><span>${appConfig.controlPlane.baseUrl || "path locale"}</span></li>
           </ul>
-          ${configWarnings.length ? `<p class="tdp-warning">${configWarnings.join(" | ")}</p>` : '<p class="tdp-ok">Nessun warning critico.</p>'}
+          ${configWarnings.length ? `<p class="tdp-warning">${configWarnings.join(" | ")}</p>` : ""}
         </article>
       </section>
     </main>

--- a/apps/pwa/src/privacy.ts
+++ b/apps/pwa/src/privacy.ts
@@ -26,7 +26,6 @@ const start = () => {
       <section class="tdp-privacy-card">
         <p class="tdp-kicker">Turni di Palco</p>
         <h1>Privacy</h1>
-        <p>Informativa ufficiale pubblicata tramite Iubenda.</p>
         <div class="tdp-privacy-actions">
           <a class="tdp-btn tdp-btn-primary" href="/">Torna alla dashboard</a>
           <a class="tdp-btn tdp-btn-ghost" href="/mobile/">Apri app mobile</a>

--- a/apps/pwa/src/pwa/sw-update.ts
+++ b/apps/pwa/src/pwa/sw-update.ts
@@ -55,9 +55,7 @@ export function promptServiceWorkerUpdate(registration: ServiceWorkerRegistratio
   const eyebrow = document.createElement("p");
   eyebrow.className = "eyebrow";
   eyebrow.textContent = "Aggiornamento disponibile";
-  const description = document.createElement("p");
-  description.textContent = "E' pronta una nuova versione offline. Ricarica per applicarla.";
-  copy.append(eyebrow, description);
+  copy.append(eyebrow);
 
   const actions = document.createElement("div");
   actions.className = "toast-actions";

--- a/apps/pwa/src/services/dev-gate.ts
+++ b/apps/pwa/src/services/dev-gate.ts
@@ -205,9 +205,7 @@ function renderGate(root: HTMLElement) {
         <div>
           <p class="eyebrow">Area riservata</p>
           <h1 class="heading-2">Accesso developer PWA</h1>
-          <p class="muted">
-            Per continuare devi autenticarti con un account abilitato su Supabase: le autorizzazioni sono verificate anche lato server.
-          </p>
+          <p class="muted">Accedi con un account abilitato.</p>
         </div>
         <form class="dev-gate-form" data-dev-gate-form>
           <label class="field">
@@ -242,9 +240,10 @@ function renderGate(root: HTMLElement) {
   }
 
   const rolesCopy = allowedRoles.length
-    ? `Ruoli abilitati: ${allowedRoles.join(", ")}.`
-    : "Nessun ruolo abilitato configurato.";
+    ? `Ruoli: ${allowedRoles.join(", ")}`
+    : "";
   rolesNote.textContent = rolesCopy;
+  rolesNote.hidden = !rolesCopy;
 
   return { root, form, message, emailInput, passwordInput, submitButton, signOutButton } satisfies DevGateState;
 }

--- a/apps/pwa/src/services/ops-sdk.ts
+++ b/apps/pwa/src/services/ops-sdk.ts
@@ -16,7 +16,6 @@ export type ControlPlanePreset = {
 export type OpsQuickAction = {
   id: string;
   label: string;
-  note: string;
   minRole: OpsRole;
   preset: ControlPlanePreset;
 };
@@ -31,7 +30,6 @@ const QUICK_ACTIONS: OpsQuickAction[] = [
   {
     id: "qa-render-health",
     label: "Stato deploy",
-    note: "Controlla stato servizi Render",
     minRole: "dev_viewer",
     preset: {
       view: "render",
@@ -43,7 +41,6 @@ const QUICK_ACTIONS: OpsQuickAction[] = [
   {
     id: "qa-audit-last",
     label: "Audit recente",
-    note: "Apri cronologia operativa",
     minRole: "dev_viewer",
     preset: {
       view: "audit",
@@ -53,7 +50,6 @@ const QUICK_ACTIONS: OpsQuickAction[] = [
   {
     id: "qa-render-trigger",
     label: "Prepara deploy",
-    note: "Preset comando deploy in dry-run",
     minRole: "dev_operator",
     preset: {
       view: "commands",
@@ -67,7 +63,6 @@ const QUICK_ACTIONS: OpsQuickAction[] = [
   {
     id: "qa-db-read",
     label: "Controllo DB",
-    note: "Preset query readonly",
     minRole: "dev_operator",
     preset: {
       view: "commands",
@@ -81,7 +76,6 @@ const QUICK_ACTIONS: OpsQuickAction[] = [
   {
     id: "qa-mobile-flags",
     label: "Feature flags",
-    note: "Gestione flag mobile runtime",
     minRole: "dev_admin",
     preset: {
       view: "mobile-flags",

--- a/apps/pwa/src/style.css
+++ b/apps/pwa/src/style.css
@@ -134,13 +134,6 @@ body {
   gap: 0.15rem;
 }
 
-.tdp-flag-description {
-  margin: 0;
-  color: var(--tdp-muted);
-  font-size: 0.82rem;
-  line-height: 1.35;
-}
-
 .tdp-flag-on {
   color: var(--tdp-success);
   font-weight: 700;

--- a/apps/pwa/src/test/main.smoke.spec.ts
+++ b/apps/pwa/src/test/main.smoke.spec.ts
@@ -29,7 +29,7 @@ describe("main shell", () => {
     );
     const actionLinks = document.querySelectorAll(".tdp-action-list .tdp-action-item a");
 
-    expect(heading?.textContent).toContain("Dashboard PWA ricostruita");
+    expect(heading?.textContent).toContain("Dashboard PWA");
     expect(systemHeading).not.toBeNull();
     expect(actionLinks).toHaveLength(3);
     expect(actionLinks[0]?.getAttribute("href")).toContain("/control-plane.html?view=commands");


### PR DESCRIPTION
## Summary
- remove redundant instructional and descriptive copy from PWA and mobile UI
- simplify install, activity, support, and dashboard surfaces to keep only essential labels and states
- update docs to replace stale references to the old UI submodule with apps/mobile

## Validation
- npm run test:pwa
- npm run build:mobile
- npm run build:pwa