### PR TITLE
Rename followed events handling to event planning and add realtime migration for planned_participations

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -550,7 +550,7 @@ const MOBILE_WATCHDOG_TIMEOUTS = {
   refreshLeaderboard: 15000,
   markBadgesSeen: 12000,
   restoreSession: 15000,
-  refreshFollowedEvents: 12000,
+  refreshEventPlanning: 12000,
   followEvent: 10000,
   unfollowEvent: 10000,
   loadCatalog: 18000,
@@ -2836,7 +2836,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     };
   }, [flushMirroredClientLogsToServer]);
 
-  const refreshFollowedEvents = useCallback(
+  const refreshEventPlanning = useCallback(
     async (catalogEvents: GameEvent[]) => {
       if (!isSupabaseConfigured || !supabase || !authUserId) {
         setEventPlansLoading(false);
@@ -2902,10 +2902,10 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           }
         },
         {
-          operation: 'refreshFollowedEvents',
-          timeoutMs: MOBILE_WATCHDOG_TIMEOUTS.refreshFollowedEvents,
-          title: 'Eventi seguiti lenti',
-          message: 'Il refresh degli eventi seguiti sta impiegando troppo tempo.',
+          operation: 'refreshEventPlanning',
+          timeoutMs: MOBILE_WATCHDOG_TIMEOUTS.refreshEventPlanning,
+          title: 'Pianificazione eventi lenta',
+          message: 'Il refresh della pianificazione eventi sta impiegando troppo tempo.',
         }
       );
     },
@@ -3320,8 +3320,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (!isSupabaseConfigured || !supabase || !authUserId) return;
-    refreshFollowedEvents(catalog.events);
-  }, [authUserId, catalog.events, refreshFollowedEvents]);
+    refreshEventPlanning(catalog.events);
+  }, [authUserId, catalog.events, refreshEventPlanning]);
 
   useEffect(() => {
     if (!isSupabaseConfigured || !supabase) return;
@@ -3394,7 +3394,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             events: nextEvents,
             activities: nextActivities,
           });
-          refreshFollowedEvents(nextEvents);
+          refreshEventPlanning(nextEvents);
         },
         {
           operation: 'loadCatalog',
@@ -3665,9 +3665,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       )
       .on(
         'postgres_changes',
-        { event: '*', schema: 'public', table: 'followed_events', filter: `user_id=eq.${authUserId}` },
+        { event: '*', schema: 'public', table: 'planned_participations', filter: `user_id=eq.${authUserId}` },
         () => {
-          refreshFollowedEvents(catalog.events);
+          refreshEventPlanning(catalog.events);
         }
       )
       .on(
@@ -3701,7 +3701,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     catalog.events,
     refreshBadges,
     refreshActivitySlotsStatus,
-    refreshFollowedEvents,
+    refreshEventPlanning,
     refreshFeatureFlags,
     refreshShopCatalog,
     refreshTheatreReputation,

--- a/supabase/migrations/20260316120000_planned_participations_realtime.sql
+++ b/supabase/migrations/20260316120000_planned_participations_realtime.sql
@@ -1,0 +1,19 @@
+do $$
+begin
+  if to_regclass('public.planned_participations') is null then
+    return;
+  end if;
+
+  if exists (select 1 from pg_publication where pubname = 'supabase_realtime') then
+    if not exists (
+      select 1
+      from pg_publication_tables
+      where pubname = 'supabase_realtime'
+        and schemaname = 'public'
+        and tablename = 'planned_participations'
+    ) then
+      alter publication supabase_realtime add table public.planned_participations;
+    end if;
+  end if;
+end;
+$$;


### PR DESCRIPTION
### Motivation
- Align naming from a "followed events" concept to a broader "event planning" domain and reflect the underlying DB table rename to `planned_participations` for realtime sync.
- Ensure Supabase realtime publication includes the `planned_participations` table so mobile clients receive change events.

### Description
- Renamed the `refreshFollowedEvents` callback to `refreshEventPlanning` and updated its watchdog operation key from `refreshFollowedEvents` to `refreshEventPlanning` and associated timeout reference `MOBILE_WATCHDOG_TIMEOUTS.refreshEventPlanning`.
- Updated user-facing watchdog titles/messages to reference planning (`Pianificazione eventi lenta` / `Il refresh della pianificazione eventi...`).
- Replaced all calls/usages of `refreshFollowedEvents` with `refreshEventPlanning`, including `useEffect` invocations and the realtime subscription change handler.
- Changed the realtime subscription to listen to the `planned_participations` table instead of `followed_events` and added a migration `supabase/migrations/20260316120000_planned_participations_realtime.sql` to add `public.planned_participations` to the `supabase_realtime` publication when present.

### Testing
- Ran TypeScript compile (`yarn build`), which completed successfully.
- Ran the project test suite (`yarn test`), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7e53a3838832681450bf157b3c49b)