### PR TITLE
Fix mobile dialog warnings and promo proxy

### DIFF
--- a/apps/mobile/src/components/ui/command.tsx
+++ b/apps/mobile/src/components/ui/command.tsx
@@ -40,11 +40,11 @@ function CommandDialog({
 }) {
   return (
     <Dialog {...props}>
-      <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
-      </DialogHeader>
       <DialogContent className="overflow-hidden p-0">
+        <DialogHeader className="sr-only">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
         <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/apps/pwa/api/promotions/proxy.js
+++ b/apps/pwa/api/promotions/proxy.js
@@ -1,0 +1,93 @@
+const PROMO_PROXY_SOURCES = Object.freeze({
+  "atcl-rss": {
+    url: "https://www.atcllazio.it/feed/",
+    defaultContentType: "application/rss+xml; charset=utf-8",
+  },
+  "rossellini-rss": {
+    url: "https://www.spaziorossellini.it/category/slide-evidenza/feed/",
+    defaultContentType: "application/rss+xml; charset=utf-8",
+  },
+  "atcl-rest": {
+    url: "https://www.atcllazio.it/wp-json/wp/v2/posts?categories=421&per_page=6&_fields=title,link,date,excerpt",
+    defaultContentType: "application/json; charset=utf-8",
+  },
+  "rossellini-rest": {
+    url: "https://www.spaziorossellini.it/wp-json/wp/v2/posts?categories=21&per_page=6&_fields=title,link,date,excerpt",
+    defaultContentType: "application/json; charset=utf-8",
+  },
+});
+
+const PROMO_PROXY_MAX_AGE_SECONDS = 300;
+const PROMO_PROXY_TIMEOUT_MS = 8000;
+
+function sendJson(res, statusCode, payload) {
+  res.status(statusCode).setHeader("Content-Type", "application/json; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store");
+  res.send(JSON.stringify(payload));
+}
+
+export const config = {
+  runtime: "nodejs",
+};
+
+export default async function handler(req, res) {
+  const method = (req.method || "GET").toUpperCase();
+  if (method !== "GET") {
+    sendJson(res, 405, { ok: false, error: "Method Not Allowed" });
+    return;
+  }
+
+  const source = typeof req.query?.source === "string" ? req.query.source.trim() : "";
+  const sourceConfig = PROMO_PROXY_SOURCES[source];
+  if (!sourceConfig) {
+    sendJson(res, 400, {
+      ok: false,
+      error: "Invalid promo source",
+      allowedSources: Object.keys(PROMO_PROXY_SOURCES),
+    });
+    return;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), PROMO_PROXY_TIMEOUT_MS);
+
+  try {
+    const upstream = await fetch(sourceConfig.url, {
+      method: "GET",
+      redirect: "follow",
+      signal: controller.signal,
+      headers: {
+        accept: "*/*",
+        "user-agent": "Turni-di-Palco/1.0 (+https://turni-di-palco.vercel.app)",
+      },
+    });
+
+    if (!upstream.ok) {
+      sendJson(res, 502, {
+        ok: false,
+        error: "Upstream request failed",
+        source,
+        upstreamStatus: upstream.status,
+      });
+      return;
+    }
+
+    const payload = Buffer.from(await upstream.arrayBuffer());
+    const contentType = upstream.headers.get("content-type") || sourceConfig.defaultContentType;
+
+    res.status(200);
+    res.setHeader("Content-Type", contentType);
+    res.setHeader("Cache-Control", `public, max-age=${PROMO_PROXY_MAX_AGE_SECONDS}`);
+    res.setHeader("X-TDP-Promo-Source", source);
+    res.send(payload);
+  } catch (error) {
+    sendJson(res, 502, {
+      ok: false,
+      error: "Promo proxy unavailable",
+      source,
+      detail: error instanceof Error ? error.message : "Unknown error",
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}


### PR DESCRIPTION
## Summary
- move the hidden Radix dialog title and description inside `DialogContent` in the mobile command dialog
- add a Vercel serverless endpoint for `/api/promotions/proxy` to match local preview behavior

## Verification
- `node --check apps/pwa/api/promotions/proxy.js`
- `npm.cmd --workspace apps/mobile exec eslint src/components/ui/command.tsx`

## Notes
- full mobile `lint` and `typecheck` are currently blocked by pre-existing JSX errors in `apps/mobile/src/components/screens/Home.tsx`
