### PR TITLE
Fix for Duplicate key in dict literal

### DIFF
--- a/tools/ticket_qr_generator/generate_ticket_qr.py
+++ b/tools/ticket_qr_generator/generate_ticket_qr.py
@@ -49,7 +49,6 @@ ITALIAN_MONTHS = {
     "febbraio": 2,
     "mar": 3,
     "marzo": 3,
-    "apr": 4,
     "aprile": 4,
     "mag": 5,
     "maggio": 5,


### PR DESCRIPTION
To fix the problem, we should ensure all keys in the `ITALIAN_MONTHS` dictionary are unique. Since both occurrences of `"apr"` map to the same value `4`, the best non-functional change is simply to remove one of them. This preserves the behavior of `_parse_calendar_date` (lookups for `"apr"` still return 4) while eliminating the duplicate and the static analysis warning.

Concretely, in `tools/ticket_qr_generator/generate_ticket_qr.py`, within the `ITALIAN_MONTHS` dict definition, remove the first `"apr": 4,` at line 52, keeping the second `"apr": 4,` at line 74 as part of the English month aliases. No new imports or helper methods are needed; it’s a straightforward dictionary literal cleanup and does not alter existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._