### PR TITLE
Fix Iubenda bootstrap

### DIFF
--- a/apps/mobile/src/components/screens/PrivacyPolicy.tsx
+++ b/apps/mobile/src/components/screens/PrivacyPolicy.tsx
@@ -12,8 +12,19 @@ const IUBENDA_SCRIPT_SRC = 'https://cdn.iubenda.com/iubenda.js';
 const IUBENDA_ANCHOR_CLASSES =
   'iubenda-nostyle no-brand iubenda-noiframe iubenda-embed iubenda-noiframe iub-body-embed';
 
+function ensureIubendaGlobal() {
+  if (typeof window === 'undefined') return;
+
+  const iubendaWindow = window as Window & { _iub?: unknown[] };
+  if (!Array.isArray(iubendaWindow._iub)) {
+    iubendaWindow._iub = [];
+  }
+}
+
 function ensureIubendaScript() {
   if (typeof document === 'undefined') return;
+
+  ensureIubendaGlobal();
 
   const existing = document.querySelector<HTMLScriptElement>(`script[src="${IUBENDA_SCRIPT_SRC}"]`);
   if (existing) return;

--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -33,7 +33,7 @@ const CORE_ASSETS = [
 const NON_PUBLIC_PATHS = new Set(CORE_ASSETS_BY_ENV.dev);
 const OFFLINE_URL = "/index.html";
 
-const CORE_CACHE_VERSION = "vc425325e";
+const CORE_CACHE_VERSION = "vbab6529e";
 const CACHE_VERSION_TAG = "v5";
 const CORE_CACHE_NAME = `turni-di-palco-core-${CORE_CACHE_VERSION}-${CACHE_VERSION_TAG}`;
 const TILE_CACHE_NAME = `turni-di-palco-tiles-${CORE_CACHE_VERSION}-${CACHE_VERSION_TAG}`;

--- a/apps/pwa/src/privacy.ts
+++ b/apps/pwa/src/privacy.ts
@@ -5,7 +5,16 @@ const IUBENDA_PRIVACY_POLICY_URL = "https://www.iubenda.com/privacy-policy/78603
 const IUBENDA_SCRIPT_SRC = "https://cdn.iubenda.com/iubenda.js";
 const IUBENDA_ANCHOR_CLASSES = "iubenda-nostyle no-brand iubenda-noiframe iubenda-embed iubenda-noiframe iub-body-embed";
 
+function ensureIubendaGlobal() {
+  const iubendaWindow = window as Window & { _iub?: unknown[] };
+  if (!Array.isArray(iubendaWindow._iub)) {
+    iubendaWindow._iub = [];
+  }
+}
+
 function ensureIubendaScript() {
+  ensureIubendaGlobal();
+
   const existing = document.querySelector<HTMLScriptElement>(`script[src="${IUBENDA_SCRIPT_SRC}"]`);
   if (existing) return;
 


### PR DESCRIPTION
Summary: initialize the Iubenda global before loading the embed script in the mobile privacy screen and the standalone PWA privacy page. Testing: npm run build:mobile; npm run build:pwa.