### PR TITLE
feat(pages): sito Jekyll con tema Cayman

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
-<div align="center">
-<img src="apps/pwa/public/icons/pwa-192.png" alt="Turni di Palco" width="120">
-<h1>Turni di Palco</h1>
-<p><strong>Il teatro come percorso. La cultura come gioco.</strong></p>
-<p><a href="https://turni-di-palco.vercel.app"><strong>→ Accedi all'applicazione</strong></a></p>
-</div>
-
+---
+layout: default
 ---
 
 ## Che cos'è
@@ -41,6 +36,8 @@ Turni di Palco nasce dall'esigenza di rendere il teatro un'esperienza continuati
 - trasforma ogni visita a teatro in un passo concreto di un percorso personale;
 - favorisce il legame tra il pubblico e le realtà teatrali del territorio.
 
+---
+
 ## Screenshot
 
 <div align="center">
@@ -49,8 +46,6 @@ Turni di Palco nasce dall'esigenza di rendere il teatro un'esperienza continuati
 <img src="assets/images/Screenshot 2026-03-17 122258.png" alt="Screenshot dell'applicazione" width="150" style="padding: 20px">
 <img src="assets/images/Screenshot 2026-03-17 122845.png" alt="Screenshot dell'applicazione" width="150" style="padding: 20px">
 </div>
-
----
 
 ---
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,28 @@
+title: Turni di Palco
+description: Il teatro come percorso. La cultura come gioco.
+lang: it
+
+remote_theme: pages-themes/cayman@v0.2.0
+plugins:
+  - jekyll-remote-theme
+
+logo: apps/pwa/public/icons/pwa-192.png
+app_url: https://turni-di-palco.vercel.app
+show_downloads: false
+
+# Exclude dev/build artifacts from the Jekyll site
+exclude:
+  - apps/
+  - shared/
+  - tools/
+  - docs/
+  - node_modules/
+  - "*.lock"
+  - "*.sh"
+  - ".env*"
+  - AGENTS.md
+  - DEVELOPMENT.md
+  - CLAUDE.md
+  - render.yaml
+  - vercel.json
+  - netlify.toml

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "it" }}">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {% seo %}
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    {% feed_meta %}
+    {% if jekyll.environment == 'production' and site.google_analytics %}
+    {% include analytics.html %}
+    {% endif %}
+  </head>
+  <body>
+    <a id="skip-to-content" href="#content">Vai al contenuto.</a>
+
+    <header class="page-header" role="banner">
+      {% if site.logo %}
+      <img src="{{ site.logo | relative_url }}" alt="{{ site.title }}" width="96" style="margin-bottom: 1rem; border-radius: 16px;">
+      {% endif %}
+      <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
+      <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
+      {% if site.app_url %}
+      <a href="{{ site.app_url }}" class="btn">→ Accedi all'applicazione</a>
+      {% endif %}
+      {% if site.github.is_project_page %}
+      <a href="{{ site.github.repository_url }}" class="btn">Codice sorgente</a>
+      {% endif %}
+    </header>
+
+    <main id="content" class="main-content" role="main">
+      {{ content }}
+
+      <footer class="site-footer">
+        <span class="site-footer-owner">
+          <a href="{{ site.github.repository_url }}">{{ site.title }}</a> è sviluppato da
+          <a href="https://atcllazio.it">A.T.C.L.</a> — Associazione Teatrale fra i Comuni del Lazio.
+        </span>
+        <span class="site-footer-credits">Sito generato con <a href="https://pages.github.com">GitHub Pages</a>.</span>
+      </footer>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Aggiunge `_config.yml` con tema Cayman (remote theme), logo dell'app e CTA verso `turni-di-palco.vercel.app`
- Crea `_layouts/default.html` che sovrascrive l'header Cayman: aggiunge logo, bottone "Accedi all'applicazione" e footer con link ad ATCL
- Aggiorna `README.md`: aggiunge front matter `layout: default`, rimuove il blocco header ridondante (ora gestito dal tema)

## Risultato su GitHub Pages

- Header con logo PWA, titolo "Turni di Palco", tagline, bottone CTA e "Codice sorgente"
- Sezioni di contenuto (`Che cos'è`, `Come funziona`, ecc.) con tipografia e stile Cayman
- Footer con attribuzione ATCL

## Test plan

- [ ] Fare il merge e attendere la build `pages-build-deployment`
- [ ] Verificare che il sito su GitHub Pages mostri header con logo e bottone CTA
- [ ] Verificare che le sezioni Markdown siano renderizzate correttamente
- [ ] Verificare che gli screenshot siano visibili

🤖 Generated with [Claude Code](https://claude.com/claude-code)