### PR TITLE
Update GitHub actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
         shell: bash
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22.14.0
           cache: npm
@@ -56,10 +56,10 @@ jobs:
       checks: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22.14.0
           cache: npm

--- a/.github/workflows/cleanup-events.yml
+++ b/.github/workflows/cleanup-events.yml
@@ -21,10 +21,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -22,10 +22,10 @@ jobs:
         shell: bash
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22.14.0
           cache: npm
@@ -37,7 +37,7 @@ jobs:
         run: npm run build:mobile
 
       - name: Upload mobile artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: mobile-build
           path: apps/pwa/public/mobile

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,10 +31,10 @@ jobs:
             lockfile: apps/mobile/package-lock.json
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22.14.0
           cache: npm
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload npm audit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: npm-audit-report-${{ matrix.name }}
           path: ${{ matrix.path }}/audit-report.json

--- a/.github/workflows/sync-deploy-branches.yml
+++ b/.github/workflows/sync-deploy-branches.yml
@@ -24,7 +24,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -370,7 +370,7 @@ jobs:
       DEPLOY_SHA: ${{ needs.sync-deploy-preview-branches.outputs.deploy_sha }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate Railway token
         run: |
@@ -486,7 +486,7 @@ jobs:
       deployments: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create GitHub Deployment - Turni-di-Palco
         uses: chrnorm/deployment-action@v2
@@ -548,7 +548,7 @@ jobs:
       deployments: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create GitHub Deployment - Maxwell-AI-Support
         uses: chrnorm/deployment-action@v2
@@ -611,7 +611,7 @@ jobs:
       deployments: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create GitHub Deployment - Turni-di-Palco-Control-Plane
         uses: chrnorm/deployment-action@v2

--- a/.github/workflows/update-server-repository.yml
+++ b/.github/workflows/update-server-repository.yml
@@ -20,7 +20,7 @@ jobs:
                 shell: powershell
         steps:
             - name: Checkout repository (main + submodules)
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                 fetch-depth: 0
                 submodules: recursive
@@ -42,14 +42,14 @@ jobs:
                 shell: powershell
         steps:
             - name: Checkout repository (main + submodules)
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                 fetch-depth: 0
                 submodules: recursive
                 persist-credentials: true
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                 node-version: 22.14.0
                 cache: npm


### PR DESCRIPTION
## Summary
- update GitHub-maintained actions to Node 24-compatible majors
- switch checkout to v5, setup-node to v5, and upload-artifact to v5 where used
- keep the existing Netlify sync workflow changes and align workflow action versions

## Testing
- git diff --check -- .github/workflows/ci.yml .github/workflows/cleanup-events.yml .github/workflows/mobile-build.yml .github/workflows/security.yml .github/workflows/sync-deploy-branches.yml .github/workflows/update-server-repository.yml

## Notes
- the self-hosted Windows runner used by update-server-repository must be on runner v2.327.1 or newer for checkout@v5/setup-node@v5