### PR TITLE
Update landing hero styles, add `.landing-page` theme, and bump service worker cache version

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,6 @@
 
     <div class="site-shell">
       <header class="page-header" role="banner">
-        <div class="hero-backdrop"></div>
         <div class="hero-inner">
           <p class="hero-kicker">A.T.C.L. presenta</p>
           {% if site.logo %}

--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -33,7 +33,7 @@ const CORE_ASSETS = [
 const NON_PUBLIC_PATHS = new Set(CORE_ASSETS_BY_ENV.dev);
 const OFFLINE_URL = "/index.html";
 
-const CORE_CACHE_VERSION = "v5d21b6a4";
+const CORE_CACHE_VERSION = "vfcac4adb";
 const CACHE_VERSION_TAG = "v5";
 const CORE_CACHE_NAME = `turni-di-palco-core-${CORE_CACHE_VERSION}-${CACHE_VERSION_TAG}`;
 const TILE_CACHE_NAME = `turni-di-palco-tiles-${CORE_CACHE_VERSION}-${CACHE_VERSION_TAG}`;

--- a/assets/css/pages-theme.css
+++ b/assets/css/pages-theme.css
@@ -69,29 +69,7 @@ a:hover {
 
 .page-header {
   position: relative;
-  isolation: isolate;
   padding: 3rem 1.5rem 2.5rem;
-}
-
-.hero-backdrop {
-  position: absolute;
-  inset: 0 0 -7rem;
-  z-index: -1;
-  background:
-    linear-gradient(135deg, rgba(45, 10, 15, 0.92), rgba(22, 17, 18, 0.78)),
-    radial-gradient(circle at top, rgba(244, 191, 79, 0.16), transparent 32%);
-  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.98) 0%, rgba(0, 0, 0, 0.75) 72%, transparent 100%);
-}
-
-.hero-backdrop::after {
-  content: "";
-  position: absolute;
-  inset: auto -8% -24% auto;
-  width: 420px;
-  aspect-ratio: 1;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(244, 191, 79, 0.18), rgba(244, 191, 79, 0));
-  filter: blur(24px);
 }
 
 .hero-inner,
@@ -820,5 +798,88 @@ a:hover {
 
   .gallery-intro {
     max-width: 42rem;
+  }
+}
+
+/* Mobile app visual alignment for marketing landing */
+.landing-page {
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", "Inter", system-ui, sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(255, 255, 255, 0.04), transparent 28%),
+    linear-gradient(180deg, #121011 0%, #0f0d0e 42%, #151213 100%);
+}
+
+.landing-page .project-name,
+.landing-page .main-content h1,
+.landing-page .main-content h2,
+.landing-page .main-content h3 {
+  font-family: inherit;
+  letter-spacing: -0.02em;
+}
+
+.landing-page .project-name {
+  font-size: clamp(2.4rem, 7vw, 4rem);
+  line-height: 1.05;
+}
+
+.landing-page .hero-inner {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: linear-gradient(180deg, rgba(36, 31, 32, 0.94), rgba(26, 22, 23, 0.9));
+  border-radius: 24px;
+}
+
+.landing-page .main-content-landing {
+  gap: 1rem;
+}
+
+.landing-page .landing-section {
+  padding: 1.35rem;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 22px;
+  background: linear-gradient(180deg, rgba(34, 28, 30, 0.86), rgba(24, 20, 21, 0.82));
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.28);
+}
+
+.landing-page .landing-manifesto {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.landing-page .journey-stack li {
+  padding-bottom: 0.9rem;
+}
+
+.landing-page .audience-columns article {
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.landing-page .gallery-layout,
+.landing-page .landing-manifesto {
+  grid-template-columns: 1fr;
+}
+
+.landing-page .gallery-intro {
+  max-width: 56rem;
+}
+
+.landing-page .landing-cta {
+  padding: 1.2rem;
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(39, 33, 34, 0.94), rgba(26, 22, 23, 0.92));
+}
+
+@media (max-width: 760px) {
+  .landing-page .landing-section {
+    padding: 1rem;
+    border-radius: 18px;
+  }
+
+  .landing-page .screen-grid-wide {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
### Motivation
- Simplify and restyle the marketing landing hero for a cleaner visual and to introduce a dedicated `landing-page` theme for improved mobile app alignment.
- Remove the decorative hero backdrop to reduce layering complexity and potential rendering issues.
- Rotate the service worker core cache version to force a cache refresh for updated assets.

### Description
- Removed the `.hero-backdrop` element from `/_layouts/default.html` and dropped related backdrop styles and the `isolation: isolate;` rule from `assets/css/pages-theme.css`.
- Added a new `.landing-page` theme and a set of layout and visual rules in `assets/css/pages-theme.css` to improve typography, background gradients, card styling, and responsive behavior for the landing experience.
- Bumped the service worker core cache version constant in `apps/pwa/public/sw.js` by changing `CORE_CACHE_VERSION` to a new value so the `CORE_CACHE_NAME`, `TILE_CACHE_NAME`, and `META_CACHE_NAME` reflect the update.
- Kept existing core asset lists and cache TTL/max entries unchanged while ensuring non-public dev assets remain excluded from production caching.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9775c4c688326ac8d4007803f0514)