### PR TITLE
fix(readme): converti markdown-in-HTML in tag HTML puri per Jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,8 @@
 <div align="center">
-
 <img src="apps/pwa/public/icons/pwa-192.png" alt="Turni di Palco" width="120">
-
-# Turni di Palco
-
-**Il teatro come percorso. La cultura come gioco.**
-
-
-[**Accedi all'applicazione**](https://turni-di-palco.vercel.app)
-
+<h1>Turni di Palco</h1>
+<p><strong>Il teatro come percorso. La cultura come gioco.</strong></p>
+<p><a href="https://turni-di-palco.vercel.app"><strong>→ Accedi all'applicazione</strong></a></p>
 </div>
 
 ---
@@ -47,13 +41,13 @@ Turni di Palco nasce dall'esigenza di rendere il teatro un'esperienza continuati
 - trasforma ogni visita a teatro in un passo concreto di un percorso personale;
 - favorisce il legame tra il pubblico e le realtà teatrali del territorio.
 
-<div align="center">
-
 ## Screenshot
+
+<div align="center">
 <img src="assets/images/Screenshot 2026-03-17 120648.png" alt="Screenshot dell'applicazione" width="150" style="padding: 20px">
 <img src="assets/images/Screenshot 2026-03-17 121756.png" alt="Screenshot dell'applicazione" width="150" style="padding: 20px">
-<img src="assets\images\Screenshot 2026-03-17 122258.png" alt="Screenshot dell'applicazione" width="150" style="padding: 20px">
-<img src="assets\images\Screenshot 2026-03-17 122845.png" alt="Screenshot dell'applicazione" width="150" style="padding: 20px">
+<img src="assets/images/Screenshot 2026-03-17 122258.png" alt="Screenshot dell'applicazione" width="150" style="padding: 20px">
+<img src="assets/images/Screenshot 2026-03-17 122845.png" alt="Screenshot dell'applicazione" width="150" style="padding: 20px">
 </div>
 
 ---


### PR DESCRIPTION
Jekyll non renderizza sintassi Markdown dentro blocchi <div>.
- Header: # h1, **bold**, []() → <h1>, <strong>, <a>
- Screenshot: sposta ## fuori dal <div>, fix backslash → slash nei path