### PR TITLE
Center hero section on both root and /development/ pages

### DIFF
--- a/assets/css/pages-theme.css
+++ b/assets/css/pages-theme.css
@@ -73,12 +73,11 @@ a:hover {
   overflow: hidden;
 }
 
-/* Override Cayman default header background and alignment */
+/* Override Cayman default header background */
 .page-header {
   background-color: transparent;
   background-image: none;
   padding: 2.5rem 1.5rem 2rem;
-  text-align: left;
 }
 
 .hero-inner,
@@ -94,6 +93,7 @@ a:hover {
   background: linear-gradient(180deg, rgba(36, 28, 31, 0.96), rgba(20, 15, 17, 0.94));
   box-shadow: var(--tdp-shadow);
   backdrop-filter: blur(14px);
+  text-align: center;
 }
 
 .main-content {
@@ -113,7 +113,7 @@ a:hover {
 
 .project-logo {
   display: block;
-  margin: 0 0 1.5rem;
+  margin: 0 auto 1.5rem;
   border-radius: 22px;
   box-shadow: 0 10px 26px rgba(0, 0, 0, 0.3);
 }
@@ -128,7 +128,7 @@ a:hover {
 }
 
 .project-tagline {
-  margin: 0.9rem 0 0;
+  margin: 0.9rem auto 0;
   color: var(--tdp-text-muted);
   font-size: clamp(1.1rem, 2vw, 1.5rem);
   font-weight: 400;
@@ -138,6 +138,7 @@ a:hover {
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 0.8rem;
   margin-top: 1.75rem;
 }


### PR DESCRIPTION
Apply centered alignment to hero-inner (logo, title, tagline, buttons) so both pages share the same style, while the rest of the content stays left-aligned.

https://claude.ai/code/session_01EmdbjjkxrEPfMbKLixwjo3