### PR TITLE
[TECH-001 follow-up] Complete duplicate-sync handling for Offline Sync Queue

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -536,7 +536,7 @@ function AppShell() {
   }): Promise<
     | {
       ok: true;
-      syncStatus: 'pending' | 'synced' | 'failed_boost_fallback';
+      syncStatus: 'pending' | 'synced' | 'synced_duplicate' | 'failed_boost_fallback';
       boostRequested: boolean;
       boostApplied: boolean;
       boostRejectionReason: string | null;
@@ -1056,4 +1056,3 @@ export default function App() {
     </GameStateProvider>
   );
 }
-

--- a/apps/mobile/src/components/screens/EventConfirmation.tsx
+++ b/apps/mobile/src/components/screens/EventConfirmation.tsx
@@ -76,6 +76,9 @@ export function EventConfirmation({
         ? 'Boost in verifica'
         : 'Turno in attesa di sincronizzazione';
     }
+    if (confirmResult.syncStatus === 'synced_duplicate') {
+      return 'Turno già sincronizzato';
+    }
     if (confirmResult.boostRequested && confirmResult.boostApplied) return 'Boost applicato';
     if (confirmResult.boostRequested && !confirmResult.boostApplied) return 'Boost non applicato';
     return 'Turno registrato';
@@ -87,6 +90,9 @@ export function EventConfirmation({
       return confirmResult.boostRequested
         ? 'Richiesta boost salvata in coda: verrà verificata online.'
         : 'Turno salvato in coda: sarà sincronizzato appena torni online.';
+    }
+    if (confirmResult.syncStatus === 'synced_duplicate') {
+      return 'Questo turno risulta già registrato: nessuna ricompensa aggiuntiva è stata applicata.';
     }
     if (confirmResult.boostRequested && confirmResult.boostApplied) {
       return 'Verifica completata: +10% XP e +10% Cachet applicati.';

--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -232,7 +232,9 @@ export function Home({
                       ? 'Boost confermato'
                       : turnSyncFeedback.syncStatus === 'failed_boost_fallback'
                         ? 'Boost non applicato (fallback base)'
-                        : 'Richiesta boost in verifica'}
+                        : turnSyncFeedback.syncStatus === 'synced_duplicate'
+                          ? 'Turno già sincronizzato'
+                          : 'Richiesta boost in verifica'}
                   </p>
                   <p className="text-xs text-[#b8b2b3]">
                     {turnSyncFeedback.eventName}

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -24,7 +24,7 @@ import {
 
 export type RoleId = 'attore' | 'luci' | 'fonico' | 'attrezzista' | 'palco';
 export type Rewards = { xp: number; reputation: number; cachet: number };
-export type TurnSyncStatus = 'pending' | 'synced' | 'failed_boost_fallback';
+export type TurnSyncStatus = 'pending' | 'synced' | 'synced_duplicate' | 'failed_boost_fallback';
 
 export type Role = {
   id: RoleId;
@@ -1115,6 +1115,12 @@ type TurnRegistrationRpcRow = {
   token_balance_after: number | null;
 };
 
+export function resolveTurnSyncStatusFromRpc(rpcRow: Pick<TurnRegistrationRpcRow, 'turn_registered' | 'boost_requested' | 'boost_applied'>): TurnSyncStatus {
+  if (!rpcRow.turn_registered) return 'synced_duplicate';
+  if (rpcRow.boost_requested && !rpcRow.boost_applied) return 'failed_boost_fallback';
+  return 'synced';
+}
+
 function normalizeRewardsPayload(value: unknown): Rewards {
   if (!isRecord(value)) return { xp: 0, reputation: 0, cachet: 0 };
   return {
@@ -1978,10 +1984,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           if (!rpcRow) {
             return { status: 'retry', error: new Error('Risposta RPC non valida') };
           }
-          const syncStatus: TurnSyncStatus =
-            rpcRow.boost_requested && !rpcRow.boost_applied
-              ? 'failed_boost_fallback'
-              : 'synced';
+          const syncStatus = resolveTurnSyncStatusFromRpc(rpcRow);
           applyTurnRegistrationResult(mutation.payload, rpcRow, syncStatus);
           return { status: 'applied' };
         }
@@ -3479,10 +3482,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           }
         );
 
-        const syncStatus: TurnSyncStatus =
-          rpcResponse.boost_requested && !rpcResponse.boost_applied
-            ? 'failed_boost_fallback'
-            : 'synced';
+        const syncStatus = resolveTurnSyncStatusFromRpc(rpcResponse);
         applyTurnRegistrationResult(turnRegisterPayload, rpcResponse, syncStatus);
         logOfflineSync('registerTurn synced immediately via RPC', {
           turnId,

--- a/apps/mobile/src/test/offline-sync-status.test.ts
+++ b/apps/mobile/src/test/offline-sync-status.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTurnSyncStatusFromRpc } from '../state/store';
+
+describe('resolveTurnSyncStatusFromRpc', () => {
+  it('returns synced_duplicate when server reports turn already registered', () => {
+    expect(resolveTurnSyncStatusFromRpc({
+      turn_registered: false,
+      boost_requested: true,
+      boost_applied: false,
+    })).toBe('synced_duplicate');
+  });
+
+  it('returns failed_boost_fallback when turn is new but boost is not applied', () => {
+    expect(resolveTurnSyncStatusFromRpc({
+      turn_registered: true,
+      boost_requested: true,
+      boost_applied: false,
+    })).toBe('failed_boost_fallback');
+  });
+
+  it('returns synced for a successful synced turn', () => {
+    expect(resolveTurnSyncStatusFromRpc({
+      turn_registered: true,
+      boost_requested: true,
+      boost_applied: true,
+    })).toBe('synced');
+  });
+});


### PR DESCRIPTION
### Motivation
- The mobile offline sync flow did not surface server-side duplicate turn outcomes (`turn_registered = false`) to the user, causing confusing feedback in retry/replay scenarios.
- The goal is to model duplicate results explicitly and centralize the logic that maps RPC responses to UI-facing sync states.

### Description
- Added a new sync status `synced_duplicate` to `TurnSyncStatus` and updated the turn confirmation typing in `App.tsx` to include it.
- Introduced `resolveTurnSyncStatusFromRpc(...)` in `apps/mobile/src/state/store.tsx` and used it for both immediate RPC registration and queued flush processing to centralize status derivation.
- Updated UI feedback strings in `EventConfirmation.tsx` and `Home.tsx` to show explicit messages when a duplicate sync outcome occurs.
- Added unit tests `apps/mobile/src/test/offline-sync-status.test.ts` that cover `synced_duplicate`, `failed_boost_fallback` and `synced` resolution.

### Testing
- Ran unit tests with `npm --workspace apps/mobile run test` and all tests passed (2 test files, 21 tests total).
- Ran type checking with `npm --workspace apps/mobile run typecheck` and it succeeded with no errors.
- Ran linter with `npm --workspace apps/mobile run lint`; lint completed with pre-existing warnings (no new errors introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b02f4647248326953f2e0098648ec7)