### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tools/ai-support-server.js
+++ b/tools/ai-support-server.js
@@ -994,16 +994,6 @@ function startGhLogin() {
   });
 }
 
-function generateDeviceCode() {
-  // Generate a random 8-character device code (GitHub format)
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-  let code = '';
-  for (let i = 0; i < 8; i++) {
-    code += chars.charAt(Math.floor(Math.random() * chars.length));
-  }
-  return code;
-}
-
 function checkCodexAuth() {
   const result = spawnCodexSync(['login', 'status']);
   if (result?.error) {


### PR DESCRIPTION
To fix the problem, we should remove the unused function `generateDeviceCode` so that the file no longer defines dead code. This addresses the static analysis warning and slightly simplifies the module, without changing existing runtime behavior, because nothing calls this function.

Concretely, in `tools/ai-support-server.js`, delete the entire `generateDeviceCode` function definition (lines 997–1005 in your snippet), leaving the surrounding functions (`startGhLogin` and `checkCodexAuth`) directly adjacent. No new imports or helpers are needed, and no other code needs to be updated because there are no references to `generateDeviceCode`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._