### PR TITLE
fix(mobile): clip slide animations and unify navbar transition direction

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -265,11 +265,8 @@ export function AppShell() {
     const previousIndex = tabOrder.indexOf(previousTabRef.current);
     let animation: string;
     if (currentIndex === -1 || previousIndex === -1) animation = 'tab-fade-in';
-    else if (currentIndex > previousIndex) {
-      animation = (nav.activeTab === 'activities' || nav.activeTab === 'profile') ? 'tab-slide-up' : 'tab-slide-right';
-    } else {
-      animation = (previousTabRef.current === 'activities' || previousTabRef.current === 'profile') ? 'tab-slide-down' : 'tab-slide-left';
-    }
+    else if (currentIndex > previousIndex) animation = 'tab-slide-right';
+    else animation = 'tab-slide-left';
     setScreenAnimation(animation);
     setScreenAnimationKey(v => v + 1);
     previousTabRef.current = nav.activeTab;

--- a/apps/mobile/src/components/ui/ScreenTransition.tsx
+++ b/apps/mobile/src/components/ui/ScreenTransition.tsx
@@ -36,9 +36,9 @@ export function ScreenTransition({
   }, [animationClass, animationKey]);
 
   return (
-    <div 
+    <div
       ref={containerRef}
-      className="w-full h-full"
+      className="w-full h-full overflow-hidden"
       onAnimationEnd={(event) => {
         if (event.target !== containerRef.current) return;
         onAnimationEnd?.();


### PR DESCRIPTION
- Add overflow-hidden to ScreenTransition to prevent animated content
  from rendering outside the viewport, which caused the background
  gradient to bleed through during tab transitions
- Simplify tab animation logic to always use directional left/right
  slides based on tab order index, removing the inconsistent mixed
  horizontal/vertical behaviour that applied slide-up/down only for
  the activities and profile tabs