### PR TITLE
Configure baseurl for GitHub Pages deployment

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 title: Turni di Palco
 description: Il teatro come percorso. La cultura come gioco.
 lang: it
+baseurl: /Turni-di-Palco
 
 remote_theme: pages-themes/cayman@v0.2.0
 plugins:


### PR DESCRIPTION
## Summary
Added the `baseurl` configuration to `_config.yml` to properly support deployment of the site to a GitHub Pages project repository.

## Changes
- Added `baseurl: /Turni-di-Palco` to the Jekyll configuration file

## Details
This change ensures that all site assets and links are correctly prefixed with `/Turni-di-Palco` when the site is deployed to a GitHub Pages project repository (as opposed to a user/organization site). This prevents broken links and missing assets that would occur if the site is served from a subdirectory rather than the root domain.

https://claude.ai/code/session_01QrvHC27SVLefEE4tz5q1fx