### PR TITLE
Potential fix for code scanning alert no. 3: Clear text storage of sensitive information

### DIFF
--- a/apps/mobile/src/hooks/useNavigation.ts
+++ b/apps/mobile/src/hooks/useNavigation.ts
@@ -168,7 +168,6 @@ export function useNavigation(initialEvents: { id: string }[], options?: UseNavi
             screen: persistedScreen,
             activeTab: persistedTab,
             legalReturnScreen,
-            isPasswordRecovery,
             scannedEventId,
             selectedActivityId,
         });


### PR DESCRIPTION
Potential fix for [https://github.com/ATCL-Lazio/Turni-di-Palco/security/code-scanning/3](https://github.com/ATCL-Lazio/Turni-di-Palco/security/code-scanning/3)

In general terms: avoid storing sensitive or security-related flags unencrypted in localStorage. For navigation persistence, only persist what’s needed to restore the UI (screen, tab, etc.), and omit sensitive flags entirely. Since we should not introduce app‑wide crypto or backends here, the best fix within this snippet is to stop including `isPasswordRecovery` in the persisted navigation state.

Concretely in `apps/mobile/src/hooks/useNavigation.ts`:

- Update the `writeNavState` call inside the `useEffect` beginning at line 156 so that the object passed to `writeNavState` no longer includes `isPasswordRecovery`.
- Leave the in‑memory `isPasswordRecovery` state management unchanged (it’s still part of the hook’s return value and React state), so existing behavior at runtime is preserved except that password‑recovery state will not be restored from persisted navigation after a reload.
- No new imports, methods, or definitions are required; we simply reduce the fields being serialized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
