### PR TITLE
Add favicon to GitHub Pages layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,11 +1,15 @@
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "it" }}">
   <head>
+    {% assign site_icon = site.logo | default: 'assets/images/pwa-192.png' %}
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#120d0f">
     {% seo %}
+    <link rel="icon" type="image/png" sizes="192x192" href="{{ site_icon | relative_url }}">
+    <link rel="shortcut icon" href="{{ site_icon | relative_url }}">
+    <link rel="apple-touch-icon" href="{{ site_icon | relative_url }}">
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     <link rel="stylesheet" href="{{ '/assets/css/pages-theme.css?v=' | append: site.github.build_revision | relative_url }}">
   </head>


### PR DESCRIPTION
## Summary
- add favicon links to the shared Jekyll layout
- reuse the existing site.logo asset for icon, shortcut icon, and pple-touch-icon
- make the favicon available across all GitHub Pages documentation pages

## Testing
- undle exec jekyll build
- verified generated HTML includes /Turni-di-Palco/assets/images/pwa-192.png in favicon links