### PR TITLE
Redesign GitHub Pages: Teatro Oscuro theme

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,11 +5,14 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#120d0f">
+    <meta name="theme-color" content="#0d0a0b">
     {% seo %}
     <link rel="icon" type="image/png" sizes="192x192" href="{{ site_icon | relative_url }}">
     <link rel="shortcut icon" href="{{ site_icon | relative_url }}">
     <link rel="apple-touch-icon" href="{{ site_icon | relative_url }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;0,800;0,900;1,700;1,800;1,900&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     <link rel="stylesheet" href="{{ '/assets/css/pages-theme.css?v=' | append: site.github.build_revision | relative_url }}">
   </head>
@@ -17,18 +20,42 @@
     <a id="skip-to-content" href="#content">Vai al contenuto.</a>
 
     <div class="site-shell">
+
+      <!-- Stage curtain decorations -->
+      <div class="curtain-left" aria-hidden="true"></div>
+      <div class="curtain-right" aria-hidden="true"></div>
+
       <header class="page-header" role="banner">
         <div class="hero-inner">
-          <p class="hero-kicker">A.T.C.L. presenta</p>
+          <div class="hero-spotlight" aria-hidden="true"></div>
+
+          <p class="hero-kicker">
+            <span class="hero-kicker-line" aria-hidden="true"></span>
+            A.T.C.L. presenta
+            <span class="hero-kicker-line" aria-hidden="true"></span>
+          </p>
+
           {% if site.logo %}
-          <img class="project-logo" src="{{ site.logo | relative_url }}" alt="{{ site.title }}" width="96" height="96">
+          <div class="project-logo-wrap">
+            <div class="project-logo-ring" aria-hidden="true"></div>
+            <img class="project-logo" src="{{ site.logo | relative_url }}" alt="{{ site.title }}" width="96" height="96">
+          </div>
           {% endif %}
+
           <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
           <p class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</p>
+
           <div class="hero-actions">
             {% if site.app_url %}
-            <a href="{{ site.app_url }}" class="btn btn-primary">Apri l'app</a>
+            <a href="{{ site.app_url }}" class="btn btn-primary">
+              <span class="btn-shine" aria-hidden="true"></span>
+              Apri l'app
+            </a>
             {% endif %}
+          </div>
+
+          <div class="hero-ornament" aria-hidden="true">
+            <span></span><span></span><span></span>
           </div>
         </div>
       </header>
@@ -43,14 +70,35 @@
         {% endif %}
 
         <footer class="site-footer">
-          <span class="site-footer-owner">
-            {{ site.title }} &egrave; sviluppato da
-            <a href="https://atcllazio.it">A.T.C.L.</a>, Associazione Teatrale fra i Comuni del Lazio.
-          </span>
-          <span class="site-footer-credits">Pubblicato tramite <a href="https://pages.github.com">GitHub Pages</a>.</span>
-          <span class="site-footer-copyright">&copy; 2025 A.T.C.L. &mdash; Tutti i diritti riservati.</span>
+          <div class="footer-inner">
+            <div class="footer-brand">
+              {% if site.logo %}
+              <img src="{{ site.logo | relative_url }}" alt="{{ site.title }}" width="40" height="40" class="footer-logo">
+              {% endif %}
+              <div class="footer-brand-text">
+                <div class="footer-brand-name">{{ site.title }}</div>
+                <div class="footer-brand-sub">Il teatro come percorso</div>
+              </div>
+            </div>
+
+            <div class="footer-divider" aria-hidden="true"></div>
+
+            <div class="footer-info">
+              <p class="footer-info-text">
+                Sviluppato da <a href="https://atcllazio.it">A.T.C.L.</a> &mdash;
+                Associazione Teatrale fra i Comuni del Lazio.<br>
+                Promuove la cultura teatrale nel territorio laziale.
+              </p>
+            </div>
+
+            <div class="footer-meta">
+              <span>&copy; 2025 A.T.C.L. &mdash; Tutti i diritti riservati.</span>
+              <span>Pubblicato tramite <a href="https://pages.github.com">GitHub Pages</a>.</span>
+            </div>
+          </div>
         </footer>
       </main>
+
     </div>
   </body>
 </html>

--- a/assets/css/pages-theme.css
+++ b/assets/css/pages-theme.css
@@ -1,26 +1,40 @@
 /* =================================================================
    Turni di Palco — GitHub Pages Theme
+   "Teatro Oscuro" — Theatrical Dark, Art Deco Editorial
    ================================================================= */
 
-/* 1. Design tokens */
+/* ─── 0. Font import (fallback if <link> not loaded) ─── */
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;0,800;0,900;1,700;1,800;1,900&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&display=swap');
+
+/* ─── 1. Design tokens ─── */
 :root {
-  --tdp-bg: #120d0f;
-  --tdp-surface: rgba(28, 22, 24, 0.94);
-  --tdp-border: rgba(255, 255, 255, 0.07);
-  --tdp-border-gold: rgba(244, 191, 79, 0.18);
-  --tdp-text: #f8f3ee;
-  --tdp-text-muted: #cfc0ba;
-  --tdp-text-soft: #a99791;
-  --tdp-gold: #f4bf4f;
-  --tdp-gold-deep: #d08a16;
-  --tdp-shadow: 0 20px 56px rgba(0, 0, 0, 0.42);
-  --tdp-radius-xl: 26px;
-  --tdp-radius-lg: 18px;
-  --tdp-radius-md: 12px;
-  --tdp-width: 1120px;
+  --tdp-bg:              #0d0a0b;
+  --tdp-surface:         rgba(20, 14, 16, 0.96);
+  --tdp-surface-card:    rgba(24, 17, 20, 0.96);
+  --tdp-border:          rgba(255, 255, 255, 0.055);
+  --tdp-border-hover:    rgba(255, 255, 255, 0.1);
+  --tdp-border-gold:     rgba(244, 191, 79, 0.22);
+  --tdp-text:            #f5ede6;
+  --tdp-text-muted:      #c7b2a9;
+  --tdp-text-soft:       #907972;
+  --tdp-gold:            #f4bf4f;
+  --tdp-gold-light:      #fdd27c;
+  --tdp-gold-deep:       #c07a10;
+  --tdp-crimson:         #8c1f35;
+  --tdp-crimson-dark:    #550e1d;
+  --tdp-shadow-sm:       0 4px 16px rgba(0, 0, 0, 0.3);
+  --tdp-shadow-md:       0 12px 36px rgba(0, 0, 0, 0.42);
+  --tdp-shadow-lg:       0 28px 72px rgba(0, 0, 0, 0.6);
+  --tdp-width:           1140px;
+  --tdp-radius-xl:       28px;
+  --tdp-radius-lg:       20px;
+  --tdp-radius-md:       14px;
+  --tdp-radius-sm:       8px;
+  --tdp-font-display:    'Playfair Display', Georgia, 'Times New Roman', serif;
+  --tdp-font-body:       'DM Sans', -apple-system, system-ui, sans-serif;
 }
 
-/* 2. Base reset */
+/* ─── 2. Base reset ─── */
 *,
 *::before,
 *::after {
@@ -35,49 +49,102 @@ body {
   margin: 0;
   min-height: 100vh;
   color: var(--tdp-text);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, system-ui, sans-serif;
-  background:
-    radial-gradient(ellipse 80% 40% at 50% 0%, rgba(150, 32, 58, 0.2), transparent),
-    linear-gradient(180deg, #140e11 0%, #110c0e 50%, #151213 100%);
+  font-family: var(--tdp-font-body);
+  font-size: 1rem;
+  line-height: 1.65;
+  background-color: var(--tdp-bg);
+  background-image:
+    radial-gradient(ellipse 110% 55% at 50% -5%,  rgba(140, 31, 53, 0.2)  0%, transparent 65%),
+    radial-gradient(ellipse  60% 40% at 15% 55%,  rgba(86, 14, 29, 0.1)   0%, transparent 60%),
+    radial-gradient(ellipse  60% 40% at 85% 80%,  rgba(86, 14, 29, 0.08)  0%, transparent 60%);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 a {
   color: var(--tdp-gold);
+  text-decoration: none;
 }
-
 a:hover {
-  color: #ffd680;
+  color: var(--tdp-gold-light);
   text-decoration: none;
 }
 
+/* ─── 3. Skip link ─── */
 #skip-to-content {
   position: absolute;
   left: -9999px;
+  z-index: 999;
 }
-
 #skip-to-content:focus {
   left: 1rem;
   top: 1rem;
-  z-index: 100;
   padding: 0.75rem 1.25rem;
   border-radius: 999px;
   background: var(--tdp-gold);
-  color: #1e1200;
+  color: #1a0e04;
   font-weight: 700;
-  text-decoration: none;
 }
 
-/* 3. Layout shell */
+/* ─── 4. Stage curtains ─── */
+.curtain-left,
+.curtain-right {
+  position: fixed;
+  top: 0;
+  width: clamp(32px, 5.5vw, 88px);
+  height: 100vh;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.curtain-left {
+  left: 0;
+  background:
+    repeating-linear-gradient(
+      to right,
+      rgba(0, 0, 0, 0.18) 0px,
+      rgba(0, 0, 0, 0.18) 3px,
+      transparent          3px,
+      transparent          12px
+    ),
+    linear-gradient(
+      to right,
+      rgba(68, 13, 25, 0.8)  0%,
+      rgba(46,  9, 17, 0.45) 60%,
+      transparent            100%
+    );
+}
+
+.curtain-right {
+  right: 0;
+  background:
+    repeating-linear-gradient(
+      to left,
+      rgba(0, 0, 0, 0.18) 0px,
+      rgba(0, 0, 0, 0.18) 3px,
+      transparent          3px,
+      transparent          12px
+    ),
+    linear-gradient(
+      to left,
+      rgba(68, 13, 25, 0.8)  0%,
+      rgba(46,  9, 17, 0.45) 60%,
+      transparent            100%
+    );
+}
+
+/* ─── 5. Layout shell ─── */
 .site-shell {
   position: relative;
   overflow: hidden;
 }
 
-/* Override Cayman default header background */
+/* ─── 6. Page header — override Cayman completely ─── */
 .page-header {
-  background-color: transparent;
-  background-image: none;
-  padding: 2.5rem 1.5rem 2rem;
+  background-color: transparent !important;
+  background-image: none !important;
+  padding: 2.75rem 1.5rem 2.25rem !important;
+  position: relative;
 }
 
 .hero-inner,
@@ -87,161 +154,343 @@ a:hover {
 }
 
 .hero-inner {
-  padding: 2rem 2.25rem;
-  border: 1px solid var(--tdp-border);
+  position: relative;
+  padding: 3rem 2.75rem 2.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-top: 1px solid rgba(244, 191, 79, 0.16);
   border-radius: var(--tdp-radius-xl);
-  background: linear-gradient(180deg, rgba(36, 28, 31, 0.96), rgba(20, 15, 17, 0.94));
-  box-shadow: var(--tdp-shadow);
-  backdrop-filter: blur(14px);
+  background:
+    linear-gradient(
+      175deg,
+      rgba(36, 24, 29, 0.97) 0%,
+      rgba(16, 11, 13, 0.97) 100%
+    );
+  box-shadow:
+    var(--tdp-shadow-lg),
+    inset 0 1px 0 rgba(244, 191, 79, 0.08);
+  backdrop-filter: blur(18px);
   text-align: center;
+  overflow: hidden;
 }
 
-.main-content {
-  padding: 0 1.5rem 3rem;
-  text-align: left;
+/* Subtle grain on hero panel */
+.hero-inner::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
+  background-size: 200px 200px;
+  pointer-events: none;
+  border-radius: inherit;
+  opacity: 0.5;
 }
 
-/* 4. Hero */
+/* Spotlight glow in hero */
+.hero-spotlight {
+  position: absolute;
+  top: -100px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 800px;
+  height: 600px;
+  background: radial-gradient(
+    ellipse 50% 55% at 50% 5%,
+    rgba(244, 191, 79, 0.065) 0%,
+    rgba(140,  31,  53, 0.055) 45%,
+    transparent 75%
+  );
+  pointer-events: none;
+  animation: spotlight-breathe 5.5s ease-in-out infinite alternate;
+}
+
+@keyframes spotlight-breathe {
+  from { opacity: 0.65; transform: translateX(-50%) scaleY(0.94); }
+  to   { opacity: 1;    transform: translateX(-50%) scaleY(1.06); }
+}
+
+/* ─── 7. Hero typography — override Cayman ─── */
 .hero-kicker {
-  margin: 0 0 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin: 0 0 1.75rem;
+  padding: 0;
   color: var(--tdp-gold);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.3em;
+  font-family: var(--tdp-font-body);
+  font-size: 0.63rem;
+  font-weight: 600;
+  letter-spacing: 0.4em;
   text-transform: uppercase;
+  animation: hero-rise 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: 0.1s;
+}
+
+.hero-kicker-line {
+  display: block;
+  flex: 0 0 24px;
+  height: 1px;
+}
+.hero-kicker-line:first-child {
+  background: linear-gradient(to right, transparent, rgba(244, 191, 79, 0.55));
+}
+.hero-kicker-line:last-child {
+  background: linear-gradient(to left, transparent, rgba(244, 191, 79, 0.55));
+}
+
+.project-logo-wrap {
+  position: relative;
+  display: inline-block;
+  margin-bottom: 1.75rem;
+  animation: hero-rise 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: 0.25s;
+}
+
+.project-logo-ring {
+  position: absolute;
+  inset: -8px;
+  border-radius: 30px;
+  border: 1px solid rgba(244, 191, 79, 0.28);
+  box-shadow:
+    0 0 18px rgba(244, 191, 79, 0.1),
+    0 0 50px rgba(140,  31,  53, 0.18);
+  animation: logo-glow 3.5s ease-in-out infinite alternate;
+}
+
+@keyframes logo-glow {
+  from {
+    border-color:  rgba(244, 191, 79, 0.18);
+    box-shadow:
+      0 0 12px rgba(244, 191, 79, 0.08),
+      0 0 36px rgba(140,  31, 53, 0.12);
+  }
+  to {
+    border-color:  rgba(244, 191, 79, 0.52);
+    box-shadow:
+      0 0 28px rgba(244, 191, 79, 0.22),
+      0 0 80px rgba(140,  31, 53, 0.22);
+  }
 }
 
 .project-logo {
   display: block;
-  margin: 0 auto 1.5rem;
   border-radius: 22px;
-  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.3);
+  position: relative;
+  z-index: 1;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 }
 
 .project-name {
-  margin: 0;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: clamp(2.8rem, 6vw, 5rem);
-  line-height: 0.96;
-  letter-spacing: -0.03em;
+  margin: 0 !important;
+  font-family: var(--tdp-font-display) !important;
+  font-size: clamp(3rem, 7.5vw, 5.8rem) !important;
+  font-weight: 900 !important;
+  font-style: italic !important;
+  line-height: 0.92 !important;
+  letter-spacing: -0.03em !important;
+  color: var(--tdp-text) !important;
+  text-shadow:
+    0 2px 40px rgba(244, 191, 79, 0.1),
+    0 0  80px rgba(140,  31, 53, 0.12);
   text-wrap: balance;
+  animation: hero-rise 0.9s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: 0.38s;
 }
 
 .project-tagline {
-  margin: 0.9rem auto 0;
-  color: var(--tdp-text-muted);
-  font-size: clamp(1.1rem, 2vw, 1.5rem);
-  font-weight: 400;
-  max-width: 34ch;
+  margin: 1.15rem auto 0 !important;
+  color: var(--tdp-text-muted) !important;
+  font-family: var(--tdp-font-body) !important;
+  font-size: clamp(1.05rem, 1.9vw, 1.4rem) !important;
+  font-weight: 300 !important;
+  letter-spacing: 0.01em;
+  max-width: 36ch;
+  animation: hero-rise 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: 0.55s;
 }
 
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 0.8rem;
-  margin-top: 1.75rem;
+  gap: 0.9rem;
+  margin-top: 2rem;
+  animation: hero-rise 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: 0.7s;
 }
 
-/* 5. Buttons */
+.hero-ornament {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  margin-top: 2.25rem;
+  animation: hero-rise 0.6s ease both;
+  animation-delay: 0.88s;
+}
+
+.hero-ornament span { display: block; }
+
+.hero-ornament span:nth-child(1),
+.hero-ornament span:nth-child(3) {
+  height: 1px;
+  width: 40px;
+  background: linear-gradient(90deg, transparent, rgba(244, 191, 79, 0.32), transparent);
+}
+
+.hero-ornament span:nth-child(2) {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--tdp-gold);
+  opacity: 0.55;
+  box-shadow: 0 0 8px rgba(244, 191, 79, 0.5);
+}
+
+@keyframes hero-rise {
+  from {
+    opacity: 0;
+    transform: translateY(22px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ─── 8. Buttons ─── */
 .btn {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 46px;
-  padding: 0.75rem 1.35rem;
+  min-height: 48px;
+  padding: 0.75rem 1.65rem;
   border: 1px solid transparent;
   border-radius: 999px;
-  font-size: 0.94rem;
-  font-weight: 700;
-  text-decoration: none;
-  transition: transform, box-shadow, background-color, border-color 160ms ease;
+  font-family: var(--tdp-font-body);
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-decoration: none !important;
+  overflow: hidden;
+  transition:
+    transform     200ms ease,
+    box-shadow    200ms ease,
+    background    200ms ease,
+    border-color  200ms ease;
+}
+.btn:hover {
+  transform: translateY(-2px);
+  text-decoration: none !important;
 }
 
-.btn:hover {
-  transform: translateY(-1px);
-  text-decoration: none;
+/* Shine sweep */
+.btn-shine {
+  position: absolute;
+  top: 0;
+  left: -90%;
+  width: 55%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+  transition: left 0.55s ease;
+  pointer-events: none;
+}
+.btn:hover .btn-shine {
+  left: 150%;
 }
 
 .btn-primary {
-  color: #1e1200;
-  background: linear-gradient(135deg, #f4bf4f 0%, #d98c18 100%);
-  box-shadow: 0 8px 24px rgba(208, 138, 22, 0.24);
+  color: #1a0e04 !important;
+  background: linear-gradient(135deg, var(--tdp-gold-light) 0%, var(--tdp-gold) 55%, var(--tdp-gold-deep) 100%);
+  box-shadow: 0 8px 28px rgba(192, 122, 16, 0.3);
 }
-
 .btn-primary:hover {
-  color: #1e1200;
-  box-shadow: 0 12px 32px rgba(208, 138, 22, 0.36);
+  color: #1a0e04 !important;
+  box-shadow: 0 14px 44px rgba(192, 122, 16, 0.46);
 }
 
 .btn-secondary {
-  color: var(--tdp-text);
+  color: var(--tdp-text) !important;
   background: rgba(255, 255, 255, 0.04);
-  border-color: rgba(255, 255, 255, 0.11);
+  border-color: rgba(255, 255, 255, 0.1);
 }
-
 .btn-secondary:hover {
-  color: var(--tdp-text);
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(244, 191, 79, 0.28);
+  color: var(--tdp-text) !important;
+  background: rgba(255, 255, 255, 0.07);
+  border-color: rgba(244, 191, 79, 0.3);
 }
 
-/* 6. Content panel (documentation pages) */
+/* ─── 9. Main content layout ─── */
+.main-content {
+  padding: 0 1.5rem 4rem;
+  text-align: left;
+}
+
+.main-content-landing {
+  padding-top: 0.5rem;
+}
+
+/* ─── 10. Content panel (doc pages) ─── */
 .content-panel {
-  padding: 2.25rem 2.5rem;
+  padding: 2.5rem 2.75rem;
   border: 1px solid var(--tdp-border);
+  border-top: 1px solid rgba(244, 191, 79, 0.12);
   border-radius: var(--tdp-radius-xl);
-  background: linear-gradient(180deg, rgba(28, 22, 24, 0.96), rgba(18, 13, 15, 0.98));
-  box-shadow: var(--tdp-shadow);
+  background: linear-gradient(175deg, rgba(26, 18, 22, 0.97), rgba(14, 10, 12, 0.98));
+  box-shadow: var(--tdp-shadow-md);
 }
 
-/* 7. Content typography (markdown-rendered pages) */
+/* ─── 11. Markdown typography ─── */
 .main-content h1,
 .main-content h2,
 .main-content h3,
 .main-content h4 {
-  font-family: Georgia, "Times New Roman", serif;
-  letter-spacing: -0.02em;
+  font-family: var(--tdp-font-display);
+  letter-spacing: -0.025em;
   color: var(--tdp-text);
   text-align: left;
 }
 
 .main-content h1 {
   font-size: clamp(2rem, 4vw, 3.2rem);
+  font-style: italic;
 }
 
 .main-content h2 {
-  margin-top: 2.5rem;
-  padding-top: 1rem;
-  border-top: 1px solid rgba(244, 191, 79, 0.14);
-  font-size: clamp(1.5rem, 2.4vw, 2rem);
+  margin-top: 2.75rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(244, 191, 79, 0.1);
+  font-size: clamp(1.5rem, 2.5vw, 2.1rem);
 }
 
 .main-content h3 {
-  font-size: 1.25rem;
+  font-size: 1.3rem;
 }
 
 .main-content p,
 .main-content li {
   color: var(--tdp-text-muted);
-  line-height: 1.75;
+  line-height: 1.8;
   text-align: left;
+  font-family: var(--tdp-font-body);
 }
 
 .main-content strong {
   color: var(--tdp-text);
+  font-weight: 600;
 }
 
 .main-content hr {
   height: 1px;
-  margin: 2rem 0;
+  margin: 2.5rem 0;
   border: 0;
-  background: linear-gradient(90deg, transparent, rgba(244, 191, 79, 0.38), transparent);
+  background: linear-gradient(90deg, transparent, rgba(244, 191, 79, 0.35), transparent);
 }
 
 .main-content ul,
 .main-content ol {
-  padding-left: 1.4rem;
+  padding-left: 1.5rem;
 }
 
 .main-content li + li {
@@ -249,17 +498,17 @@ a:hover {
 }
 
 .main-content code {
-  padding: 0.18rem 0.42rem;
-  border-radius: 0.4rem;
-  background: rgba(244, 191, 79, 0.1);
+  padding: 0.18rem 0.44rem;
+  border-radius: var(--tdp-radius-sm);
+  background: rgba(244, 191, 79, 0.09);
   color: #ffd99a;
-  font-size: 0.91em;
+  font-size: 0.9em;
 }
 
 .main-content pre {
-  padding: 1.2rem 1.5rem;
+  padding: 1.35rem 1.6rem;
   border-radius: var(--tdp-radius-md);
-  background: rgba(0, 0, 0, 0.36);
+  background: rgba(0, 0, 0, 0.4);
   border: 1px solid var(--tdp-border);
   overflow-x: auto;
 }
@@ -275,7 +524,7 @@ a:hover {
   height: auto;
   border-radius: var(--tdp-radius-md);
   border: 1px solid var(--tdp-border);
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.24);
+  box-shadow: var(--tdp-shadow-sm);
 }
 
 .main-content table {
@@ -285,172 +534,360 @@ a:hover {
 }
 
 .main-content th {
-  padding: 0.55rem 0.85rem;
+  padding: 0.6rem 0.9rem;
   text-align: left;
-  border-bottom: 1px solid rgba(244, 191, 79, 0.2);
+  border-bottom: 1px solid rgba(244, 191, 79, 0.18);
   color: var(--tdp-text);
-  font-weight: 700;
+  font-weight: 600;
+  font-family: var(--tdp-font-body);
 }
 
 .main-content td {
-  padding: 0.55rem 0.85rem;
+  padding: 0.6rem 0.9rem;
   border-bottom: 1px solid var(--tdp-border);
   color: var(--tdp-text-muted);
   vertical-align: middle;
+  font-family: var(--tdp-font-body);
 }
 
 .main-content tr:last-child td {
   border-bottom: 0;
 }
 
-/* 8. Footer */
+/* ─── 12. Footer ─── */
 .site-footer {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 0.5rem 1.5rem;
-  margin-top: 1.5rem;
-  padding-top: 1rem;
+  margin-top: 3rem;
+  padding: 2rem 0 0;
   border-top: 1px solid var(--tdp-border);
-  color: var(--tdp-text-soft);
-  font-size: 0.87rem;
-  text-align: left;
 }
 
-.site-footer a {
+.footer-inner {
+  display: grid;
+  grid-template-areas:
+    "brand  divider  info"
+    "meta   meta     meta";
+  grid-template-columns: auto 1px 1fr;
+  gap: 1rem 2rem;
+  align-items: center;
+}
+
+.footer-brand {
+  grid-area: brand;
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.footer-logo {
+  border-radius: 10px;
+  opacity: 0.82;
+  flex-shrink: 0;
+}
+
+.footer-brand-name {
+  font-family: var(--tdp-font-display);
+  font-size: 1.05rem;
+  font-weight: 700;
+  font-style: italic;
+  color: var(--tdp-text);
+  letter-spacing: -0.02em;
+}
+
+.footer-brand-sub {
+  font-family: var(--tdp-font-body);
+  font-size: 0.74rem;
+  color: var(--tdp-text-soft);
+  letter-spacing: 0.04em;
+  margin-top: 0.1rem;
+}
+
+.footer-divider {
+  grid-area: divider;
+  background: var(--tdp-border);
+  align-self: stretch;
+  margin: 0.25rem 0;
+}
+
+.footer-info {
+  grid-area: info;
+}
+
+.footer-info-text {
+  margin: 0;
+  color: var(--tdp-text-soft);
+  font-family: var(--tdp-font-body);
+  font-size: 0.85rem;
+  line-height: 1.75;
+}
+
+.footer-info-text a {
   color: var(--tdp-text-muted);
 }
 
-.site-footer-copyright {
-  flex-basis: 100%;
-  text-align: center;
-  margin-top: 0.25rem;
+.footer-info-text a:hover {
+  color: var(--tdp-gold);
 }
 
-/* 9. Landing page */
-.main-content-landing {
-  padding-top: 0.25rem;
+.footer-meta {
+  grid-area: meta;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1.5rem;
+  margin-top: 0.5rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--tdp-border);
+  color: var(--tdp-text-soft);
+  font-family: var(--tdp-font-body);
+  font-size: 0.79rem;
 }
 
+.footer-meta a {
+  color: var(--tdp-text-soft);
+}
+
+.footer-meta a:hover {
+  color: var(--tdp-gold);
+}
+
+/* ─── 13. Landing page compositor ─── */
 .landing-composer {
   display: grid;
-  gap: 1.25rem;
+  gap: 1.5rem;
+}
+
+/* Scroll-driven reveal (progressive enhancement) */
+@supports (animation-timeline: view()) {
+  .landing-block {
+    animation: block-in linear both;
+    animation-timeline: view();
+    animation-range: entry 0% entry 28%;
+  }
+
+  @keyframes block-in {
+    from {
+      opacity: 0;
+      transform: translateY(30px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
 }
 
 /* Section label */
 .section-label {
-  display: inline-block;
-  margin-bottom: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin-bottom: 0.85rem;
   color: var(--tdp-gold);
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.26em;
+  font-family: var(--tdp-font-body);
+  font-size: 0.63rem;
+  font-weight: 600;
+  letter-spacing: 0.38em;
   text-transform: uppercase;
+}
+
+.section-label::before {
+  content: '';
+  display: block;
+  width: 14px;
+  height: 1px;
+  background: var(--tdp-gold);
+  opacity: 0.55;
+  flex-shrink: 0;
 }
 
 /* Generic block card */
 .landing-block {
-  padding: 1.75rem;
+  padding: 2rem 2.25rem;
   border: 1px solid var(--tdp-border);
   border-radius: var(--tdp-radius-xl);
-  background: linear-gradient(180deg, rgba(28, 22, 25, 0.94), rgba(19, 15, 17, 0.94));
-  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.2);
+  background: linear-gradient(
+    160deg,
+    rgba(26, 18, 21, 0.96) 0%,
+    rgba(15, 11, 13, 0.97) 100%
+  );
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.22);
   text-align: left;
+  position: relative;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+/* Top gold accent line on hover */
+.landing-block:not(.landing-block-cta)::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 2rem;
+  right: 2rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(244, 191, 79, 0.55), transparent);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  border-radius: 0;
+}
+
+.landing-block:not(.landing-block-cta):hover::before {
+  opacity: 1;
+}
+
+.landing-block:not(.landing-block-cta):hover {
+  border-color: rgba(244, 191, 79, 0.1);
+  box-shadow: 0 14px 44px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(244, 191, 79, 0.04);
 }
 
 .landing-block-head {
   max-width: 54rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.75rem;
 }
 
 .landing-block-head h2 {
   margin: 0;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: clamp(1.7rem, 3vw, 2.6rem);
-  line-height: 1.1;
+  font-family: var(--tdp-font-display);
+  font-style: italic;
+  font-size: clamp(1.85rem, 3.2vw, 2.9rem);
+  line-height: 1.07;
   letter-spacing: -0.03em;
   text-wrap: balance;
+  color: var(--tdp-text);
 }
 
 .landing-support-copy {
-  margin: 0.7rem 0 0;
+  margin: 0.85rem 0 0;
   color: var(--tdp-text-soft);
-  line-height: 1.7;
-}
-
-/* Intro block */
-.landing-block h2 {
-  margin: 0;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: clamp(1.8rem, 3.2vw, 2.8rem);
-  line-height: 1.08;
-  letter-spacing: -0.03em;
-  text-wrap: balance;
-}
-
-.landing-intro-copy {
-  margin: 0.75rem 0 0;
-  max-width: 56ch;
-  color: var(--tdp-text-soft);
+  font-family: var(--tdp-font-body);
+  font-size: 0.96rem;
   line-height: 1.72;
 }
 
+/* Intro h2 */
+.landing-block > h2 {
+  margin: 0;
+  font-family: var(--tdp-font-display);
+  font-style: italic;
+  font-size: clamp(1.9rem, 3.6vw, 3.1rem);
+  line-height: 1.06;
+  letter-spacing: -0.03em;
+  text-wrap: balance;
+  color: var(--tdp-text);
+}
+
+.landing-intro-copy {
+  margin: 0.85rem 0 0;
+  max-width: 58ch;
+  color: var(--tdp-text-muted);
+  font-family: var(--tdp-font-body);
+  font-size: 0.97rem;
+  line-height: 1.8;
+}
+
+/* ─── 14. Pills ─── */
 .landing-pill-row {
   display: flex;
   flex-wrap: wrap;
   gap: 0.55rem;
-  margin-top: 1.1rem;
+  margin-top: 1.3rem;
 }
 
 .landing-pill {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  padding: 0.28rem 0.8rem;
+  padding: 0.3rem 0.88rem;
   border-radius: 999px;
-  background: rgba(244, 191, 79, 0.1);
+  background: rgba(244, 191, 79, 0.08);
   border: 1px solid rgba(244, 191, 79, 0.18);
   color: var(--tdp-gold);
-  font-size: 0.74rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
+  font-family: var(--tdp-font-body);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.09em;
   text-transform: uppercase;
+  overflow: hidden;
+  transition: background 0.22s ease, border-color 0.22s ease;
 }
 
+.landing-pill::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -85%;
+  width: 60%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.15), transparent);
+  transition: left 0.48s ease;
+}
+
+.landing-pill:hover {
+  background: rgba(244, 191, 79, 0.13);
+  border-color: rgba(244, 191, 79, 0.33);
+}
+
+.landing-pill:hover::after {
+  left: 145%;
+}
+
+/* ─── 15. Value cards (Partecipa / Gioca / Cresci) ─── */
 .intro-values {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1rem;
-  margin-top: 1.5rem;
-}
-
-@media (max-width: 1060px) and (min-width: 860px) {
-  .intro-values {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  margin-top: 1.75rem;
 }
 
 .intro-value {
-  padding: 1.1rem 1.25rem;
+  padding: 1.3rem 1.45rem;
   border: 1px solid var(--tdp-border);
   border-radius: var(--tdp-radius-lg);
-  background: rgba(255, 255, 255, 0.025);
+  background: rgba(255, 255, 255, 0.022);
+  position: relative;
+  overflow: hidden;
+  transition: border-color 0.25s ease, background 0.25s ease, transform 0.28s ease;
+}
+
+.intro-value::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(244, 191, 79, 0.38), transparent);
+  transform: scaleX(0);
+  transition: transform 0.38s ease;
+}
+
+.intro-value:hover {
+  border-color: rgba(244, 191, 79, 0.18);
+  background: rgba(244, 191, 79, 0.035);
+  transform: translateY(-3px);
+}
+
+.intro-value:hover::before {
+  transform: scaleX(1);
 }
 
 .intro-value strong {
   display: block;
-  margin-bottom: 0.35rem;
+  margin-bottom: 0.42rem;
+  font-family: var(--tdp-font-display);
+  font-style: italic;
+  font-size: 1.08rem;
   color: var(--tdp-text);
-  font-size: 1rem;
+  letter-spacing: -0.015em;
 }
 
 .intro-value span {
   display: block;
   color: var(--tdp-text-muted);
-  font-size: 0.9rem;
-  line-height: 1.65;
+  font-family: var(--tdp-font-body);
+  font-size: 0.88rem;
+  line-height: 1.67;
 }
 
-/* Feature cards */
+/* ─── 16. Feature panels ─── */
 .feature-stack {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -458,40 +895,80 @@ a:hover {
 }
 
 .feature-panel {
-  padding: 1.35rem;
+  padding: 1.5rem 1.65rem;
   border: 1px solid var(--tdp-border);
   border-radius: var(--tdp-radius-lg);
-  background: rgba(255, 255, 255, 0.025);
+  background: rgba(255, 255, 255, 0.022);
+  position: relative;
+  overflow: hidden;
+  transition:
+    transform     0.3s cubic-bezier(0.34, 1.2, 0.64, 1),
+    border-color  0.3s ease,
+    box-shadow    0.3s ease;
+}
+
+/* Colour-wash sweep on hover */
+.feature-panel::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    var(--tdp-crimson-dark),
+    var(--tdp-gold),
+    var(--tdp-crimson-dark)
+  );
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.48s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.feature-panel:hover {
+  transform: translateY(-6px);
+  border-color: rgba(244, 191, 79, 0.2);
+  box-shadow: 0 24px 56px rgba(0, 0, 0, 0.36), 0 0 0 1px rgba(244, 191, 79, 0.06);
+}
+
+.feature-panel:hover::before {
+  transform: scaleX(1);
 }
 
 .feature-kicker {
   display: inline-flex;
-  padding: 0.25rem 0.7rem;
+  padding: 0.27rem 0.78rem;
   border-radius: 999px;
   background: rgba(244, 191, 79, 0.1);
+  border: 1px solid rgba(244, 191, 79, 0.16);
   color: var(--tdp-gold);
-  font-size: 0.7rem;
-  font-weight: 700;
+  font-family: var(--tdp-font-body);
+  font-size: 0.67rem;
+  font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
 }
 
 .feature-panel h3 {
-  margin: 0.85rem 0 0;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: 1.2rem;
-  line-height: 1.28;
-  letter-spacing: -0.02em;
+  margin: 1rem 0 0;
+  font-family: var(--tdp-font-display);
+  font-style: italic;
+  font-size: 1.28rem;
+  line-height: 1.24;
+  letter-spacing: -0.025em;
+  color: var(--tdp-text);
 }
 
 .feature-panel p {
-  margin: 0.6rem 0 0;
+  margin: 0.65rem 0 0;
   color: var(--tdp-text-muted);
-  font-size: 0.93rem;
-  line-height: 1.7;
+  font-family: var(--tdp-font-body);
+  font-size: 0.92rem;
+  line-height: 1.74;
 }
 
-/* User flow */
+/* ─── 17. User flow ─── */
 .landing-flow {
   margin: 0;
   padding: 0;
@@ -503,96 +980,143 @@ a:hover {
 .landing-flow li {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 1.1rem;
+  gap: 1.5rem;
   align-items: start;
-  padding: 1.1rem 0;
+  padding: 1.4rem 0;
   border-bottom: 1px solid var(--tdp-border);
 }
 
-.landing-flow li:first-child {
-  padding-top: 0;
-}
-
-.landing-flow li:last-child {
-  padding-bottom: 0;
-  border-bottom: 0;
-}
+.landing-flow li:first-child { padding-top: 0; }
+.landing-flow li:last-child  { padding-bottom: 0; border-bottom: 0; }
 
 .landing-flow-index {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.8rem;
-  height: 2.8rem;
-  border-radius: 14px;
-  background: rgba(244, 191, 79, 0.1);
-  border: 1px solid rgba(244, 191, 79, 0.22);
+  width: 3rem;
+  height: 3rem;
+  border-radius: var(--tdp-radius-md);
+  background: rgba(244, 191, 79, 0.08);
+  border: 1px solid rgba(244, 191, 79, 0.2);
   color: var(--tdp-gold);
-  font-size: 0.86rem;
-  font-weight: 800;
-  letter-spacing: 0.04em;
+  font-family: var(--tdp-font-display);
+  font-size: 1rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  transition: background 0.25s ease, border-color 0.25s ease, transform 0.28s ease;
+}
+
+.landing-flow li:hover .landing-flow-index {
+  background: rgba(244, 191, 79, 0.14);
+  border-color: rgba(244, 191, 79, 0.4);
+  transform: scale(1.07);
 }
 
 .landing-flow h3 {
   margin: 0;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: 1.2rem;
-  line-height: 1.28;
+  font-family: var(--tdp-font-display);
+  font-style: italic;
+  font-size: 1.28rem;
+  line-height: 1.24;
+  letter-spacing: -0.025em;
+  color: var(--tdp-text);
 }
 
 .landing-flow p {
-  margin: 0.4rem 0 0;
+  margin: 0.45rem 0 0;
   color: var(--tdp-text-muted);
+  font-family: var(--tdp-font-body);
   font-size: 0.93rem;
-  line-height: 1.7;
+  line-height: 1.74;
 }
 
-/* Screenshot gallery */
+/* ─── 18. Screenshot gallery — phone mockup frames ─── */
 .showcase-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-@media (max-width: 1199px) {
-  .showcase-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 900px) {
-  .showcase-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  gap: 1.25rem;
 }
 
 .showcase-card {
-  margin: 0;
-  padding: 0.75rem;
-  border: 1px solid var(--tdp-border);
-  border-radius: var(--tdp-radius-lg);
-  background: rgba(255, 255, 255, 0.02);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
 }
 
-.showcase-card img {
+/* Phone frame */
+.phone-frame {
+  position: relative;
+  border-radius: 36px;
+  background: #0e0b0c;
+  border: 6px solid rgba(255, 255, 255, 0.09);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.055),
+    0 30px 64px rgba(0, 0, 0, 0.56),
+    0 8px 20px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+  transition:
+    transform   0.38s cubic-bezier(0.34, 1.2, 0.64, 1),
+    box-shadow  0.38s ease;
+}
+
+/* Notch */
+.phone-frame::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 62px;
+  height: 22px;
+  background: #0e0b0c;
+  border-radius: 0 0 14px 14px;
+  z-index: 5;
+}
+
+/* Screen reflection */
+.phone-frame::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    130deg,
+    rgba(255, 255, 255, 0.04) 0%,
+    transparent 42%
+  );
+  pointer-events: none;
+  z-index: 4;
+  border-radius: inherit;
+}
+
+.phone-frame img {
   display: block;
   width: 100%;
-  aspect-ratio: 9 / 16;
+  aspect-ratio: 9 / 19.5;
   object-fit: cover;
-  border-radius: 10px;
-  border: none;
-  box-shadow: none;
+  border-radius: 30px;
+  position: relative;
+  z-index: 1;
+}
+
+.showcase-card:hover .phone-frame {
+  transform: translateY(-10px) scale(1.025);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 50px 88px rgba(0, 0, 0, 0.64),
+    0 0 0 1px rgba(244, 191, 79, 0.09),
+    0 8px 24px rgba(244, 191, 79, 0.05);
 }
 
 .showcase-card figcaption {
-  padding: 0.8rem 0.2rem 0.2rem;
+  padding: 0 0.3rem;
   color: var(--tdp-text-muted);
-  font-size: 0.84rem;
+  font-family: var(--tdp-font-body);
+  font-size: 0.82rem;
   line-height: 1.58;
-  text-align: left;
+  text-align: center;
 }
 
-/* Audience cards */
+/* ─── 19. Audience panels ─── */
 .audience-stack {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -600,84 +1124,168 @@ a:hover {
 }
 
 .audience-panel {
-  padding: 1.35rem;
+  padding: 1.5rem 1.65rem;
   border: 1px solid var(--tdp-border);
   border-radius: var(--tdp-radius-lg);
-  background: rgba(255, 255, 255, 0.025);
+  background: rgba(255, 255, 255, 0.022);
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+/* Bottom gold accent on hover */
+.audience-panel::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(244, 191, 79, 0.4), transparent);
+  transform: scaleX(0);
+  transition: transform 0.4s ease;
+}
+
+.audience-panel:hover {
+  transform: translateY(-4px);
+  border-color: rgba(244, 191, 79, 0.16);
+}
+
+.audience-panel:hover::after {
+  transform: scaleX(1);
 }
 
 .audience-tag {
   display: inline-flex;
-  padding: 0.25rem 0.7rem;
+  padding: 0.27rem 0.78rem;
   border-radius: 999px;
   background: rgba(244, 191, 79, 0.1);
+  border: 1px solid rgba(244, 191, 79, 0.16);
   color: var(--tdp-gold);
-  font-size: 0.7rem;
-  font-weight: 700;
+  font-family: var(--tdp-font-body);
+  font-size: 0.67rem;
+  font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
 }
 
 .audience-panel h3 {
-  margin: 0.85rem 0 0;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: 1.2rem;
-  line-height: 1.28;
-  letter-spacing: -0.02em;
+  margin: 1rem 0 0;
+  font-family: var(--tdp-font-display);
+  font-style: italic;
+  font-size: 1.24rem;
+  line-height: 1.24;
+  letter-spacing: -0.025em;
+  color: var(--tdp-text);
 }
 
 .audience-panel p {
   margin: 0.6rem 0 0;
   color: var(--tdp-text-muted);
-  font-size: 0.93rem;
-  line-height: 1.7;
+  font-family: var(--tdp-font-body);
+  font-size: 0.92rem;
+  line-height: 1.73;
 }
 
-/* CTA section */
+/* ─── 20. CTA section ─── */
 .landing-block-cta {
-  padding: 0;
-  border: 0;
-  background: transparent;
-  box-shadow: none;
+  padding: 0 !important;
+  border: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
 }
 
 .landing-cta-panel {
+  position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 1.25rem 2rem;
+  gap: 1.5rem 2.5rem;
   align-items: center;
-  padding: 2rem 2.25rem;
+  padding: 3rem 2.75rem;
   border: 1px solid var(--tdp-border-gold);
   border-radius: var(--tdp-radius-xl);
-  background: linear-gradient(135deg, rgba(50, 16, 24, 0.96), rgba(22, 16, 18, 0.94));
-  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.28), inset 0 1px 0 rgba(244, 191, 79, 0.08);
+  background:
+    radial-gradient(ellipse 75% 85% at 40% 50%, rgba(140, 31, 53, 0.2) 0%, transparent 70%),
+    linear-gradient(160deg, rgba(60, 18, 28, 0.98) 0%, rgba(18, 11, 15, 0.98) 100%);
+  box-shadow:
+    0 28px 80px rgba(0, 0, 0, 0.52),
+    inset 0 1px 0 rgba(244, 191, 79, 0.1),
+    inset 0 -1px 0 rgba(244, 191, 79, 0.04);
+  overflow: hidden;
+}
+
+/* Spotlight pulse */
+.landing-cta-panel::before {
+  content: '';
+  position: absolute;
+  top: -80px;
+  left: 38%;
+  transform: translateX(-50%);
+  width: 500px;
+  height: 500px;
+  background: radial-gradient(
+    ellipse 55% 55% at 50% 0%,
+    rgba(244, 191, 79, 0.065) 0%,
+    transparent 70%
+  );
+  pointer-events: none;
+  animation: cta-spotlight 4.5s ease-in-out infinite alternate;
+}
+
+/* Subtle grid lines in CTA */
+.landing-cta-panel::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    90deg,
+    transparent        0px,
+    transparent        64px,
+    rgba(244, 191, 79, 0.015) 64px,
+    rgba(244, 191, 79, 0.015) 65px
+  );
+  pointer-events: none;
+}
+
+@keyframes cta-spotlight {
+  from { opacity: 0.55; transform: translateX(-50%) scale(0.92); }
+  to   { opacity: 1;    transform: translateX(-50%) scale(1.12); }
+}
+
+.landing-cta-copy {
+  position: relative;
+  z-index: 1;
 }
 
 .landing-cta-copy h2 {
   margin: 0;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: clamp(1.6rem, 2.8vw, 2.4rem);
-  line-height: 1.08;
+  font-family: var(--tdp-font-display);
+  font-style: italic;
+  font-size: clamp(1.8rem, 3.2vw, 2.7rem);
+  line-height: 1.06;
   letter-spacing: -0.03em;
-  text-wrap: balance;
+  color: var(--tdp-text);
 }
 
 .landing-cta-copy p {
-  margin: 0.7rem 0 0;
+  margin: 0.75rem 0 0;
   color: var(--tdp-text-soft);
-  font-size: 0.96rem;
-  line-height: 1.7;
+  font-family: var(--tdp-font-body);
+  font-size: 0.95rem;
+  line-height: 1.73;
 }
 
 .landing-cta-actions {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 0.75rem;
 }
 
-/* 10. Responsive */
-@media (max-width: 1060px) {
+/* ─── 21. Responsive ─── */
+@media (max-width: 1100px) {
   .showcase-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -697,50 +1305,85 @@ a:hover {
   .landing-cta-actions {
     justify-content: flex-start;
   }
+
+  .footer-inner {
+    grid-template-areas:
+      "brand"
+      "divider"
+      "info"
+      "meta";
+    grid-template-columns: 1fr;
+  }
+
+  .footer-divider {
+    height: 1px;
+    width: 100%;
+    align-self: auto;
+    margin: 0;
+  }
 }
 
 @media (max-width: 660px) {
   .page-header {
-    padding: 1rem 1rem 1.25rem;
+    padding: 1.25rem 1rem 1.5rem !important;
   }
 
-  .hero-inner,
+  .hero-inner {
+    padding: 1.75rem 1.4rem 1.5rem;
+    border-radius: 20px;
+  }
+
   .content-panel {
-    padding: 1.35rem;
+    padding: 1.5rem;
     border-radius: 20px;
   }
 
   .main-content {
-    padding: 0 1rem 2rem;
+    padding: 0 1rem 2.5rem;
   }
 
   .landing-block {
-    padding: 1.25rem;
+    padding: 1.5rem 1.4rem;
     border-radius: 20px;
   }
 
-  .project-name {
-    font-size: clamp(2.4rem, 11vw, 3.8rem);
+  .landing-cta-panel {
+    padding: 1.75rem 1.5rem;
+    border-radius: 20px;
+  }
+
+  .landing-cta-actions .btn,
+  .hero-actions .btn {
+    width: 100%;
+    justify-content: center;
   }
 
   .hero-actions {
     flex-direction: column;
   }
 
-  .hero-actions .btn {
-    width: 100%;
+  .project-name {
+    font-size: clamp(2.8rem, 14vw, 4.2rem) !important;
   }
 
   .showcase-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
   }
 
-  .landing-cta-panel {
-    padding: 1.35rem;
-    border-radius: 20px;
+  .curtain-left,
+  .curtain-right {
+    display: none;
   }
+}
 
-  .landing-cta-actions .btn {
-    width: 100%;
+/* ─── 22. Reduced motion ─── */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/index.html
+++ b/index.html
@@ -108,19 +108,27 @@ content_panel: false
     </div>
     <div class="showcase-grid">
       <figure class="showcase-card">
-        <img src="assets/images/Screenshot 2026-03-17 120648.png" alt="Dashboard con progressione, reputazione e attività recenti" loading="lazy">
+        <div class="phone-frame">
+          <img src="assets/images/Screenshot 2026-03-17 120648.png" alt="Dashboard con progressione, reputazione e attività recenti" loading="lazy">
+        </div>
         <figcaption>Dashboard personale con stato carriera, risorse e attività in evidenza.</figcaption>
       </figure>
       <figure class="showcase-card">
-        <img src="assets/images/Screenshot 2026-03-17 121756.png" alt="Schermata eventi con missioni e disponibilità del circuito" loading="lazy">
+        <div class="phone-frame">
+          <img src="assets/images/Screenshot 2026-03-17 121756.png" alt="Schermata eventi con missioni e disponibilità del circuito" loading="lazy">
+        </div>
         <figcaption>Vista eventi e missioni disponibili collegate agli spettacoli del circuito.</figcaption>
       </figure>
       <figure class="showcase-card">
-        <img src="assets/images/Screenshot 2026-03-17 122258.png" alt="Shop interno con premi, risorse e oggetti digitali" loading="lazy">
+        <div class="phone-frame">
+          <img src="assets/images/Screenshot 2026-03-17 122258.png" alt="Shop interno con premi, risorse e oggetti digitali" loading="lazy">
+        </div>
         <figcaption>Shop interno per riscattare risorse e premi collegati alla progressione.</figcaption>
       </figure>
       <figure class="showcase-card">
-        <img src="assets/images/Screenshot 2026-03-17 122845.png" alt="Schermata carriera con statistiche, reputazione e avanzamento" loading="lazy">
+        <div class="phone-frame">
+          <img src="assets/images/Screenshot 2026-03-17 122845.png" alt="Schermata carriera con statistiche, reputazione e avanzamento" loading="lazy">
+        </div>
         <figcaption>Schermata carriera con reputazione, caratteristiche e avanzamento del ruolo scelto.</figcaption>
       </figure>
     </div>
@@ -158,7 +166,10 @@ content_panel: false
         <p>Accedi all'app per partecipare agli eventi, completare missioni e costruire la tua carriera culturale.</p>
       </div>
       <div class="landing-cta-actions">
-        <a href="{{ site.app_url }}" class="btn btn-primary">Apri l'app</a>
+        <a href="{{ site.app_url }}" class="btn btn-primary">
+          <span class="btn-shine" aria-hidden="true"></span>
+          Apri l'app
+        </a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
- Hero teatrale con spotlight pulsante, tendaggi CSS laterali e logo con
  anello animato; titolo Playfair Display italic enorme con staggered reveal
- Screenshot gallery con phone mockup frame (notch + screen reflection)
- Cards con micro-animazioni: top-line reveal su hover, sweep dorato su
  feature panels, lift su audience panels
- CTA section con gradiente bordeaux profondo e spotlight radiale animato
- Footer a griglia con brand A.T.C.L., divisore e note di copyright
- Font: Playfair Display (headings) + DM Sans (body) via Google Fonts
- Scroll-driven reveal via animation-timeline: view() (progressive enhancement)
- Curtain effect fisso su desktop con fold lines CSS
- Tutti i colori e i contenuti italiani preservati

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>