### PR TITLE
Ignore local Vercel link files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ maxwell-ai-credentials.json
 # Python cache
 tools/ticket_qr_generator/out/
 tools/ticket_qr_generator/__pycache__/
+.vercel


### PR DESCRIPTION
## Summary
- add .vercel to .gitignore
- keep Vercel link metadata local to each developer machine

## Testing
- not run (config-only change)