### PR TITLE
Remove hero backdrop and add landing-page theme CSS

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,6 @@
 
     <div class="site-shell">
       <header class="page-header" role="banner">
-        <div class="hero-backdrop"></div>
         <div class="hero-inner">
           <p class="hero-kicker">A.T.C.L. presenta</p>
           {% if site.logo %}

--- a/assets/css/pages-theme.css
+++ b/assets/css/pages-theme.css
@@ -69,29 +69,7 @@ a:hover {
 
 .page-header {
   position: relative;
-  isolation: isolate;
   padding: 3rem 1.5rem 2.5rem;
-}
-
-.hero-backdrop {
-  position: absolute;
-  inset: 0 0 -7rem;
-  z-index: -1;
-  background:
-    linear-gradient(135deg, rgba(45, 10, 15, 0.92), rgba(22, 17, 18, 0.78)),
-    radial-gradient(circle at top, rgba(244, 191, 79, 0.16), transparent 32%);
-  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.98) 0%, rgba(0, 0, 0, 0.75) 72%, transparent 100%);
-}
-
-.hero-backdrop::after {
-  content: "";
-  position: absolute;
-  inset: auto -8% -24% auto;
-  width: 420px;
-  aspect-ratio: 1;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(244, 191, 79, 0.18), rgba(244, 191, 79, 0));
-  filter: blur(24px);
 }
 
 .hero-inner,
@@ -820,5 +798,85 @@ a:hover {
 
   .gallery-intro {
     max-width: 42rem;
+  }
+}
+
+/* Mobile app visual alignment for marketing landing */
+.landing-page {
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", "Inter", system-ui, sans-serif;
+}
+
+.landing-page .project-name,
+.landing-page .main-content h1,
+.landing-page .main-content h2,
+.landing-page .main-content h3 {
+  font-family: inherit;
+  letter-spacing: -0.02em;
+}
+
+.landing-page .project-name {
+  font-size: clamp(2.4rem, 7vw, 4rem);
+  line-height: 1.05;
+}
+
+.landing-page .hero-inner {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: linear-gradient(180deg, rgba(36, 31, 32, 0.94), rgba(26, 22, 23, 0.9));
+  border-radius: 24px;
+}
+
+.landing-page .main-content-landing {
+  gap: 1rem;
+}
+
+.landing-page .landing-section {
+  padding: 1.35rem;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 22px;
+  background: linear-gradient(180deg, rgba(34, 28, 30, 0.86), rgba(24, 20, 21, 0.82));
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.28);
+}
+
+.landing-page .landing-manifesto {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.landing-page .journey-stack li {
+  padding-bottom: 0.9rem;
+}
+
+.landing-page .audience-columns article {
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.landing-page .gallery-layout,
+.landing-page .landing-manifesto {
+  grid-template-columns: 1fr;
+}
+
+.landing-page .gallery-intro {
+  max-width: 56rem;
+}
+
+.landing-page .landing-cta {
+  padding: 1.2rem;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(74, 14, 26, 0.95), rgba(38, 31, 33, 0.9));
+}
+
+@media (max-width: 760px) {
+  .landing-page .landing-section {
+    padding: 1rem;
+    border-radius: 18px;
+  }
+
+  .landing-page .screen-grid-wide {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
### Motivation
- Simplify the header markup and remove a heavy decorative backdrop that was adding complexity and visual clutter.
- Provide a dedicated `landing-page` theme to better align typographic and layout styling for mobile app marketing pages.
- Reduce layering complexity in the header to improve maintainability and rendering predictability.

### Description
- Removed the `.hero-backdrop` element from `_layouts/default.html` and deleted its corresponding CSS rules from `assets/css/pages-theme.css`.
- Removed `isolation: isolate;` from the `.page-header` rule to simplify stacking context behavior.
- Added a new `.landing-page` stylesheet section with typography, layout, component, and responsive rules to style the marketing/landing pages, including overrides for `.project-name`, `.hero-inner`, and various layout utilities.
- Kept existing header structure and button links while consolidating visual styles into the new landing theme.

### Testing
- Ran `jekyll build` locally to verify the site builds without errors and the updated templates and styles compile successfully.
- No automated unit tests were added for this style/layout change and CI should validate rendering on the next run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9775c4c688326ac8d4007803f0514)