### PR TITLE
Align text to left across all page elements

### DIFF
--- a/assets/css/pages-theme.css
+++ b/assets/css/pages-theme.css
@@ -73,11 +73,12 @@ a:hover {
   overflow: hidden;
 }
 
-/* Override Cayman default header background */
+/* Override Cayman default header background and alignment */
 .page-header {
   background-color: transparent;
   background-image: none;
   padding: 2.5rem 1.5rem 2rem;
+  text-align: left;
 }
 
 .hero-inner,
@@ -97,6 +98,7 @@ a:hover {
 
 .main-content {
   padding: 0 1.5rem 3rem;
+  text-align: left;
 }
 
 /* 4. Hero */
@@ -111,7 +113,7 @@ a:hover {
 
 .project-logo {
   display: block;
-  margin: 0 auto 1.5rem;
+  margin: 0 0 1.5rem;
   border-radius: 22px;
   box-shadow: 0 10px 26px rgba(0, 0, 0, 0.3);
 }
@@ -200,6 +202,7 @@ a:hover {
   font-family: Georgia, "Times New Roman", serif;
   letter-spacing: -0.02em;
   color: var(--tdp-text);
+  text-align: left;
 }
 
 .main-content h1 {
@@ -221,6 +224,7 @@ a:hover {
 .main-content li {
   color: var(--tdp-text-muted);
   line-height: 1.75;
+  text-align: left;
 }
 
 .main-content strong {
@@ -309,6 +313,7 @@ a:hover {
   border-top: 1px solid var(--tdp-border);
   color: var(--tdp-text-soft);
   font-size: 0.87rem;
+  text-align: left;
 }
 
 .site-footer a {
@@ -343,6 +348,7 @@ a:hover {
   border-radius: var(--tdp-radius-xl);
   background: linear-gradient(180deg, rgba(28, 22, 25, 0.94), rgba(19, 15, 17, 0.94));
   box-shadow: 0 10px 32px rgba(0, 0, 0, 0.2);
+  text-align: left;
 }
 
 .landing-block-head {
@@ -558,6 +564,7 @@ a:hover {
   color: var(--tdp-text-muted);
   font-size: 0.84rem;
   line-height: 1.58;
+  text-align: left;
 }
 
 /* Audience cards */


### PR DESCRIPTION
## Summary
This PR updates the theme stylesheet to enforce left text alignment across all major page components, overriding any center alignment that may have been inherited from the Cayman theme defaults.

## Key Changes
- Updated `.page-header` comment to reflect both background and alignment overrides
- Added `text-align: left` to `.page-header` and `.main-content` for primary content areas
- Changed `.project-logo` margin from `0 auto 1.5rem` to `0 0 1.5rem` to remove center alignment
- Added `text-align: left` to multiple content elements:
  - Headings (`.main-content h`)
  - List items (`.main-content li`)
  - Footer (`.site-footer`)
  - Landing blocks (`.landing-block`)
  - Block descriptions (`.landing-block-description`)

## Implementation Details
The changes systematically apply left alignment across the entire page layout, ensuring consistent text direction and removing any automatic centering that the parent Cayman theme may have applied. This affects both structural containers and individual content elements to guarantee uniform left-aligned text throughout the site.

https://claude.ai/code/session_01EmdbjjkxrEPfMbKLixwjo3