### PR TITLE
Add copyright notice to site footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,6 +46,7 @@
             <a href="https://atcllazio.it">A.T.C.L.</a>, Associazione Teatrale fra i Comuni del Lazio.
           </span>
           <span class="site-footer-credits">Pubblicato tramite <a href="https://pages.github.com">GitHub Pages</a>.</span>
+          <span class="site-footer-copyright">&copy; 2025 A.T.C.L. &mdash; Tutti i diritti riservati.</span>
         </footer>
       </main>
     </div>

--- a/assets/css/pages-theme.css
+++ b/assets/css/pages-theme.css
@@ -321,6 +321,12 @@ a:hover {
   color: var(--tdp-text-muted);
 }
 
+.site-footer-copyright {
+  flex-basis: 100%;
+  text-align: center;
+  margin-top: 0.25rem;
+}
+
 /* 9. Landing page */
 .main-content-landing {
   padding-top: 0.25rem;


### PR DESCRIPTION
## Summary
Added a copyright notice to the site footer with proper styling and layout.

## Changes
- **CSS**: Added `.site-footer-copyright` class to `pages-theme.css` with flexbox styling to ensure the copyright text spans full width and is centered with appropriate spacing
- **Layout**: Added copyright text "© 2025 A.T.C.L. — Tutti i diritti riservati." to the footer in `_layouts/default.html`

## Implementation Details
The copyright notice is implemented as a separate `<span>` element with the new `.site-footer-copyright` class, which uses `flex-basis: 100%` to force it onto its own line within the footer's flex container. The `text-align: center` ensures the text is centered, and `margin-top: 0.25rem` provides consistent spacing from the elements above it.

https://claude.ai/code/session_011QxU4vjm9xVYxrNoZcHptC