### PR TITLE
fix(nav): persist isPasswordRecovery in writeNavState

### DIFF
--- a/apps/mobile/src/hooks/useNavigation.ts
+++ b/apps/mobile/src/hooks/useNavigation.ts
@@ -168,10 +168,11 @@ export function useNavigation(initialEvents: { id: string }[], options?: UseNavi
             screen: persistedScreen,
             activeTab: persistedTab,
             legalReturnScreen,
+            isPasswordRecovery,
             scannedEventId,
             selectedActivityId,
         });
-    }, [activeTab, currentScreen, isScreenEnabled, isTabEnabled, legalReturnScreen, scannedEventId, selectedActivityId]);
+    }, [activeTab, currentScreen, isPasswordRecovery, isScreenEnabled, isTabEnabled, legalReturnScreen, scannedEventId, selectedActivityId]);
 
     const handleTabChange = (tab: Tab) => {
         const nextTab = isTabEnabled && !isTabEnabled(tab) ? resolveFallbackTab(isTabEnabled) : tab;


### PR DESCRIPTION
## Summary

- `writeNavState` non includeva `isPasswordRecovery` nell'oggetto passato, causando un errore TypeScript preesistente (`TS2345`: tipo non assegnabile a `PersistedNavState`)
- Ogni scrittura su localStorage azzerava silenziosamente il flag di password recovery
- Aggiunto `isPasswordRecovery` nell'oggetto e ripristinato nel deps array dell'`useEffect`

## Test plan

- [ ] Verificare che `tsc --noEmit` passi senza errori su `useNavigation.ts`
- [ ] Testare il flusso di password recovery: avviare recovery, navigare, verificare che il flag venga correttamente ripristinato da localStorage al reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)