### PR TITLE
Potential fix for code scanning alert no. 20: Incomplete string escaping or encoding

### DIFF
--- a/apps/mobile/src/components/screens/EventDetails.tsx
+++ b/apps/mobile/src/components/screens/EventDetails.tsx
@@ -336,7 +336,7 @@ function parseEventDateTime(dateValue: string, timeValue: string) {
 }
 
 function sanitizeIcsText(value: string) {
-  return value.replace(/([,;])/g, '\\$1').replace(/\r?\n/g, '\\n');
+  return value.replace(/\\/g, '\\\\').replace(/([,;])/g, '\\$1').replace(/\r?\n/g, '\\n');
 }
 
 const MONTHS: Record<string, number> = {


### PR DESCRIPTION
Potential fix for [https://github.com/ATCL-Lazio/Turni-di-Palco/security/code-scanning/20](https://github.com/ATCL-Lazio/Turni-di-Palco/security/code-scanning/20)

In general, to correctly escape text for ICS properties, you must first escape existing backslashes (`\` → `\\`), and then escape commas and semicolons (`,` and `;`) and line breaks (`\n`/`\r\n`) according to RFC 5545. Doing this in the wrong order leads to double-meaning sequences, because backslash is the escape introducer.

The single best fix here is to update `sanitizeIcsText` so that it:
1. First replaces all backslashes with double backslashes using a global regular expression.
2. Then replaces all commas and semicolons with backslash-escaped versions.
3. Finally replaces CRLF/LF newlines with the literal sequence `\n`.

This retains the function’s intended behavior while making the escaping complete and order-safe. No other code needs to change, and no new imports are required.

Concretely, in `apps/mobile/src/components/screens/EventDetails.tsx`, replace the body of `sanitizeIcsText` (line 339) with a version that first escapes backslashes, then commas/semicolons, then newlines.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
