### PR TITLE
Fix bottom navigation safe area inset handling on mobile

### DIFF
--- a/apps/mobile/src/components/BottomNav.tsx
+++ b/apps/mobile/src/components/BottomNav.tsx
@@ -33,9 +33,9 @@ export function BottomNav({ activeTab, onTabChange, enabledTabs }: BottomNavProp
   } : undefined;
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 w-full app-nav z-50">
+    <nav className="fixed left-0 right-0 w-full app-nav z-50" style={{ bottom: 'env(safe-area-inset-bottom, 0px)' }}>
       <div className="bg-[#0f0d0e]/90 backdrop-blur-2xl border-t border-white/[0.05]">
-        <div className="relative app-content flex items-stretch justify-around px-2 pt-1 pb-[calc(env(safe-area-inset-bottom,_0px)+4px)] min-h-[54px]">
+        <div className="relative app-content flex items-stretch justify-around px-2 pt-1 pb-1 min-h-[54px]">
 
           {indicatorStyle && (
             <div


### PR DESCRIPTION
## Summary
Improved the bottom navigation component's handling of safe area insets on mobile devices by moving the inset calculation from padding to the nav element's positioning.

## Key Changes
- Moved `env(safe-area-inset-bottom)` from the inner div's padding to the nav element's `bottom` style property
- Removed the complex `pb-[calc(env(safe-area-inset-bottom,_0px)+4px)]` padding calculation and replaced it with simple `pb-1`
- This ensures the navigation bar respects device safe areas (notches, home indicators) more reliably

## Implementation Details
The change simplifies the safe area handling by applying it at the container level rather than through padding calculations. This approach is more semantically correct and provides better compatibility with devices that have notches or home indicators at the bottom of the screen.

https://claude.ai/code/session_01BrDhgcLnnB1CPBiyeg7nsA