### PR TITLE
Fix navbar alignment: position nav at bottom-0 with internal safe area padding

### DIFF
--- a/apps/mobile/src/components/BottomNav.tsx
+++ b/apps/mobile/src/components/BottomNav.tsx
@@ -33,9 +33,8 @@ export function BottomNav({ activeTab, onTabChange, enabledTabs }: BottomNavProp
   } : undefined;
 
   return (
-    <nav className="fixed left-0 right-0 w-full app-nav z-50" style={{ bottom: 'env(safe-area-inset-bottom, 0px)' }}>
-      <div className="bg-[#0f0d0e]/90 backdrop-blur-2xl border-t border-white/[0.05]">
-        <div className="relative app-content flex items-stretch justify-around px-2 pt-1 pb-1 min-h-[54px]">
+    <nav className="fixed bottom-0 left-0 right-0 w-full z-50 bg-[#0f0d0e]/90 backdrop-blur-2xl border-t border-white/[0.05]">
+      <div className="relative app-content flex items-stretch justify-around px-2 pt-1 min-h-[54px]" style={{ paddingBottom: 'calc(4px + env(safe-area-inset-bottom, 0px))' }}>
 
           {indicatorStyle && (
             <div
@@ -54,7 +53,6 @@ export function BottomNav({ activeTab, onTabChange, enabledTabs }: BottomNavProp
               onPress={onTabChange}
             />
           ))}
-        </div>
       </div>
     </nav>
   );


### PR DESCRIPTION
The navbar was using both `bottom: env(safe-area-inset-bottom)` (inline style)
and `padding-bottom: var(--safe-area-inset-bottom)` (.app-nav class), causing
the dark background to end above the safe area zone. Page content was visible
in the transparent gap between the nav background and the viewport bottom.

Fix: set nav to `bottom: 0` and move bg/blur/border onto the `<nav>` element
so the dark background covers the full bottom including the safe area. Tab
buttons are kept above the safe area via `padding-bottom: calc(4px + env(safe-area-inset-bottom))`.

https://claude.ai/code/session_013wNs3uVzK3Y63HyksKaU7c