### PR TITLE
Retrigger Pages build for technical notes

### DIFF
--- a/development/technical_notes.md
+++ b/development/technical_notes.md
@@ -2,7 +2,7 @@
 layout: default
 permalink: /development/technical_notes/
 title: Note tecniche - Turni di Palco
-description: Architettura, integrazioni e note operative di Turni di Palco
+description: Architettura, integrazioni e note operative di Turni di Palco.
 ---
 
 [<- Torna alla documentazione tecnica]({{ '/development/' | relative_url }})


### PR DESCRIPTION
## Summary
- apply a no-risk metadata change on development/technical_notes.md
- force a fresh Pages-triggering commit after the mojibake fix merge was not picked up by GitHub Pages

## Testing
- verified the previous merge already fixed the generated Jekyll output locally
- this PR exists only to retrigger the Pages deployment workflow