### PR TITLE
fix(pages): permalink per index e pulizia esclusi Jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+permalink: /
 ---
 
 ## Che cos'è

--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,11 @@ exclude:
   - AGENTS.md
   - DEVELOPMENT.md
   - CLAUDE.md
+  - DEPLOY_NETLIFY.md
+  - TECHNICAL_NOTES.md
+  - SECURITY.md
+  - supabase/
+  - railway/
   - render.yaml
   - vercel.json
   - netlify.toml


### PR DESCRIPTION
## Problema

Il build Jekyll scriveva `_site/README.html` invece di `_site/index.html`, causando il 404 su `atcl-lazio.github.io/Turni-di-Palco/`.

**Causa**: `jekyll-readme-index` non interviene su file che hanno già front matter. Con `layout: default` nel front matter, Jekyll usa il nome del file (`README.md` → `README.html`) invece di `index.html`.

## Fix

- `README.md`: aggiunto `permalink: /` nel front matter → Jekyll scrive `index.html`
- `_config.yml`: aggiunti `DEPLOY_NETLIFY.md`, `TECHNICAL_NOTES.md`, `SECURITY.md`, `supabase/`, `railway/` agli esclusi (erano visibili nel build log come pagine pubbliche indesiderate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)