### PR TITLE
Add GitHub Pages deployment workflow and base path configuration

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,55 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.14.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build PWA
+        run: npm --workspace apps/pwa run build
+        env:
+          VITE_BASE: /development/
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/pwa/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/apps/pwa/vite.config.ts
+++ b/apps/pwa/vite.config.ts
@@ -63,6 +63,7 @@ export default defineConfig(({ mode }) => {
   const allowedHosts = resolveAllowedHosts(env);
 
   return {
+    base: env.VITE_BASE || process.env.VITE_BASE || "/",
     plugins: [tailwindcss()],
     build: {
       rollupOptions: {


### PR DESCRIPTION
## Summary
This PR adds automated deployment to GitHub Pages and configures the PWA to support custom base paths for deployment to subdirectories.

## Key Changes
- **New GitHub Actions workflow** (`deploy-gh-pages.yml`): Automatically builds and deploys the PWA to GitHub Pages on pushes to main branch
  - Builds the PWA with `VITE_BASE=/development/` for deployment to a subdirectory
  - Uploads build artifacts and deploys to GitHub Pages
  - Includes proper permissions and concurrency settings

- **Vite configuration update**: Added support for configurable base path via `VITE_BASE` environment variable
  - Allows the PWA to be deployed to subdirectories (e.g., `/development/`) instead of just the root
  - Falls back to `/` if not specified, maintaining backward compatibility

## Implementation Details
The workflow uses GitHub's official Pages actions and Node.js 22.14.0. The base path configuration in Vite enables the same build to be deployed to different paths by setting the `VITE_BASE` environment variable, which is particularly useful for staging/development deployments.

https://claude.ai/code/session_019yuZCAbJ1pygZDHnUUHhH6