### PR TITLE
feat(db): add rename migration followed_events → planned_participations

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3665,7 +3665,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       )
       .on(
         'postgres_changes',
-        { event: '*', schema: 'public', table: 'followed_events', filter: `user_id=eq.${authUserId}` },
+        { event: '*', schema: 'public', table: 'planned_participations', filter: `user_id=eq.${authUserId}` },
         () => {
           refreshFollowedEvents(catalog.events);
         }

--- a/supabase/migrations/20260316113430_rename_followed_events.sql
+++ b/supabase/migrations/20260316113430_rename_followed_events.sql
@@ -1,0 +1,117 @@
+-- Issue #330 follow-up: rename followed_events → planned_participations.
+-- Idempotent: only acts when followed_events exists and planned_participations does not.
+
+do $$
+begin
+  -- Case 1: followed_events exists, planned_participations does not → rename + backfill schema.
+  if exists (
+    select 1 from information_schema.tables
+    where table_schema = 'public' and table_name = 'followed_events'
+  ) and not exists (
+    select 1 from information_schema.tables
+    where table_schema = 'public' and table_name = 'planned_participations'
+  ) then
+
+    alter table public.followed_events rename to planned_participations;
+
+    -- Add columns introduced by the richer planning schema if they are missing.
+    if not exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public' and table_name = 'planned_participations' and column_name = 'id'
+    ) then
+      alter table public.planned_participations
+        add column id uuid not null default gen_random_uuid();
+    end if;
+
+    if not exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public' and table_name = 'planned_participations' and column_name = 'role_id'
+    ) then
+      alter table public.planned_participations
+        add column role_id text references public.roles(id) on update cascade on delete restrict;
+    end if;
+
+    if not exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public' and table_name = 'planned_participations' and column_name = 'status'
+    ) then
+      -- Ensure the enum type exists before using it.
+      if not exists (select 1 from pg_type where typname = 'participation_status') then
+        create type public.participation_status as enum ('planned', 'confirmed', 'cancelled');
+      end if;
+      alter table public.planned_participations
+        add column status public.participation_status not null default 'planned';
+    end if;
+
+    if not exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public' and table_name = 'planned_participations' and column_name = 'notes'
+    ) then
+      alter table public.planned_participations add column notes text;
+    end if;
+
+    if not exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public' and table_name = 'planned_participations' and column_name = 'created_at'
+    ) then
+      alter table public.planned_participations
+        add column created_at timestamptz not null default now();
+    end if;
+
+    if not exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public' and table_name = 'planned_participations' and column_name = 'updated_at'
+    ) then
+      alter table public.planned_participations
+        add column updated_at timestamptz not null default now();
+    end if;
+
+    -- Rename legacy RLS policies to match the new table name.
+    if exists (
+      select 1 from pg_policies
+      where schemaname = 'public' and tablename = 'planned_participations'
+        and policyname = 'followed events select own'
+    ) then
+      alter policy "followed events select own"
+        on public.planned_participations
+        rename to "planned participations select own";
+    end if;
+
+    if exists (
+      select 1 from pg_policies
+      where schemaname = 'public' and tablename = 'planned_participations'
+        and policyname = 'followed events insert own'
+    ) then
+      alter policy "followed events insert own"
+        on public.planned_participations
+        rename to "planned participations insert own";
+    end if;
+
+    if exists (
+      select 1 from pg_policies
+      where schemaname = 'public' and tablename = 'planned_participations'
+        and policyname = 'followed events delete own'
+    ) then
+      alter policy "followed events delete own"
+        on public.planned_participations
+        rename to "planned participations delete own";
+    end if;
+
+    raise notice 'followed_events renamed to planned_participations';
+
+  -- Case 2: both tables exist → drop the legacy one (data already in planned_participations).
+  elsif exists (
+    select 1 from information_schema.tables
+    where table_schema = 'public' and table_name = 'followed_events'
+  ) and exists (
+    select 1 from information_schema.tables
+    where table_schema = 'public' and table_name = 'planned_participations'
+  ) then
+    drop table public.followed_events;
+    raise notice 'followed_events dropped (planned_participations already existed)';
+
+  else
+    raise notice 'planned_participations already exists, nothing to do';
+  end if;
+end;
+$$;

--- a/supabase/migrations/20260316113431_planned_participations_realtime.sql
+++ b/supabase/migrations/20260316113431_planned_participations_realtime.sql
@@ -1,0 +1,17 @@
+-- PR #373: add planned_participations to supabase_realtime publication.
+-- Depends on planned_participations existing (created/renamed by 20260316113430).
+
+do $$
+begin
+  if exists (select 1 from pg_publication where pubname = 'supabase_realtime') then
+    if not exists (
+      select 1 from pg_publication_tables
+      where pubname = 'supabase_realtime'
+        and schemaname = 'public'
+        and tablename = 'planned_participations'
+    ) then
+      alter publication supabase_realtime add table public.planned_participations;
+    end if;
+  end if;
+end;
+$$;


### PR DESCRIPTION
- 20260316113430: idempotent migration that renames followed_events to
  planned_participations (backfills missing columns when renaming) or
  drops the legacy table when planned_participations already exists
- 20260316113431: adds planned_participations to supabase_realtime
  publication so mobile clients receive live updates
- store.tsx: update realtime subscription to listen on
  planned_participations instead of the old followed_events table

Fixes realtime not firing for planned_participations clients (#330).