### PR TITLE
Add deployment status dashboard to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,16 @@ L’obiettivo è semplice: vivere il teatro in modo più attivo, scoprendo non s
 
 ![Icona app](apps/pwa/public/icons/badge.png)
 
-## Cos'è
+## Stato dei Deploy
+
+| Piattaforma | Stato | URL |
+|-------------|-------|-----|
+| Render | [![Render](https://turni-di-palco-badges.onrender.com/website?url=https%3A%2F%2Fturni-di-palco-fq85.onrender.com&label=stato&logo=render&logoColor=white&up_message=online&down_message=offline&up_color=brightgreen&down_color=red)](https://turni-di-palco-fq85.onrender.com) | [turni-di-palco-fq85.onrender.com](https://turni-di-palco-fq85.onrender.com) |
+| Railway | [![Railway](https://turni-di-palco-badges.onrender.com/website?url=https%3A%2F%2Fturni-di-palco-production.up.railway.app&label=stato&logo=railway&logoColor=white&up_message=online&down_message=offline&up_color=brightgreen&down_color=red)](https://turni-di-palco-production.up.railway.app) | [turni-di-palco-production.up.railway.app](https://turni-di-palco-production.up.railway.app) |
+| Vercel | [![Vercel](https://turni-di-palco-badges.onrender.com/website?url=https%3A%2F%2Fturni-di-palco.vercel.app&label=stato&logo=vercel&logoColor=white&up_message=online&down_message=offline&up_color=brightgreen&down_color=red)](https://turni-di-palco.vercel.app) | [turni-di-palco.vercel.app](https://turni-di-palco.vercel.app) |
+| Netlify | [![Netlify](https://turni-di-palco-badges.onrender.com/website?url=https%3A%2F%2Fturni-di-palco.netlify.app&label=stato&logo=netlify&logoColor=white&up_message=online&down_message=offline&up_color=brightgreen&down_color=red)](https://turni-di-palco.netlify.app) | [turni-di-palco.netlify.app](https://turni-di-palco.netlify.app) |
+
+## Cos’è
 
 Turni di Palco è una app in cui l’utente costruisce una carriera teatrale virtuale.
 La progressione non dipende solo dal gioco: cresce davvero quando si partecipa agli eventi reali del circuito.


### PR DESCRIPTION
## Summary
Added a new "Stato dei Deploy" (Deployment Status) section to the README that displays the current status of the application across multiple hosting platforms with live status badges and direct links.

## Changes Made
- Added a new "Stato dei Deploy" section in the README with a status table
- Included deployment status badges for 4 platforms:
  - Render (turni-di-palco-fq85.onrender.com)
  - Railway (turni-di-palco-production.up.railway.app)
  - Vercel (turni-di-palco.vercel.app)
  - Netlify (turni-di-palco.netlify.app)
- Each badge displays real-time online/offline status with color indicators (green for online, red for offline)
- Badges link directly to the deployed applications

## Implementation Details
- Uses a badge service (turni-di-palco-badges.onrender.com) to generate dynamic status indicators
- Status badges automatically update to show whether each deployment is online or offline
- Table format provides clear organization and easy access to all deployment URLs
- Positioned prominently in the README after the app icon and before the "Cos'è" section

https://claude.ai/code/session_01HWa9zTMzNgAV1JX9gR3R6f