### PR TITLE
fix(mobile): align event planning realtime with rename migration

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -13,8 +13,8 @@
   
 
 ## Events feed and follow
-- The events list can be pulled from Supabase; Home shows followed events, while Turni ATCL shows the full catalog with follow/unfollow.
-- Followed events are stored in `followed_events` and refreshed via realtime subscriptions.
+- The events list can be pulled from Supabase; Home shows planned events, while Turni ATCL shows the full catalog with follow/unfollow.
+- Event planning is stored in `planned_participations` and refreshed via realtime subscriptions.
 
 ## Event details
 - The event detail screen can export a local `.ics` calendar file using `event_date` + `event_time` from the feed.

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -550,7 +550,7 @@ const MOBILE_WATCHDOG_TIMEOUTS = {
   refreshLeaderboard: 15000,
   markBadgesSeen: 12000,
   restoreSession: 15000,
-  refreshFollowedEvents: 12000,
+  refreshEventPlanning: 12000,
   followEvent: 10000,
   unfollowEvent: 10000,
   loadCatalog: 18000,
@@ -2836,7 +2836,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     };
   }, [flushMirroredClientLogsToServer]);
 
-  const refreshFollowedEvents = useCallback(
+  const refreshEventPlanning = useCallback(
     async (catalogEvents: GameEvent[]) => {
       if (!isSupabaseConfigured || !supabase || !authUserId) {
         setEventPlansLoading(false);
@@ -2902,10 +2902,10 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           }
         },
         {
-          operation: 'refreshFollowedEvents',
-          timeoutMs: MOBILE_WATCHDOG_TIMEOUTS.refreshFollowedEvents,
-          title: 'Eventi seguiti lenti',
-          message: 'Il refresh degli eventi seguiti sta impiegando troppo tempo.',
+          operation: 'refreshEventPlanning',
+          timeoutMs: MOBILE_WATCHDOG_TIMEOUTS.refreshEventPlanning,
+          title: 'Pianificazione eventi lenta',
+          message: 'Il refresh della pianificazione eventi sta impiegando troppo tempo.',
         }
       );
     },
@@ -3320,8 +3320,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (!isSupabaseConfigured || !supabase || !authUserId) return;
-    refreshFollowedEvents(catalog.events);
-  }, [authUserId, catalog.events, refreshFollowedEvents]);
+    refreshEventPlanning(catalog.events);
+  }, [authUserId, catalog.events, refreshEventPlanning]);
 
   useEffect(() => {
     if (!isSupabaseConfigured || !supabase) return;
@@ -3394,7 +3394,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             events: nextEvents,
             activities: nextActivities,
           });
-          refreshFollowedEvents(nextEvents);
+          refreshEventPlanning(nextEvents);
         },
         {
           operation: 'loadCatalog',
@@ -3667,7 +3667,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         'postgres_changes',
         { event: '*', schema: 'public', table: 'planned_participations', filter: `user_id=eq.${authUserId}` },
         () => {
-          refreshFollowedEvents(catalog.events);
+          refreshEventPlanning(catalog.events);
         }
       )
       .on(
@@ -3701,7 +3701,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     catalog.events,
     refreshBadges,
     refreshActivitySlotsStatus,
-    refreshFollowedEvents,
+    refreshEventPlanning,
     refreshFeatureFlags,
     refreshShopCatalog,
     refreshTheatreReputation,

--- a/supabase/migrations/20260316113430_rename_followed_events.sql
+++ b/supabase/migrations/20260316113430_rename_followed_events.sql
@@ -1,9 +1,9 @@
--- Issue #330 follow-up: rename followed_events → planned_participations.
--- Idempotent: only acts when followed_events exists and planned_participations does not.
+-- Backfill older environments that still have the legacy followed_events table.
+-- Idempotent: renames when only followed_events exists, or drops the legacy table
+-- once planned_participations is already present.
 
 do $$
 begin
-  -- Case 1: followed_events exists, planned_participations does not → rename + backfill schema.
   if exists (
     select 1 from information_schema.tables
     where table_schema = 'public' and table_name = 'followed_events'
@@ -11,10 +11,8 @@ begin
     select 1 from information_schema.tables
     where table_schema = 'public' and table_name = 'planned_participations'
   ) then
-
     alter table public.followed_events rename to planned_participations;
 
-    -- Add columns introduced by the richer planning schema if they are missing.
     if not exists (
       select 1 from information_schema.columns
       where table_schema = 'public' and table_name = 'planned_participations' and column_name = 'id'
@@ -35,7 +33,6 @@ begin
       select 1 from information_schema.columns
       where table_schema = 'public' and table_name = 'planned_participations' and column_name = 'status'
     ) then
-      -- Ensure the enum type exists before using it.
       if not exists (select 1 from pg_type where typname = 'participation_status') then
         create type public.participation_status as enum ('planned', 'confirmed', 'cancelled');
       end if;
@@ -66,7 +63,6 @@ begin
         add column updated_at timestamptz not null default now();
     end if;
 
-    -- Rename legacy RLS policies to match the new table name.
     if exists (
       select 1 from pg_policies
       where schemaname = 'public' and tablename = 'planned_participations'
@@ -98,8 +94,6 @@ begin
     end if;
 
     raise notice 'followed_events renamed to planned_participations';
-
-  -- Case 2: both tables exist → drop the legacy one (data already in planned_participations).
   elsif exists (
     select 1 from information_schema.tables
     where table_schema = 'public' and table_name = 'followed_events'
@@ -109,7 +103,6 @@ begin
   ) then
     drop table public.followed_events;
     raise notice 'followed_events dropped (planned_participations already existed)';
-
   else
     raise notice 'planned_participations already exists, nothing to do';
   end if;

--- a/supabase/migrations/20260316113431_planned_participations_realtime.sql
+++ b/supabase/migrations/20260316113431_planned_participations_realtime.sql
@@ -1,11 +1,16 @@
--- PR #373: add planned_participations to supabase_realtime publication.
--- Depends on planned_participations existing (created/renamed by 20260316113430).
+-- Ensure planned_participations is replicated over Supabase Realtime after the
+-- rename/backfill migration has run on older environments.
 
 do $$
 begin
+  if to_regclass('public.planned_participations') is null then
+    return;
+  end if;
+
   if exists (select 1 from pg_publication where pubname = 'supabase_realtime') then
     if not exists (
-      select 1 from pg_publication_tables
+      select 1
+      from pg_publication_tables
       where pubname = 'supabase_realtime'
         and schemaname = 'public'
         and tablename = 'planned_participations'


### PR DESCRIPTION
## Summary
- keep the mobile event planning refresh aligned with planned_participations
- preserve the idempotent rename migration from ollowed_events
- harden the realtime publication migration and update the mobile README

## Verification
- npm --workspace apps/mobile run build
- npm --workspace apps/mobile run typecheck *(currently fails on pre-existing vitest type resolution in mobile tests)*