### PR TITLE
Add root Vercel promo proxy

### DIFF
--- a/api/promotions/proxy.js
+++ b/api/promotions/proxy.js
@@ -1,0 +1,1 @@
+export { config, default } from '../../apps/pwa/api/promotions/proxy.js';

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "npm ci",
+  "buildCommand": "npm run build:mobile && npm run build:pwa",
+  "outputDirectory": "apps/pwa/dist"
+}


### PR DESCRIPTION
## Summary
- expose the promotions proxy from the repo root so Vercel detects the serverless route in monorepo deployments
- add a root vercel.json that builds from the repo root and publishes apps/pwa/dist

## Testing
- npm.cmd run build:mobile
- npm.cmd run build:pwa