### PR TITLE
Fix for Useless conditional

### DIFF
--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -306,11 +306,9 @@ export function Home({
                       Scansiona QR
                     </Button>
                   ) : null}
-                  {allowTurnsSection ? (
-                    <Button variant="ghost" size="sm" onClick={onViewTurni}>
-                      Vedi turni
-                    </Button>
-                  ) : null}
+                  <Button variant="ghost" size="sm" onClick={onViewTurni}>
+                    Vedi turni
+                  </Button>
                 </div>
               </div>
             ) : (


### PR DESCRIPTION
In general, to fix a conditional that always evaluates to true, either (a) remove the redundant condition if the guarded code should always execute, or (b) correct the logic so it depends on a value that can actually vary at runtime. This avoids misleading, dead, or redundant branches and makes the code’s intent clear both to readers and to analysis tools.

Here, CodeQL says `allowTurnsSection` is always `true` at line 309. That means the JSX ternary:

```tsx
{allowTurnsSection ? (
  <Button ...>
    Vedi turni
  </Button>
) : null}
```

is equivalent to always rendering the `<Button>`. The simplest fix without changing runtime behavior is to remove the redundant condition and render the button unconditionally. Since we are constrained to the shown snippet, we will not alter how `allowTurnsSection` is computed elsewhere; we will only simplify this JSX. Concretely:

- In `apps/mobile/src/components/screens/Home.tsx`, in the section around lines 300–314, replace the `allowTurnsSection` ternary at line 309–313 with an unconditional `<Button>` block.
- No new imports or helper methods are required.

This preserves existing behavior (the button still always appears, as before) while eliminating the logically dead condition CodeQL is complaining about.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._