### PR TITLE
Potential fix for code scanning alert no. 3: Clear text storage of sensitive information

### DIFF
--- a/apps/mobile/src/hooks/useNavigation.ts
+++ b/apps/mobile/src/hooks/useNavigation.ts
@@ -130,7 +130,7 @@ export function useNavigation(initialEvents: { id: string }[], options?: UseNavi
 
     const [currentScreen, setCurrentScreen] = useState<Screen>(() => persistedNavState?.screen ?? 'welcome');
     const [legalReturnScreen, setLegalReturnScreen] = useState<LegalReturnScreen>(() => persistedNavState?.legalReturnScreen ?? 'welcome');
-    const [isPasswordRecovery, setIsPasswordRecovery] = useState(() => persistedNavState?.isPasswordRecovery ?? false);
+    const [isPasswordRecovery, setIsPasswordRecovery] = useState(false);
     const [activeTab, setActiveTab] = useState<Tab>(() => persistedNavState?.activeTab ?? 'home');
     const [scannedEventId, setScannedEventId] = useState<string>(() => persistedNavState?.scannedEventId ?? initialEvents[0]?.id ?? '');
     const [selectedActivityId, setSelectedActivityId] = useState<string>(() => persistedNavState?.selectedActivityId ?? '');
@@ -168,7 +168,6 @@ export function useNavigation(initialEvents: { id: string }[], options?: UseNavi
             screen: persistedScreen,
             activeTab: persistedTab,
             legalReturnScreen,
-            isPasswordRecovery,
             scannedEventId,
             selectedActivityId,
         });


### PR DESCRIPTION
Potential fix for [https://github.com/ATCL-Lazio/Turni-di-Palco/security/code-scanning/3](https://github.com/ATCL-Lazio/Turni-di-Palco/security/code-scanning/3)

In general, to fix clear-text storage issues, you either stop persisting the sensitive data, or you encrypt it before writing and decrypt it when reading. Since `isPasswordRecovery` is just a boolean flag used for UI flow and not critical long-term state, the simplest and safest approach is to exclude it from the persisted navigation state completely. This preserves all existing behavior except that the password-recovery flag will reset when the app reloads, which is a reasonable security/UX trade-off.

Concretely in `apps/mobile/src/hooks/useNavigation.ts`:

1. **Stop reading `isPasswordRecovery` from persisted state**: change the initial state in the `useState` hook so it no longer uses `persistedNavState?.isPasswordRecovery` and instead always initializes to `false`.
2. **Stop writing `isPasswordRecovery` into persisted state**: remove `isPasswordRecovery` from the object passed to `writeNavState` in the `useEffect` that syncs state to localStorage.
3. **Optionally** (for type safety), if `PersistedNavState` currently includes `isPasswordRecovery`, it should be updated in `../types/navigation` to remove that field, but this file is outside the snippet we’re allowed to edit, so we will keep the type reference and simply not supply the field at runtime—TypeScript will compile away and runtime behavior is fine in JS. The existing `readNavState` already treats `parsed.isPasswordRecovery` as optional and coerces with `Boolean(...)`, so if it’s missing, it will just be `false`.

These changes are all in the shown file; no new imports or helper methods are needed, and no encryption library is required because we’re avoiding persistence of the sensitive field altogether.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
