### PR TITLE
Add mobile copyright notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,12 +168,5 @@ Copyright © 2025 A.T.C.L. Associazione Teatrale fra i Comuni del Lazio.
 
 All rights reserved.
 
-This software is proprietary and confidential to ATCL.
-Unauthorized copying, distribution, modification, or use
-of this software is strictly prohibited.
-
-This software may not be reproduced, modified, or redistributed
-without the express written permission of ATCL.
-
-Any violation of this copyright notice will be prosecuted
-to the fullest extent of the law.
+This project is proprietary and confidential to ATCL.
+See [LICENSE](LICENSE) for the full notice.

--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -24,6 +24,7 @@ import {
   type NotificationPermissionState,
 } from '../../lib/notifications';
 import { checkAiSupportAvailability } from '../../services/ai';
+import { CopyrightNotice } from '../ui/CopyrightNotice';
 
 interface AccountSettingsProps {
   userName: string;
@@ -719,7 +720,9 @@ export function AccountSettings({
           </button>
         </div>
 
-        <div className="mt-auto">
+        <div className="mt-auto flex flex-col gap-4">
+          <CopyrightNotice />
+
           <button
             type="button"
             onClick={onLogout}

--- a/apps/mobile/src/components/screens/PrivacyPolicy.tsx
+++ b/apps/mobile/src/components/screens/PrivacyPolicy.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { ArrowLeft } from 'lucide-react';
 import { Screen } from '../ui/Screen';
+import { CopyrightNotice } from '../ui/CopyrightNotice';
 
 interface PrivacyPolicyProps {
   onBack: () => void;
@@ -66,6 +67,8 @@ export function PrivacyPolicy({ onBack }: PrivacyPolicyProps) {
             Nota: è necessaria una connessione internet per caricare il documento.
           </p>
         </div>
+
+        <CopyrightNotice />
       </div>
     </Screen>
   );

--- a/apps/mobile/src/components/screens/TermsAndConditions.tsx
+++ b/apps/mobile/src/components/screens/TermsAndConditions.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ArrowLeft } from 'lucide-react';
 import { Screen } from '../ui/Screen';
+import { CopyrightNotice } from '../ui/CopyrightNotice';
 
 interface TermsAndConditionsProps {
   onBack: () => void;
@@ -82,6 +83,8 @@ export function TermsAndConditions({ onBack }: TermsAndConditionsProps) {
             </div>
           </div>
         </div>
+
+        <CopyrightNotice />
       </div>
     </Screen>
   );

--- a/apps/mobile/src/components/ui/CopyrightNotice.tsx
+++ b/apps/mobile/src/components/ui/CopyrightNotice.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { cn } from './utils';
+
+interface CopyrightNoticeProps {
+  className?: string;
+}
+
+export function CopyrightNotice({ className }: CopyrightNoticeProps) {
+  return (
+    <p
+      className={cn(
+        'text-center text-[11px] leading-[16px] text-[#7a7577] !m-0',
+        className
+      )}
+    >
+      Copyright © 2025 A.T.C.L. Associazione Teatrale fra i Comuni del Lazio. Tutti i diritti
+      riservati.
+    </p>
+  );
+}


### PR DESCRIPTION
Summary: add a reusable mobile copyright notice, show it in the legal screens and account settings, and align the README license section. Testing: npm run build:mobile.