### PR TITLE
Fix relative URLs for Jekyll site compatibility

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -153,4 +153,4 @@ python ticket_qr_generator.py
 
 oppure aprire il file `ticket_qr_generator_ui.py` con un editor di testo e eseguirlo.
 
-![Screenshot dell'app](</assets/images/Screenshot 2026-02-27 121448.png>)
+![Screenshot dell'app]({{ '/assets/images/Screenshot 2026-02-27 121448.png' | relative_url }})

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,7 @@
             {% if site.app_url %}
             <a href="{{ site.app_url }}" class="btn btn-primary">Apri l'app</a>
             {% endif %}
-            <a href="/development/" class="btn btn-secondary">Documentazione</a>
+            <a href="{{ '/development/' | relative_url }}" class="btn btn-secondary">Documentazione</a>
             <a href="{{ site.github.repository_url }}" class="btn btn-secondary">Repository</a>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@ content_panel: false
       </div>
       <div class="landing-cta-actions">
         <a href="{{ site.app_url }}" class="btn btn-primary">Apri App</a>
-        <a href="/development/" class="btn btn-secondary">Documentazione</a>
+        <a href="{{ '/development/' | relative_url }}" class="btn btn-secondary">Documentazione</a>
         <a href="{{ site.github.repository_url }}" class="btn btn-secondary">Repository</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Updated hardcoded absolute URLs to use Jekyll's `relative_url` filter for better site portability and compatibility with different deployment contexts.

## Key Changes
- **DEVELOPMENT.md**: Fixed image path to use Jekyll's `relative_url` filter instead of hardcoded absolute path
- **_layouts/default.html**: Updated "Documentazione" link to use `relative_url` filter for proper URL resolution
- **index.html**: Updated "Documentazione" link to use `relative_url` filter for consistent URL handling

## Implementation Details
All changes follow Jekyll best practices by replacing hardcoded `/development/` paths with `{{ '/development/' | relative_url }}` syntax. This ensures URLs are correctly resolved regardless of whether the site is deployed at the root domain or a subdirectory, improving site portability and preventing broken links in different deployment scenarios.

https://claude.ai/code/session_01SxU5vnj9H7YSNqEVtQRFDX