### PR TITLE
Add technical notes page and ATCL ticketing map

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,6 +23,12 @@ description: Guida tecnica e architettura del progetto Turni di Palco
 
 ---
 
+## Approfondimenti
+
+- [Note tecniche]({{ '/development/technical_notes/' | relative_url }}): architettura, QR, Supabase, ticketing e note operative.
+
+---
+
 ## Stato dei Deploy
 
 | Piattaforma | Stato | URL | QR |

--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,6 @@ exclude:
   - AGENTS.md
   - CLAUDE.md
   - DEPLOY_NETLIFY.md
-  - TECHNICAL_NOTES.md
   - SECURITY.md
   - supabase/
   - railway/

--- a/development/technical_notes.md
+++ b/development/technical_notes.md
@@ -1,0 +1,10 @@
+---
+layout: default
+permalink: /development/technical_notes/
+title: Note tecniche
+description: Architettura, integrazioni e note operative di Turni di Palco
+---
+
+[<- Torna alla documentazione tecnica]({{ '/development/' | relative_url }})
+
+{% include_relative ../TECHNICAL_NOTES.md %}

--- a/docs/2026-03-23-atcl-teatri-ticketing.md
+++ b/docs/2026-03-23-atcl-teatri-ticketing.md
@@ -1,0 +1,133 @@
+# Mappatura Teatri ATCL e Sistemi di Ticketing
+
+Data verifica pubblica: 2026-03-23
+
+## Scopo
+
+Questo documento raccoglie una mappatura operativa dei teatri/venue ATCL emersi dalle pagine pubbliche di stagione 2025-2026 e 2026 del sito ATCL, associando a ciascuno il sistema di ticketing indicato pubblicamente.
+
+Obiettivo pratico:
+
+- capire quali circuiti ricorrono davvero nella rete ATCL;
+- distinguere i casi con circuito esplicito dai casi in cui la pagina ATCL rimanda solo al sito del teatro o al botteghino;
+- evitare assunzioni errate su account centralizzati ATCL.
+
+## Metodo
+
+- Fonte primaria: pagine pubbliche ATCL delle stagioni 2025-2026/2026.
+- Quando la pagina ATCL nomina esplicitamente un circuito o linka direttamente il provider, la mappatura e' marcata come `Alta`.
+- Quando la pagina ATCL indica solo "online", "sito web" o il botteghino del teatro senza nominare il circuito, la mappatura e' marcata come `Media` o `Bassa`.
+- Dove non emerge un circuito online pubblico, il dato viene lasciato come `Non esplicitato`.
+
+## Sintesi
+
+- TicketOne compare in modo esplicito in piu' piazze importanti della rete ATCL, ma non e' il circuito unico di tutto il network.
+- Ciaotickets e Tickettando/18Tickets sono presenti in modo chiaro in alcune venue specifiche.
+- Liveticket emerge chiaramente almeno a Colleferro.
+- In diversi teatri il sito ATCL non pubblica il circuito: rimanda al botteghino locale o al sito del teatro.
+- Cassino, nella stagione ATCL 2025-2026, non risulta pubblicamente appoggiata a 18Tickets dalla sola pagina ATCL: la pagina rimanda al sito del Teatro Manzoni senza nominare il circuito.
+
+## Mappa
+
+| Comune | Teatro / venue | Ticketing pubblico associato | Affidabilita | Nota operativa |
+| --- | --- | --- | --- | --- |
+| Capranica | Teatro Francigena | Ciaotickets | Alta | La pagina ATCL indica "Vendita biglietti online su www.ciaotickets.com". |
+| Carpineto Romano | Auditorium Leone XIII | Tickettando / 18Tickets / 18Months | Alta | La pagina ATCL indica "Biglietti disponibili su Tickettando/18thMonths" e link `*.18tickets.it`. |
+| Cassino | Cinema Teatro Manzoni | Non esplicitato nella pagina ATCL | Media | La pagina ATCL rimanda al sito del Teatro Manzoni di Cassino ma non nomina TicketOne, 18Tickets o altri circuiti. |
+| Civitavecchia | Teatro Traiano | TicketOne | Alta | La pagina ATCL linka direttamente `ticketone.it`. |
+| Colleferro | Teatro Vittorio Veneto | Liveticket | Alta | La pagina ATCL indica "online su liveticket.it". |
+| Colonna | Teatro Chiesa Vecchia | Non verificato pubblicamente | Bassa | Dal catalogo ATCL emerge la venue, ma il circuito non e' emerso nella verifica pubblica svolta oggi. |
+| Fara in Sabina | Teatro Potlach | Prenotazione diretta / circuito non emerso | Media | Nella verifica pubblica ATCL non emerge un provider online chiaro; nelle pagine correlate compaiono contatti diretti del teatro. |
+| Fiuggi | Teatro Comunale di Fiuggi | Vendita online non esplicitata | Media | La pagina ATCL dice che i biglietti sono disponibili anche online, ma non nomina il provider. |
+| Fondi | Teatro Citta' di Fondi "Nino Canale" | Vendita online non esplicitata | Media | La pagina ATCL indica apertura vendita online dal 1 novembre, senza nominare il circuito. |
+| Formia | Piccolo Teatro Iqbal Masih | Non esplicitato / sito del teatro | Bassa | La pagina ATCL rimanda al sito del teatro, senza indicare un provider di biglietteria. |
+| Frascati | Spazio Teatro Faber | Ciaotickets | Alta | La pagina ATCL rimanda a `www.ciaotickets.com`. |
+| Frosinone | Teatro Comunale Vittoria | Ciaotickets | Alta | La pagina ATCL indica "Online: dal 12 gennaio su Ciaotickets". |
+| Gaeta | Teatro Ariston | Non esplicitato / sito del teatro | Bassa | La pagina ATCL rimanda al sito `aristongaeta.it`, senza nominare il circuito. |
+| Latina | Teatro Comunale D'Annunzio | TicketOne | Alta | La pagina ATCL linka direttamente `ticketone.it`. |
+| Magliano Sabina | Teatro Manlio | Botteghino locale / circuito online non emerso | Media | Nella verifica pubblica non emerge un circuito online; la vendita sembra gestita soprattutto dal teatro/botteghino. |
+| Montalto di Castro | Teatro Lea Padovani | Non esplicitato / sito del teatro | Bassa | La pagina ATCL rimanda al sito del teatro ma non nomina il provider. |
+| Monterotondo | Teatro Comunale F. Ramarini | Tickettando / 18Tickets | Alta | La pagina ATCL indica "tramite il circuito Tickettando.it" e link `*.18tickets.it`. |
+| Priverno | Teatro Comunale Gigi Proietti | Botteghino locale | Media | La pagina ATCL riporta solo ritiro abbonamenti e biglietteria locale, senza canale online esplicito. |
+| Rieti | Teatro Flavio Vespasiano | TicketOne | Alta | La pagina ATCL indica "Biglietti online dal 13 ottobre su Ticketone.it". |
+| Rignano Flaminio | Teatro Paladino | Tickettando / 18Tickets | Alta | La pagina ATCL indica abbonamenti e biglietti online su `Tickettando.it` con link `*.18tickets.it`. |
+| Tarquinia | Teatro Comunale Rossella Falk | Non esplicitato nella pagina ATCL | Media | La pagina ATCL usa un link esterno abbreviato (`shorturl.at`) ma non rende leggibile il provider nella pagina stessa. |
+| Tivoli | Teatro Giuseppetti | Vendita online non esplicitata | Media | La pagina ATCL indica "vendita online e al botteghino", ma non nomina il circuito. |
+| Tuscania | Teatro Il Rivellino | Non emerso pubblicamente nella verifica ATCL | Bassa | La venue e' presente nel catalogo ATCL 2026, ma il circuito di biglietteria non e' emerso chiaramente dalle pagine verificate. |
+| Velletri | Teatro Artemisio Gian Maria Volonte' | TicketOne | Alta | La pagina ATCL indica "Biglietti online su ticketone.it". |
+| Viterbo | Teatro dell'Unione | TicketOne | Alta | La pagina ATCL linka direttamente `ticketone.it`; nelle pagine teatro ragazzi compare anche la dicitura "online su Ticketone". |
+
+## Raggruppamento per circuito
+
+### TicketOne
+
+- Civitavecchia, Teatro Traiano
+- Latina, Teatro Comunale D'Annunzio
+- Rieti, Teatro Flavio Vespasiano
+- Velletri, Teatro Artemisio Gian Maria Volonte'
+- Viterbo, Teatro dell'Unione
+
+### Ciaotickets
+
+- Capranica, Teatro Francigena
+- Frascati, Spazio Teatro Faber
+- Frosinone, Teatro Comunale Vittoria
+
+### Tickettando / 18Tickets / 18Months
+
+- Carpineto Romano, Auditorium Leone XIII
+- Monterotondo, Teatro Comunale F. Ramarini
+- Rignano Flaminio, Teatro Paladino
+
+### Liveticket
+
+- Colleferro, Teatro Vittorio Veneto
+
+### Non esplicitato o gestito localmente
+
+- Cassino
+- Colonna
+- Fara in Sabina
+- Fiuggi
+- Fondi
+- Formia
+- Gaeta
+- Magliano Sabina
+- Montalto di Castro
+- Priverno
+- Tarquinia
+- Tivoli
+- Tuscania
+
+## Note operative
+
+- Questa mappa mostra che ATCL non appare come unico titolare tecnico di un solo circuito di biglietteria per tutta la rete.
+- Il modello ricorrente e' distribuito: alcuni teatri usano TicketOne, altri Ciaotickets, altri Tickettando/18Tickets, altri ancora gestiscono botteghino e sito locale.
+- Se serve una futura integrazione tecnica, l'interlocutore corretto non e' "ATCL in generale", ma il singolo teatro/venue o il circuito effettivamente usato da quella piazza.
+- Cassino merita verifica separata direttamente con il Teatro Manzoni se l'obiettivo e' capire accessi tecnici, API o export.
+
+## Fonti principali usate
+
+- ATCL, indice stagione: https://www.atcllazio.it/stagione-teatrale-2025-2026/
+- Capranica: https://www.atcllazio.it/2025/capranica-stagione-teatrale-2025-2026/
+- Carpineto Romano: https://www.atcllazio.it/2025/carpineto-romano-stagione-teatrale-2025-2026/
+- Cassino: https://www.atcllazio.it/2025/cassino-stagione-teatrale-2025-2026/
+- Civitavecchia: https://www.atcllazio.it/2025/civitavecchia-stagione-teatrale-2025-2026/
+- Colleferro: https://www.atcllazio.it/2025/colleferro-stagione-teatrale-2025-2026/
+- Fondi: https://www.atcllazio.it/2025/fondi-stagione-teatrale-2025-2026/
+- Formia: https://www.atcllazio.it/2025/formia-stagione-teatrale-2025-2026/
+- Frascati: https://www.atcllazio.it/2025/frascati-stagione-teatrale-2025-2026/
+- Frosinone: https://www.atcllazio.it/2025/frosinone-stagione-teatrale-2025-2026/
+- Gaeta: https://www.atcllazio.it/2025/gaeta-stagione-teatrale-2025-2026/
+- Latina: https://www.atcllazio.it/2025/latina-stagione-teatrale-2025-2026/
+- Montalto di Castro: https://www.atcllazio.it/2025/montalto-di-castro-stagione-teatrale-2025-2026/
+- Monterotondo: https://www.atcllazio.it/2025/monterotondo-stagione-teatrale-2025-2026/
+- Priverno: https://www.atcllazio.it/2025/priverno-stagione-teatrale-2025-2026/
+- Rieti: https://www.atcllazio.it/2025/rieti-stagione-teatrale-2025-2026/
+- Rignano Flaminio: https://www.atcllazio.it/2025/rignano-flaminio-stagione-teatrale-2025-2026/
+- Tarquinia: https://www.atcllazio.it/2025/tarquinia-stagione-teatrale-2025-2026/
+- Tivoli: https://www.atcllazio.it/2025/tivoli-stagione-teatrale-2025-2026/
+- Velletri: https://www.atcllazio.it/2025/velletri-stagione-teatrale-2025-2026/
+- Viterbo: https://www.atcllazio.it/2025/viterbo-stagione-teatrale-2025-2026/
+- Catalogo stagioni/rassegne ATCL per venue non completamente aperte in pagina: https://www.atcllazio.it/stagioni-e-rassegne/
+


### PR DESCRIPTION
## Summary
- publish technical notes under GitHub Pages at /development/technical_notes/
- link the new technical notes page from the development landing page
- add the ATCL theatres and ticketing mapping document under docs/

## Testing
- not run (documentation/Jekyll changes only)