### PR TITLE
Disable support button when status is unknown

### DIFF
--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -588,7 +588,7 @@ export function AccountSettings({
               <button
                 type="button"
                 onClick={onViewSupport}
-                disabled={supportUnavailable || supportChecking}
+                disabled={supportUnavailable || supportChecking || supportUnknown}
                 className="min-h-[56px] py-[2px] flex items-center justify-between disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 <div className="flex items-center gap-[12px]">
@@ -607,11 +607,6 @@ export function AccountSettings({
               {supportUnavailable ? (
                 <p className="text-[14px] leading-[20px] text-[#ff4d4f]">
                   Supporto AI attualmente non disponibile.
-                </p>
-              ) : null}
-              {supportUnknown ? (
-                <p className="text-[14px] leading-[20px] text-[#f4bf4f]">
-                  Stato del supporto non verificabile. Puoi comunque provare ad aprire la chat.
                 </p>
               ) : null}
             </>


### PR DESCRIPTION
## Summary
Updated the support button behavior to disable when the support status is unknown, and removed the associated informational message that was previously shown to users.

## Key Changes
- Added `supportUnknown` to the disabled state condition for the support button, preventing users from attempting to open support when the status cannot be verified
- Removed the warning message that was displayed when support status was unknown ("Stato del supporto non verificabile. Puoi comunque provare ad aprire la chat.")

## Implementation Details
The support button now disables in three scenarios:
1. When support is unavailable (`supportUnavailable`)
2. When the status is being checked (`supportChecking`)
3. When the status cannot be determined (`supportUnknown`)

This change provides a more consistent user experience by preventing interaction with the support feature when its availability status is uncertain, rather than allowing users to attempt opening the chat with a warning message.

https://claude.ai/code/session_01EJpKvfKijKhHMVygSbeERm