### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { supabase, isSupabaseConfigured } from '../lib/supabase';
 import { resolveDisplayName } from '../lib/profile-utils';
 import { PlayerProfile } from '../state/store';


### PR DESCRIPTION
To fix this, we should remove the unused `useRef` from the React import while leaving the rest of the hook implementation unchanged. This keeps the code behavior identical (since `useRef` is not used) and resolves the CodeQL finding.

Concretely, in `apps/mobile/src/hooks/useAuth.ts`, edit the first import line so that it only imports the React hooks that are actually used in this file: `useState`, `useEffect`, and `useCallback`. No additional imports, methods, or definitions are needed, and no other lines need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._