### PR TITLE
ci: exclude English docs from IT LanguageTool, add EN comparison check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,25 @@ jobs:
         run: node tools/extract-ui-copy.js
 
       - name: Run Italian spelling and grammar check
+        id: italian-lt
         uses: reviewdog/action-languagetool@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-check
           language: it
           patterns: "**/*.md **/*.txt **/*.html .temp/ci/ui-copy.txt"
+          ignore_patterns: "AGENTS.md CLAUDE.md"
           disabled_categories: "CASING,PUNCTUATION"
           level: error
+
+      - name: Run English comparison check (post Italian failure)
+        if: always() && steps.italian-lt.outcome == 'failure'
+        uses: reviewdog/action-languagetool@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-check
+          language: en-US
+          patterns: "AGENTS.md CLAUDE.md"
+          disabled_categories: "CASING,PUNCTUATION"
+          level: error
+          fail_on_error: false


### PR DESCRIPTION
## Summary

- `AGENTS.md` e `CLAUDE.md` sono scritti in inglese → esclusi dal check italiano tramite `ignore_patterns`, eliminando ~4849 falsi positivi `MORFOLOGIK_RULE_IT_IT`
- Aggiunto step **English LanguageTool (en-US)** che si attiva **solo quando il check italiano fallisce**, scansionando esclusivamente quei file
- Il check EN è `fail_on_error: false` — puramente informativo, non blocca la CI

## Comportamento atteso

| Scenario | IT check | EN check |
|---|---|---|
| Solo errori nei file inglesi | ✅ pass | non gira |
| Errori in file italiani | ❌ fail | ✅ gira (confronto) |
| Errori in entrambi | ❌ fail | ✅ gira (confronto) |

## Test plan
- [ ] Verificare che `italian-proofreading` passi senza segnalazioni su `AGENTS.md`/`CLAUDE.md`
- [ ] Introdurre un errore italiano in un `.md` e verificare che il check EN compaia come step di confronto

🤖 Generated with [Claude Code](https://claude.com/claude-code)