### PR TITLE
Fix for Useless conditional

### DIFF
--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -266,7 +266,7 @@ export function Home({
         <section className="space-y-3">
           <div className="flex items-center justify-between">
             <h3 className="text-white text-lg font-semibold" style={{ margin: '20px 0 5px' }}>Prossimo evento</h3>
-            {eventState === 'ready' && allowTurnsSection ? (
+            {eventState === 'ready' ? (
               <button
                 onClick={onViewEventDetails}
                 className="text-sm text-[#f4bf4f] hover:text-[#e6a23c] px-3 py-[12px] rounded-lg"
@@ -278,7 +278,7 @@ export function Home({
           </div>
 
           <Card 
-            hoverable={eventState === 'ready' && allowTurnsSection}
+            hoverable={eventState === 'ready'}
             onClick={eventState === 'ready' ? onViewTurni : undefined}
             animateOnMount
           >


### PR DESCRIPTION
To fix the problem, remove the redundant `allowTurnsSection` checks from conditions that are already executed only when `allowTurnsSection` is true. Specifically, inside the `<section>` that is already wrapped by `{allowTurnsSection ? ( ... ) : null}`, we should simplify conditions that currently combine `eventState === 'ready'` with `allowTurnsSection`.

The best minimal fix without changing functionality is:
- At line 269, change `{eventState === 'ready' && allowTurnsSection ? (` to `{eventState === 'ready' ? (`.
- At lines 281–282, change `hoverable={eventState === 'ready' && allowTurnsSection}` to `hoverable={eventState === 'ready'}` and `onClick={eventState === 'ready' && allowTurnsSection ? onViewTurni : undefined}` to `onClick={eventState === 'ready' ? onViewTurni : undefined}`.

These changes are all within `apps/mobile/src/components/screens/Home.tsx` and do not require new imports or helper methods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._