### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -12,7 +12,7 @@ interface QRScannerProps {
 }
 
 export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
-  const [manualCode, setManualCode] = useState('');
+  const [manualCode] = useState('');
   const [manualTicket, setManualTicket] = useState('');
   const [manualEventId, setManualEventId] = useState('');
   const [isScanning, setIsScanning] = useState(true);


### PR DESCRIPTION
In general, to fix an unused setter from a `useState` hook, you can either (1) remove the unused state entirely if the value is not needed, or (2) keep only the part that is actually used. For React state, if only the value is read and never updated, you should convert it into a simple constant with `useState` (or remove it) and avoid binding the setter.

The best targeted fix here, without altering functionality, is to stop binding the unused `setManualCode` variable while still keeping `manualCode` and its initial value. React allows you to ignore the setter from the tuple; you can write `const [manualCode] = useState('');`. This keeps `manualCode` as a stateful value (it will not be updated, but behavior remains the same as today, since the setter is never used) and removes the unused variable. Concretely, in `apps/mobile/src/components/screens/QRScanner.tsx`, at line 15, replace `const [manualCode, setManualCode] = useState('');` with `const [manualCode] = useState('');`. No imports or further changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._