### PR TITLE
Follow-up: integrazione base ruolo RSPP (catalogo app + seed DB)

### DIFF
--- a/apps/mobile/src/components/screens/Career.tsx
+++ b/apps/mobile/src/components/screens/Career.tsx
@@ -14,6 +14,7 @@ import {
   Volume2,
   Package,
   Clipboard,
+  ShieldCheck,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { Screen } from '../ui/Screen';
@@ -42,6 +43,7 @@ const ROLE_ICONS: Record<RoleId, React.ElementType> = {
   fonico: Volume2,
   attrezzista: Package,
   palco: Clipboard,
+  rspp: ShieldCheck,
 };
 
 const ROLE_STAT_KEYS = ['presence', 'precision', 'leadership', 'creativity'] as const;

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -22,7 +22,7 @@ import {
   writeMobileFeatureFlagsCache,
 } from '../services/feature-flags';
 
-export type RoleId = 'attore' | 'luci' | 'fonico' | 'attrezzista' | 'palco';
+export type RoleId = 'attore' | 'luci' | 'fonico' | 'attrezzista' | 'palco' | 'rspp';
 export type Rewards = { xp: number; reputation: number; cachet: number };
 export type TurnSyncStatus = 'pending' | 'synced' | 'failed_boost_fallback';
 
@@ -314,6 +314,7 @@ export const roles: Role[] = [
   { id: 'fonico', name: 'Fonico', focus: 'Pulizia audio', stats: { presence: 45, precision: 90, leadership: 60, creativity: 70 } },
   { id: 'attrezzista', name: 'Attrezzista / Scenografo', focus: 'Allestimento rapido', stats: { presence: 55, precision: 85, leadership: 70, creativity: 90 } },
   { id: 'palco', name: 'Assistente di Palco', focus: 'Coordinamento', stats: { presence: 60, precision: 88, leadership: 85, creativity: 65 } },
+  { id: 'rspp', name: 'RSPP', focus: 'Sicurezza e prevenzione', stats: { presence: 65, precision: 92, leadership: 88, creativity: 58 } },
 ];
 
 export const events: GameEvent[] = [
@@ -1787,7 +1788,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           const rows = (data as LeaderboardRow[]) ?? [];
           const nextLeaderboard: LeaderboardEntry[] = rows.map((row) => {
             const roleCandidate = row.role_id ?? 'attore';
-            const roleId: RoleId = (roleCandidate === 'attore' || roleCandidate === 'luci' || roleCandidate === 'fonico' || roleCandidate === 'attrezzista' || roleCandidate === 'palco')
+            const roleId: RoleId = (roleCandidate === 'attore' || roleCandidate === 'luci' || roleCandidate === 'fonico' || roleCandidate === 'attrezzista' || roleCandidate === 'palco' || roleCandidate === 'rspp')
               ? (roleCandidate as RoleId)
               : 'attore';
             const lastActivityAt = row.last_activity_at ? new Date(row.last_activity_at).getTime() : undefined;

--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -33,7 +33,7 @@ const CORE_ASSETS = [
 const NON_PUBLIC_PATHS = new Set(CORE_ASSETS_BY_ENV.dev);
 const OFFLINE_URL = "/index.html";
 
-const CORE_CACHE_VERSION = "vbab6529e";
+const CORE_CACHE_VERSION = "vfcac4adb";
 const CACHE_VERSION_TAG = "v5";
 const CORE_CACHE_NAME = `turni-di-palco-core-${CORE_CACHE_VERSION}-${CACHE_VERSION_TAG}`;
 const TILE_CACHE_NAME = `turni-di-palco-tiles-${CORE_CACHE_VERSION}-${CACHE_VERSION_TAG}`;

--- a/apps/pwa/src/state.ts
+++ b/apps/pwa/src/state.ts
@@ -10,6 +10,7 @@ export const roles: Role[] = [
   { id: "fonico", name: "Fonico", focus: "Pulizia audio", stats: ["Ascolto", "Reattivita", "Problem solving"] },
   { id: "attrezzista", name: "Attrezzista / Scenografo", focus: "Allestimento rapido", stats: ["Creativita", "Manualita", "Organizzazione"] },
   { id: "palco", name: "Assistente di palco", focus: "Coordinamento", stats: ["Coordinazione", "Leadership", "Sangue freddo"] },
+  { id: "rspp", name: "RSPP", focus: "Sicurezza e prevenzione", stats: ["Prevenzione", "Valutazione rischi", "Coordinamento"] },
 ];
 
 export const avatarIcons: { id: AvatarIcon; label: string; symbol: string }[] = [

--- a/apps/pwa/src/types.ts
+++ b/apps/pwa/src/types.ts
@@ -1,4 +1,4 @@
-export type RoleId = "attore" | "luci" | "fonico" | "attrezzista" | "palco";
+export type RoleId = "attore" | "luci" | "fonico" | "attrezzista" | "palco" | "rspp";
 export type Rewards = { xp: number; cachet: number; reputation: number };
 export type Role = { id: RoleId; name: string; focus: string; stats: string[] };
 export type AvatarIcon = "mask" | "spot" | "gear" | "note";

--- a/supabase/migrations/20260310120000_add_rspp_role.sql
+++ b/supabase/migrations/20260310120000_add_rspp_role.sql
@@ -1,0 +1,11 @@
+insert into public.roles (id, name, focus, stats)
+values (
+  'rspp',
+  'RSPP',
+  'Sicurezza e prevenzione',
+  '{"presence":65,"precision":92,"leadership":88,"creativity":58}'
+)
+on conflict (id) do update set
+  name = excluded.name,
+  focus = excluded.focus,
+  stats = excluded.stats;


### PR DESCRIPTION
### Motivation
- Allineare il modello dominio e i cataloghi client per introdurre il nuovo ruolo `RSPP` in modo che sia selezionabile, visualizzabile e persistibile lato DB.
- Preparare il database con una migration che inserisca (upsert) il ruolo `rspp` in `public.roles` per ambienti già deployati.

### Description
- Esteso il tipo `RoleId` con `rspp` sia in `apps/mobile` che in `apps/pwa`.
- Aggiunto il ruolo `{ id: 'rspp', name: 'RSPP', focus: 'Sicurezza e prevenzione', stats: ... }` ai cataloghi locali di mobile e PWA.
- Aggiornata la logica della leaderboard mobile per riconoscere `rspp` come valore valido e evitarne il fallback errato.
- Aggiornata la UI `Career` mobile aggiungendo l'icona `ShieldCheck` in `ROLE_ICONS` per il nuovo ruolo.
- Aggiunta una migration SQL `supabase/migrations/20260310120000_add_rspp_role.sql` che esegue upsert del ruolo `rspp` in `public.roles`.

### Testing
- Eseguito `npm run build:pwa` con esito positivo (build completata e aggiornamento automatico `CORE_CACHE_VERSION` in `apps/pwa/public/sw.js`).
- Eseguito `npm run build:mobile` con esito positivo (bundle mobile generato correttamente).
- Avviato dev server mobile e generato uno screenshot headless per verifica visuale della selezione ruolo (Playwright); operazione completata con successo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b02d5af5148326b0d4bdd68234faae)