### PR TITLE
Fix Dependabot #20: bump picomatch 4.0.3 → 4.0.4 (CVE-2026-33672)

### DIFF
--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -4096,9 +4096,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7199,19 +7199,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "overrides": {
     "minimatch": "^10.2.3",
+    "picomatch": "4.0.4",
     "rollup": "^4.59.0"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `picomatch: "4.0.4"` to the root `package.json` `overrides` so the workspace lockfile resolves the patched version
- Patches `apps/mobile/package-lock.json` directly (standalone lockfile, not controlled by workspace root install)
- Fixes CVE-2026-33672: method injection via POSIX character classes in glob patterns

## Details
**Alert**: GHSA-3v7f-55p6-f55p / CVE-2026-33672 — Medium (CVSS 5.3)  
**Package**: `picomatch` (transitive dev dependency via `vite`/`rollup`)  
**Before**: 4.0.3 | **After**: 4.0.4

The vulnerability allows method injection through specially crafted POSIX bracket expressions (e.g. `[[:constructor:]]`), causing incorrect glob matching. No RCE risk; integrity impact only when processing untrusted glob patterns.

## Test plan
- [ ] `npm install` completes without errors
- [ ] `npm run build:mobile` succeeds
- [ ] Dependabot alert #20 closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)