### PR TITLE
Fix for Useless conditional

### DIFF
--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -279,7 +279,7 @@ export function Home({
 
           <Card 
             hoverable={eventState === 'ready' && allowTurnsSection}
-            onClick={eventState === 'ready' && allowTurnsSection ? onViewTurni : undefined}
+            onClick={eventState === 'ready' ? onViewTurni : undefined}
             animateOnMount
           >
             {eventState === 'loading' ? (


### PR DESCRIPTION
In general, to fix a conditional expression that always evaluates to the same boolean, we should either remove the redundant condition (if it is truly constant and adds no value) or correct the logic so that the condition actually reflects the intended variability. Here, at line 282 the `onClick` is guarded by `eventState === 'ready' && allowTurnsSection ? onViewTurni : undefined`, but this button is already inside `{allowTurnsSection ? ( <section> ... ) : null}`, and CodeQL reports that `allowTurnsSection` is always true at this point. That makes the `&& allowTurnsSection` part redundant and potentially confusing.

The best fix without changing functionality is therefore to simplify the condition at line 282 to depend only on `eventState`, which is the part that actually varies for this card’s clickability. We leave the outer `allowTurnsSection` gating of the section and the other uses (lines 269 and 309) unchanged, since they still represent meaningful feature flags or permissions. Concretely, in `apps/mobile/src/components/screens/Home.tsx`, update line 282 so that `onClick` is set to `onViewTurni` when `eventState === 'ready'`, without checking `allowTurnsSection` again. No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._