### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -12,7 +12,6 @@ interface QRScannerProps {
 }
 
 export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
-  const [manualCode] = useState('');
   const [manualTicket, setManualTicket] = useState('');
   const [manualEventId, setManualEventId] = useState('');
   const [isScanning, setIsScanning] = useState(true);


### PR DESCRIPTION
General fix: Remove unused state/variables, or start using them meaningfully. To avoid changing functionality, we should prefer deleting clearly dead code rather than introducing new behavior. Since there is no evidence that `manualCode` should be used and closely related state (`manualTicket`, `manualEventId`) exists, the safest fix is to delete the `manualCode` state tuple entirely.

Concrete change: In `apps/mobile/src/components/screens/QRScanner.tsx`, on the line where `manualCode` is declared, remove the entire `useState` declaration for `manualCode` and its setter. No other code changes are needed, since neither the state variable nor setter are referenced elsewhere in the shown snippet. This will eliminate the unused variable and any associated re-rendering overhead.

Needed elements: No new methods, imports, or definitions are required. We only delete the unused state declaration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._