### PR TITLE
Fix for Duplicate key in dict literal

### DIFF
--- a/tools/ticket_qr_generator/generate_ticket_qr.py
+++ b/tools/ticket_qr_generator/generate_ticket_qr.py
@@ -83,7 +83,6 @@ ITALIAN_MONTHS = {
     "september": 9,
     "oct": 10,
     "october": 10,
-    "nov": 11,
     "dec": 12,
     "december": 12,
 }


### PR DESCRIPTION
In general, to fix “duplicate key in dict literal” issues, remove or consolidate duplicate entries so that each key appears only once, keeping the intended value. If different values are needed in different contexts, use separate dictionaries or conditionally construct them instead of relying on overwriting inside a single literal.

Here, the `ITALIAN_MONTHS` mapping defines `"nov": 11` twice (lines 65 and 86). Both map to the same numerical month, so the best fix that preserves existing behaviour is simply to remove one of the duplicates. To keep the structure clear, we can leave the Italian block intact and drop the later `"nov": 11` from the English section (or vice versa; behaviour is identical). This change is confined to `tools/ticket_qr_generator/generate_ticket_qr.py`, in the `ITALIAN_MONTHS` dict definition, and does not require any new imports or auxiliary functions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._