### PR TITLE
Semplifica feature flag mobile per non sviluppatori

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -193,7 +193,7 @@ export function AppShell() {
 
   // Navigation action helpers
   const openQrScanner = useCallback(() => {
-    if (!isFeatureEnabled('mobile.action.qr_scan')) {
+    if (!isFeatureEnabled('qr_scan')) {
       showFeatureDisabledAlert('Registrazione biglietto');
       return;
     }
@@ -339,7 +339,7 @@ export function AppShell() {
     window.sessionStorage.setItem(PENDING_EVENT_KEY, pendingFromUrl.eventId);
     try { window.history.replaceState({}, '', stripEventLinkParams(window.location.href)); } catch { /* ignore */ }
     if (authReady && isAuthValid) {
-      if (!isFeatureEnabled('mobile.action.turn_submit')) { window.sessionStorage.removeItem(PENDING_EVENT_KEY); return; }
+      if (!isFeatureEnabled('registra_turno')) { window.sessionStorage.removeItem(PENDING_EVENT_KEY); return; }
       setPendingTicketActivation(null);
       setConfirmationEventOverride(null);
       nav.setScannedEventId(pendingFromUrl.eventId);
@@ -354,7 +354,7 @@ export function AppShell() {
     if (!authReady || !isAuthValid) return;
     const pendingEventId = window.sessionStorage.getItem(PENDING_EVENT_KEY);
     if (!pendingEventId) return;
-    if (!isFeatureEnabled('mobile.action.turn_submit')) { window.sessionStorage.removeItem(PENDING_EVENT_KEY); return; }
+    if (!isFeatureEnabled('registra_turno')) { window.sessionStorage.removeItem(PENDING_EVENT_KEY); return; }
     setPendingTicketActivation(null);
     setConfirmationEventOverride(null);
     nav.setScannedEventId(pendingEventId);
@@ -390,7 +390,7 @@ export function AppShell() {
             level={state.profile.level} xp={state.profile.xp} xpToNextLevel={state.profile.xpToNextLevel}
             reputation={state.profile.reputation} cachet={state.profile.cachet} tokenAtcl={state.profile.tokenAtcl}
             pendingBoostRequests={pendingBoostRequests} turnSyncFeedback={turnSyncFeedback} onDismissTurnSyncFeedback={clearTurnSyncFeedback}
-            allowScanQr={isFeatureEnabled('mobile.action.qr_scan')} allowTurnsSection={tabFlags.turns} allowActivitiesSection={tabFlags.activities}
+            allowScanQr={isFeatureEnabled('qr_scan')} allowTurnsSection={tabFlags.turns} allowActivitiesSection={tabFlags.activities}
             onScanQR={openQrScanner} onViewActivities={openActivities} onOpenRoleJourney={openActivities} onViewTurni={openTurns}
             onViewEventDetails={() => {
               if (!tabFlags.turns) { showFeatureDisabledAlert('La sezione turni'); return; }
@@ -418,17 +418,17 @@ export function AppShell() {
                 onEditPlanning={(id: string) => { nav.setScannedEventId(id); nav.navigate('event-details'); }}
                 onViewMap={() => openEventsMap(events.map(e => e.theatre))}
                 onViewEvent={(id: string) => { nav.setScannedEventId(id); nav.navigate('event-details'); }}
-                onScanQR={openQrScanner} canScanQr={isFeatureEnabled('mobile.action.qr_scan')} embedded />
+                onScanQR={openQrScanner} canScanQr={isFeatureEnabled('qr_scan')} embedded />
             }
             activitiesView={
               <Activities activities={visibleActivities}
                 activeRole={roleJourneyEnabled ? selectedRole : undefined}
                 slotsStatus={activitySlotsStatus} slotsLoading={activitySlotsLoading}
                 isOnline={typeof navigator === 'undefined' ? true : navigator.onLine}
-                canStartActivities={isFeatureEnabled('mobile.action.activity_start')}
+                canStartActivities={isFeatureEnabled('avvia_attivita')}
                 recommendedActivityId={roleJourneyEnabled ? recommendedActivityId : undefined}
                 onStartActivity={(id: string) => {
-                  if (!isFeatureEnabled('mobile.action.activity_start')) { showFeatureDisabledAlert('Avvio attivita'); return; }
+                  if (!isFeatureEnabled('avvia_attivita')) { showFeatureDisabledAlert('Avvio attivita'); return; }
                   nav.setSelectedActivityId(id);
                   nav.navigate('activity-detail');
                 }} embedded />
@@ -440,7 +440,7 @@ export function AppShell() {
         return <Leaderboard onSelectEntry={openLeaderboardProfile} />;
 
       case 'qr-scanner':
-        if (!isFeatureEnabled('mobile.action.qr_scan')) {
+        if (!isFeatureEnabled('qr_scan')) {
           return (
             <div className="min-h-screen pb-24">
               <div className="app-content px-6 pt-6 space-y-4">
@@ -458,7 +458,7 @@ export function AppShell() {
       case 'event-confirmation':
         return (
           <EventConfirmation event={selectedEvent} role={selectedRole} cachet={state.profile.cachet} tokenAtcl={state.profile.tokenAtcl}
-            pendingBoostRequests={pendingBoostRequests} allowBoost={isFeatureEnabled('mobile.action.turn_boost')}
+            pendingBoostRequests={pendingBoostRequests} allowBoost={isFeatureEnabled('boost_turno')}
             onConfirm={handleEventConfirm} onSuccess={() => handleTabChange('home')}
             onCancel={() => { setPendingTicketActivation(null); setConfirmationEventOverride(null); nav.setScannedEventId(''); handleTabChange(nav.activeTab === 'home' ? 'home' : 'activities'); }} />
         );
@@ -481,14 +481,14 @@ export function AppShell() {
         return (
           <Shop cachet={state.profile.cachet} extraActivitySlots={state.profile.extraActivitySlots}
             items={shopCatalog} theatreOptions={theatreReputation.map(item => ({ theatre: item.theatre, reputation: item.reputation }))}
-            loading={shopCatalogLoading} canPurchase={isFeatureEnabled('mobile.action.shop_purchase')} onPurchase={purchaseShopItem} />
+            loading={shopCatalogLoading} canPurchase={isFeatureEnabled('acquisti')} onPurchase={purchaseShopItem} />
         );
 
       case 'activity-detail':
         return currentActivity && (
           <ActivityDetail activity={currentActivity} role={roleJourneyEnabled ? selectedRole : undefined}
             onStart={() => {
-              if (!isFeatureEnabled('mobile.action.activity_start')) { showFeatureDisabledAlert('Avvio attivita'); return; }
+              if (!isFeatureEnabled('avvia_attivita')) { showFeatureDisabledAlert('Avvio attivita'); return; }
               setActivityOutcome(null); setActivityCompletion(null); nav.navigate('activity-minigame');
             }}
             onClose={() => nav.navigate('activities')} />
@@ -500,7 +500,7 @@ export function AppShell() {
             onCancel={() => nav.navigate('activity-detail')}
             onComplete={outcome => {
               void (async () => {
-                if (!isFeatureEnabled('mobile.action.activity_complete')) { showFeatureDisabledAlert('Completamento attivita'); handleTabChange('activities'); return; }
+                if (!isFeatureEnabled('completa_attivita')) { showFeatureDisabledAlert('Completamento attivita'); handleTabChange('activities'); return; }
                 const completion = await completeActivity(nav.selectedActivityId, outcome);
                 if (!completion.ok) { window.alert(completion.error); handleTabChange('activities'); return; }
                 setActivityOutcome(outcome);
@@ -517,10 +517,10 @@ export function AppShell() {
           <Activities activities={visibleActivities} activeRole={roleJourneyEnabled ? selectedRole : undefined}
             slotsStatus={activitySlotsStatus} slotsLoading={activitySlotsLoading}
             isOnline={typeof navigator === 'undefined' ? true : navigator.onLine}
-            canStartActivities={isFeatureEnabled('mobile.action.activity_start')}
+            canStartActivities={isFeatureEnabled('avvia_attivita')}
             recommendedActivityId={roleJourneyEnabled ? recommendedActivityId : undefined}
             onStartActivity={(id: string) => {
-              if (!isFeatureEnabled('mobile.action.activity_start')) { showFeatureDisabledAlert('Avvio attivita'); return; }
+              if (!isFeatureEnabled('avvia_attivita')) { showFeatureDisabledAlert('Avvio attivita'); return; }
               nav.setSelectedActivityId(id); nav.navigate('activity-detail');
             }} />
         );

--- a/apps/mobile/src/handlers/useFeatureGates.ts
+++ b/apps/mobile/src/handlers/useFeatureGates.ts
@@ -16,12 +16,12 @@ export function useFeatureGates(
   isFeatureEnabled: (key: MobileFeatureFlagKey) => boolean,
 ) {
   const tabFlags = useMemo<TabFeatureFlags>(() => ({
-    turns: featureFlags['mobile.section.turns'],
-    leaderboard: featureFlags['mobile.section.leaderboard'],
-    activities: featureFlags['mobile.section.activities'],
-    shop: featureFlags['mobile.section.shop'],
-    career: featureFlags['mobile.section.career'],
-    earnedTitles: featureFlags['mobile.section.earned_titles'],
+    turns: featureFlags['turni'],
+    leaderboard: featureFlags['classifica'],
+    activities: featureFlags['attivita'],
+    shop: featureFlags['shop'],
+    career: featureFlags['carriera'],
+    earnedTitles: featureFlags['titoli'],
   }), [featureFlags]);
 
   const isTabEnabled = useCallback((tab: Tab) => {
@@ -40,10 +40,10 @@ export function useFeatureGates(
     if (screen === 'shop') return tabFlags.shop;
     if (screen === 'career') return tabFlags.career;
     if (screen === 'earned-titles') return tabFlags.earnedTitles;
-    if (screen === 'support') return isFeatureEnabled('mobile.action.ai_support');
-    if (screen === 'qr-scanner') return isFeatureEnabled('mobile.action.qr_scan');
-    if (screen === 'event-confirmation') return isFeatureEnabled('mobile.action.turn_submit');
-    if (screen === 'ticket-qr-prototype') return isFeatureEnabled('mobile.dev.ticket_qr_prototype');
+    if (screen === 'support') return isFeatureEnabled('supporto_ai');
+    if (screen === 'qr-scanner') return isFeatureEnabled('qr_scan');
+    if (screen === 'event-confirmation') return isFeatureEnabled('registra_turno');
+    if (screen === 'ticket-qr-prototype') return isFeatureEnabled('ticket_qr');
     return true;
   }, [isFeatureEnabled, tabFlags]);
 
@@ -66,8 +66,8 @@ export function useFeatureGates(
     isScreenEnabled,
     showFeatureDisabledAlert,
     enabledNavTabs,
-    canViewAiSupport: isFeatureEnabled('mobile.action.ai_support'),
-    canViewTicketQrPrototype: isFeatureEnabled('mobile.dev.ticket_qr_prototype'),
-    roleJourneyEnabled: isFeatureEnabled('mobile.section.role_journey'),
+    canViewAiSupport: isFeatureEnabled('supporto_ai'),
+    canViewTicketQrPrototype: isFeatureEnabled('ticket_qr'),
+    roleJourneyEnabled: isFeatureEnabled('percorso_ruolo'),
   };
 }

--- a/apps/mobile/src/handlers/useQrHandlers.ts
+++ b/apps/mobile/src/handlers/useQrHandlers.ts
@@ -78,7 +78,7 @@ export function useQrHandlers(deps: QrHandlerDeps) {
   } = deps;
 
   const handleQRScanAttempt = useCallback(async (code: string) => {
-    const qrScanEnabled = isFeatureEnabled('mobile.action.qr_scan');
+    const qrScanEnabled = isFeatureEnabled('qr_scan');
 
     if (!qrScanEnabled) {
       return { ok: false as const, error: 'Registrazione temporaneamente disattivata.' };
@@ -155,10 +155,10 @@ export function useQrHandlers(deps: QrHandlerDeps) {
     | { ok: true; syncStatus: TurnSyncStatus; boostRequested: boolean; boostApplied: boolean; boostRejectionReason: string | null; rewards: Rewards }
     | { ok: false; error: string }
   > => {
-    if (!isFeatureEnabled('mobile.action.turn_submit')) {
+    if (!isFeatureEnabled('registra_turno')) {
       return { ok: false, error: 'Registrazione turni temporaneamente disattivata.' };
     }
-    if (boostRequested && !isFeatureEnabled('mobile.action.turn_boost')) {
+    if (boostRequested && !isFeatureEnabled('boost_turno')) {
       return { ok: false, error: 'Boost turno temporaneamente disattivato.' };
     }
 

--- a/apps/mobile/src/services/feature-flags.ts
+++ b/apps/mobile/src/services/feature-flags.ts
@@ -25,7 +25,7 @@ export const MOBILE_FEATURE_FLAGS_FAIL_CLOSED = buildFlagState(false);
 export const MOBILE_FEATURE_FLAGS_ALL_ON = buildFlagState(true);
 export const MOBILE_FEATURE_FLAGS_DEFAULTS: MobileFeatureFlagsState = {
   ...MOBILE_FEATURE_FLAGS_ALL_ON,
-  "mobile.dev.ticket_qr_prototype": false,
+  "ticket_qr": false,
 };
 
 export type MobileFeatureFlagRow = {

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3871,13 +3871,13 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         return { ok: false, error: 'Evento non trovato.' };
       }
 
-      if (!featureFlags['mobile.action.turn_submit']) {
-        logOfflineSync('registerTurn aborted: feature disabled', { eventId, roleId, feature: 'mobile.action.turn_submit' }, 'warn');
+      if (!featureFlags['registra_turno']) {
+        logOfflineSync('registerTurn aborted: feature disabled', { eventId, roleId, feature: 'registra_turno' }, 'warn');
         return { ok: false, error: 'Registrazione turni temporaneamente disattivata.' };
       }
 
-      if (boostRequested && !featureFlags['mobile.action.turn_boost']) {
-        logOfflineSync('registerTurn aborted: boost feature disabled', { eventId, roleId, feature: 'mobile.action.turn_boost' }, 'warn');
+      if (boostRequested && !featureFlags['boost_turno']) {
+        logOfflineSync('registerTurn aborted: boost feature disabled', { eventId, roleId, feature: 'boost_turno' }, 'warn');
         return { ok: false, error: 'Boost turno temporaneamente disattivato.' };
       }
 
@@ -3892,7 +3892,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           ? globalThis.crypto.randomUUID()
           : `turn-${Date.now()}`;
 
-      const geofenceValidationEnabled = featureFlags['mobile.action.turn_geofence'];
+      const geofenceValidationEnabled = featureFlags['geofence'];
       const requiresServerGeolocation = geofenceValidationEnabled
         && isSupabaseConfigured
         && Boolean(supabase)
@@ -4135,7 +4135,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
   const purchaseShopItem = useCallback(
     async (itemCode: string, targetTheatre?: string | null): Promise<ShopPurchaseResult> => {
-      if (!featureFlags['mobile.action.shop_purchase']) {
+      if (!featureFlags['acquisti']) {
         return {
           ok: false,
           status: 'error',
@@ -4233,7 +4233,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       activityId: string,
       telemetry?: ActivityTelemetryInput
     ): Promise<CompleteActivityResult> => {
-      if (!featureFlags['mobile.action.activity_complete']) {
+      if (!featureFlags['completa_attivita']) {
         return { ok: false, error: 'Completamento attivita temporaneamente disattivato.' };
       }
       const activity = catalog.activities.find((item) => item.id === activityId);

--- a/shared/flags/catalog.ts
+++ b/shared/flags/catalog.ts
@@ -1,76 +1,40 @@
-export const PWA_FEATURE_FLAG_KEYS = [
-  "status-card",
-  "permissions-card",
-  "ai-support",
-  "home.main-actions",
-  "home.pwa-flags",
-  "cp.pwa-flags",
-  "cp.quick-presets",
-  "cp.command-wizard",
-  "cp.mobile-flags",
-  "cp.render-overview",
-  "cp.audit-overview",
-  "cp.db-overview",
-  "cp.footer-status",
-] as const;
-export type PwaFeatureFlagKey = (typeof PWA_FEATURE_FLAG_KEYS)[number];
-
-export const PWA_FEATURE_FLAG_DESCRIPTIONS: Record<PwaFeatureFlagKey, string> = {
-  "status-card": "Mostra i messaggi di stato ed errori sintetici nella dashboard.",
-  "permissions-card": "Mostra i ruoli e permessi della sessione utente nel control-plane.",
-  "ai-support": "Abilita i preset rapidi legati al supporto operativo assistito.",
-  "home.main-actions": "Mostra il blocco Azioni principali nella home PWA.",
-  "home.pwa-flags": "Mostra il riepilogo delle feature flag nella home PWA.",
-  "cp.pwa-flags": "Abilita la sezione toggle delle feature flag PWA nel control-plane.",
-  "cp.quick-presets": "Abilita la sezione preset rapidi nel control-plane.",
-  "cp.command-wizard": "Abilita il wizard comandi Step 1/2 nel control-plane.",
-  "cp.mobile-flags": "Abilita la sezione toggle delle feature flag mobile nel control-plane.",
-  "cp.render-overview": "Mostra la card panoramica rilasci e servizi Render.",
-  "cp.audit-overview": "Mostra la card registro operazioni recenti.",
-  "cp.db-overview": "Mostra la card panoramica operazioni database.",
-  "cp.footer-status": "Mostra il footer con last refresh e data source.",
-};
-
 export const MOBILE_FEATURE_FLAG_KEYS = [
-  "mobile.section.turns",
-  "mobile.section.leaderboard",
-  "mobile.section.activities",
-  "mobile.section.shop",
-  "mobile.section.career",
-  "mobile.section.earned_titles",
-  "mobile.section.role_journey",
-  "mobile.action.ai_support",
-  "mobile.action.qr_scan",
-  "mobile.action.turn_submit",
-  "mobile.action.turn_geofence",
-  "mobile.action.turn_boost",
-  "mobile.action.activity_start",
-  "mobile.action.activity_complete",
-  "mobile.action.shop_purchase",
-  "mobile.dev.ticket_qr_prototype",
+  "turni",
+  "classifica",
+  "attivita",
+  "shop",
+  "carriera",
+  "titoli",
+  "percorso_ruolo",
+  "supporto_ai",
+  "qr_scan",
+  "registra_turno",
+  "geofence",
+  "boost_turno",
+  "avvia_attivita",
+  "completa_attivita",
+  "acquisti",
+  "ticket_qr",
 ] as const;
 export type MobileFeatureFlagKey = (typeof MOBILE_FEATURE_FLAG_KEYS)[number];
 
 export const MOBILE_FEATURE_FLAG_DESCRIPTIONS: Record<MobileFeatureFlagKey, string> = {
-  "mobile.section.turns": "Mostra la sezione Turni ATCL nell'app mobile.",
-  "mobile.section.leaderboard": "Mostra la sezione Classifica nell'app mobile.",
-  "mobile.section.activities": "Mostra la sezione Attivita nell'app mobile.",
-  "mobile.section.shop": "Mostra la sezione Shop nell'app mobile.",
-  "mobile.section.career": "Mostra la sezione Carriera nell'app mobile.",
-  "mobile.section.earned_titles": "Mostra la sezione Titoli ottenuti nell'app mobile.",
-  "mobile.section.role_journey":
-    "Abilita il percorso ruolo con onboarding, ordinamento attivita e card dedicate nell'app mobile.",
-  "mobile.action.ai_support": "Abilita l'accesso al Supporto AI nelle impostazioni account dell'app mobile.",
-  "mobile.action.qr_scan": "Abilita la scansione QR nell'app mobile.",
-  "mobile.action.turn_submit": "Abilita la registrazione turni nell'app mobile.",
-  "mobile.action.turn_geofence":
-    "Abilita la validazione geofence in registrazione turno (coordinate + raggio teatro).",
-  "mobile.action.turn_boost": "Abilita il boost turno nell'app mobile.",
-  "mobile.action.activity_start": "Abilita l'avvio attivita simulate nell'app mobile.",
-  "mobile.action.activity_complete": "Abilita il completamento attivita simulate nell'app mobile.",
-  "mobile.action.shop_purchase": "Abilita gli acquisti nello shop mobile.",
-  "mobile.dev.ticket_qr_prototype":
-    "Abilita il prototipo developer per generazione e attivazione ticket QR nelle impostazioni account.",
+  turni: "Schermata Turni",
+  classifica: "Schermata Classifica",
+  attivita: "Schermata Attività",
+  shop: "Schermata Shop",
+  carriera: "Schermata Carriera",
+  titoli: "Schermata Titoli",
+  percorso_ruolo: "Percorso Ruolo",
+  supporto_ai: "Supporto AI",
+  qr_scan: "Scansione QR",
+  registra_turno: "Registra Turno",
+  geofence: "Validazione GPS",
+  boost_turno: "Boost Turno",
+  avvia_attivita: "Avvia Attività",
+  completa_attivita: "Completa Attività",
+  acquisti: "Acquisti Shop",
+  ticket_qr: "Ticket QR (dev)",
 };
 
 type FlagOption = {
@@ -106,22 +70,15 @@ function buildVercelFlagDefinitionRecord<K extends string>(
   ) as Record<K, VercelFlagDefinition>;
 }
 
-export const PWA_VERCEL_FLAG_DEFINITIONS = buildVercelFlagDefinitionRecord(
-  PWA_FEATURE_FLAG_KEYS,
-  PWA_FEATURE_FLAG_DESCRIPTIONS,
-  "pwa-runtime"
-);
-
 export const MOBILE_VERCEL_FLAG_DEFINITIONS = buildVercelFlagDefinitionRecord(
   MOBILE_FEATURE_FLAG_KEYS,
   MOBILE_FEATURE_FLAG_DESCRIPTIONS,
   "mobile-runtime"
 );
 
-export type VercelFlagKey = PwaFeatureFlagKey | MobileFeatureFlagKey;
+export type VercelFlagKey = MobileFeatureFlagKey;
 
 export const VERCEL_FLAG_DEFINITIONS: Record<VercelFlagKey, VercelFlagDefinition> = {
-  ...PWA_VERCEL_FLAG_DEFINITIONS,
   ...MOBILE_VERCEL_FLAG_DEFINITIONS,
 };
 


### PR DESCRIPTION
Ristruttura il catalogo feature flag per renderlo estremamente comprensibile ai non sviluppatori.

## Cambiamenti
- Rimosse tutte le PWA feature flag (lasciata solo l'interfaccia di gestione)
- Chiavi mobile semplificate: 
  - mobile.section.turns → 	urni
  - mobile.action.qr_scan → qr_scan
  - etc.
- Descrizioni accorciate in linguaggio comune (max 5 parole)
- Aggiornati tutti i riferimenti nel codice mobile

## Issue
Closes #439