### PR TITLE
Fix for Empty except

### DIFF
--- a/tools/ticket_qr_generator/ticket_qr_generator_ui.py
+++ b/tools/ticket_qr_generator/ticket_qr_generator_ui.py
@@ -130,6 +130,7 @@ class TicketQrGeneratorUI:
         try:
             style.theme_use("clam")
         except tk.TclError:
+            # If the "clam" theme is not available, silently fall back to the default Tk theme.
             pass
 
         self.root.configure(bg=COLOR_APP_BG)


### PR DESCRIPTION
To fix the problem without changing functionality, we should keep ignoring `tk.TclError` (since failing to apply the "clam" theme is not critical), but add an explanatory comment inside the `except` block. This documents that the exception is intentionally suppressed because the default theme is acceptable, and it satisfies the CodeQL rule.

Concretely, in `tools/ticket_qr_generator/ticket_qr_generator_ui.py`, in the `_configure_theme` method around lines 129–135, replace the bare `pass` in the `except tk.TclError:` block with a short comment such as `# Fallback to default Tk theme if "clam" is not available.` followed by `pass`, or just the comment if desired. No imports or additional methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._