### PR TITLE
Add light/dark theme toggle and accordion TOC navigation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.lang | default: "it" }}">
+<html lang="{{ site.lang | default: "it" }}" data-theme="dark">
   <head>
     {% assign site_icon = site.logo | default: 'assets/images/pwa-192.png' %}
     <meta charset="UTF-8">
@@ -7,6 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#0d0a0b">
     {% seo %}
+    <!-- Prevent flash of wrong theme before CSS loads -->
+    <script>!function(){var t=localStorage.getItem('tdp-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t)}();</script>
     <link rel="icon" type="image/png" sizes="192x192" href="{{ site_icon | relative_url }}">
     <link rel="shortcut icon" href="{{ site_icon | relative_url }}">
     <link rel="apple-touch-icon" href="{{ site_icon | relative_url }}">
@@ -18,6 +20,11 @@
   </head>
   <body{% if page.page_class %} class="{{ page.page_class }}"{% endif %}>
     <a id="skip-to-content" href="#content">Vai al contenuto.</a>
+
+    <button id="tdp-theme-toggle" aria-label="Cambia tema">
+      <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+      <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+    </button>
 
     <div class="site-shell">
 
@@ -127,13 +134,109 @@
 
     <script>
     (function () {
+
+      /* ── Theme toggle ── */
+      var THEME_KEY = 'tdp-theme';
+      var toggleBtn = document.getElementById('tdp-theme-toggle');
+
+      function applyTheme(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        localStorage.setItem(THEME_KEY, theme);
+      }
+
+      if (toggleBtn) {
+        toggleBtn.addEventListener('click', function () {
+          var current = document.documentElement.getAttribute('data-theme');
+          applyTheme(current === 'dark' ? 'light' : 'dark');
+        });
+      }
+
+      /* ── Accordion sections ── */
+      document.querySelectorAll('.landing-block .section-header').forEach(function (header) {
+        var block = header.closest('.landing-block');
+        var body  = block ? block.querySelector('.section-body') : null;
+        if (!block || !body) return;
+
+        /* Set initial maxHeight for collapsed state */
+        if (block.classList.contains('is-collapsed')) {
+          body.style.maxHeight = '0px';
+        } else {
+          body.style.maxHeight = 'none';
+        }
+
+        header.addEventListener('click', function () {
+          var collapsed = block.classList.contains('is-collapsed');
+          if (collapsed) {
+            /* Expand */
+            block.classList.remove('is-collapsed');
+            body.style.maxHeight = body.scrollHeight + 'px';
+            body.addEventListener('transitionend', function onEnd() {
+              body.removeEventListener('transitionend', onEnd);
+              if (!block.classList.contains('is-collapsed')) {
+                body.style.maxHeight = 'none';
+              }
+            });
+          } else {
+            /* Collapse: pin explicit height first, then animate to 0 */
+            body.style.maxHeight = body.scrollHeight + 'px';
+            requestAnimationFrame(function () {
+              requestAnimationFrame(function () {
+                block.classList.add('is-collapsed');
+                body.style.maxHeight = '0px';
+              });
+            });
+          }
+        });
+
+        /* Keyboard support */
+        header.setAttribute('role', 'button');
+        header.setAttribute('tabindex', '0');
+        header.addEventListener('keydown', function (e) {
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); header.click(); }
+        });
+      });
+
+      /* ── TOC active link highlight on scroll ── */
+      var tocLinks = document.querySelectorAll('.sections-toc a[href^="#"]');
+      if (tocLinks.length) {
+        var observer = new IntersectionObserver(function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) {
+              tocLinks.forEach(function (a) {
+                a.classList.toggle('is-active', a.getAttribute('href') === '#' + entry.target.id);
+              });
+            }
+          });
+        }, { threshold: 0.25 });
+
+        tocLinks.forEach(function (a) {
+          var target = document.querySelector(a.getAttribute('href'));
+          if (target) observer.observe(target);
+        });
+
+        /* TOC click: expand section if collapsed, then scroll */
+        tocLinks.forEach(function (a) {
+          a.addEventListener('click', function () {
+            var targetId = a.getAttribute('href').slice(1);
+            var target   = document.getElementById(targetId);
+            if (!target) return;
+            var block    = target.closest('.landing-block');
+            if (block && block.classList.contains('is-collapsed')) {
+              var hdr = block.querySelector('.section-header');
+              if (hdr) hdr.click();
+            }
+          });
+        });
+      }
+
+      /* ── Lightbox ── */
       var lb      = document.getElementById('tdp-lightbox');
       var lbImg   = document.getElementById('tdp-lightbox-img');
       var lbCap   = document.getElementById('tdp-lightbox-caption');
       var lbClose = document.getElementById('tdp-lightbox-close');
       var lastFocus;
 
-      function open(src, alt, caption) {
+      function lbOpen(src, alt, caption) {
         lastFocus = document.activeElement;
         lbImg.src = src;
         lbImg.alt = alt || '';
@@ -143,23 +246,22 @@
         lbClose.focus();
       }
 
-      function close() {
+      function lbClose_fn() {
         lb.classList.remove('is-open');
         document.body.style.overflow = '';
         lbImg.src = '';
         if (lastFocus) lastFocus.focus();
       }
 
-      /* Attach to all zoomable images */
       document.querySelectorAll('.phone-frame img, .content-panel img').forEach(function (img) {
         img.classList.add('tdp-zoomable');
         img.setAttribute('tabindex', '0');
         img.setAttribute('role', 'button');
         img.setAttribute('aria-label', 'Ingrandisci immagine');
         function trigger() {
-          var fig     = img.closest('figure, .showcase-card');
-          var figcap  = fig ? fig.querySelector('figcaption') : null;
-          open(img.src, img.alt, figcap ? figcap.textContent.trim() : '');
+          var fig    = img.closest('figure, .showcase-card');
+          var figcap = fig ? fig.querySelector('figcaption') : null;
+          lbOpen(img.src, img.alt, figcap ? figcap.textContent.trim() : '');
         }
         img.addEventListener('click', trigger);
         img.addEventListener('keydown', function (e) {
@@ -167,11 +269,12 @@
         });
       });
 
-      lbClose.addEventListener('click', close);
-      lb.addEventListener('click', function (e) { if (e.target === lb) close(); });
+      lbClose.addEventListener('click', lbClose_fn);
+      lb.addEventListener('click', function (e) { if (e.target === lb) lbClose_fn(); });
       document.addEventListener('keydown', function (e) {
-        if (e.key === 'Escape' && lb.classList.contains('is-open')) close();
+        if (e.key === 'Escape' && lb.classList.contains('is-open')) lbClose_fn();
       });
+
     })();
     </script>
   </body>

--- a/assets/css/pages-theme.css
+++ b/assets/css/pages-theme.css
@@ -1508,3 +1508,226 @@ a:hover {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* ─── 24. Light theme token overrides ─── */
+html[data-theme="light"] {
+  --tdp-bg:              #f7f3ef;
+  --tdp-surface:         rgba(255, 252, 249, 0.97);
+  --tdp-surface-card:    rgba(255, 250, 246, 0.97);
+  --tdp-border:          rgba(0, 0, 0, 0.08);
+  --tdp-border-hover:    rgba(0, 0, 0, 0.15);
+  --tdp-border-gold:     rgba(160, 100, 10, 0.2);
+  --tdp-text:            #1a1210;
+  --tdp-text-muted:      #5a4a42;
+  --tdp-text-soft:       #8a7068;
+  --tdp-gold:            #a06408;
+  --tdp-gold-light:      #c07a10;
+  --tdp-gold-deep:       #7a4c04;
+  --tdp-crimson:         #7a1028;
+  --tdp-crimson-dark:    #550e1d;
+  --tdp-shadow-sm:       0 4px 16px rgba(0, 0, 0, 0.08);
+  --tdp-shadow-md:       0 12px 36px rgba(0, 0, 0, 0.12);
+  --tdp-shadow-lg:       0 28px 72px rgba(0, 0, 0, 0.18);
+}
+
+html[data-theme="light"] body {
+  background-color: var(--tdp-bg);
+  color: var(--tdp-text);
+}
+
+html[data-theme="light"] .page-header {
+  background-color: #3d0b18 !important;
+  background-image: none !important;
+}
+
+html[data-theme="light"] .curtain-left,
+html[data-theme="light"] .curtain-right {
+  background: linear-gradient(to bottom, #3d0b18, #200610);
+}
+
+html[data-theme="light"] .feature-panel,
+html[data-theme="light"] .audience-panel {
+  background: var(--tdp-surface-card);
+  border-color: var(--tdp-border);
+}
+
+html[data-theme="light"] .landing-pill {
+  background: rgba(160, 100, 8, 0.1);
+  color: var(--tdp-gold);
+  border-color: rgba(160, 100, 8, 0.2);
+}
+
+html[data-theme="light"] .intro-value {
+  background: var(--tdp-surface-card);
+  border-color: var(--tdp-border);
+}
+
+html[data-theme="light"] .landing-flow li {
+  border-color: var(--tdp-border);
+}
+
+html[data-theme="light"] .landing-flow-index {
+  color: var(--tdp-gold);
+}
+
+html[data-theme="light"] .showcase-card figcaption {
+  color: var(--tdp-text-muted);
+}
+
+html[data-theme="light"] .footer-social-link {
+  background: rgba(0, 0, 0, 0.06);
+  color: var(--tdp-text-muted);
+}
+
+html[data-theme="light"] .footer-social-link:hover {
+  background: rgba(160, 100, 8, 0.12);
+  color: var(--tdp-gold);
+}
+
+html[data-theme="light"] #tdp-lightbox {
+  background: rgba(230, 220, 215, 0.88);
+}
+
+html[data-theme="light"] #tdp-lightbox-close {
+  background: rgba(0, 0, 0, 0.06);
+  border-color: rgba(0, 0, 0, 0.1);
+  color: var(--tdp-text-muted);
+}
+
+/* ─── 25. Theme toggle button ─── */
+#tdp-theme-toggle {
+  position: fixed;
+  bottom: 1.25rem;
+  right: 1.25rem;
+  z-index: 900;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  border: 1px solid var(--tdp-border-gold);
+  background: var(--tdp-surface);
+  color: var(--tdp-gold);
+  cursor: pointer;
+  box-shadow: var(--tdp-shadow-md);
+  transition: background 0.2s, border-color 0.2s, transform 0.2s, box-shadow 0.2s;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+#tdp-theme-toggle:hover {
+  background: rgba(244, 191, 79, 0.1);
+  border-color: var(--tdp-gold);
+  transform: scale(1.08);
+  box-shadow: 0 0 0 3px rgba(244, 191, 79, 0.15), var(--tdp-shadow-md);
+}
+
+#tdp-theme-toggle .icon-sun,
+#tdp-theme-toggle .icon-moon {
+  position: absolute;
+  transition: opacity 0.2s, transform 0.3s;
+}
+
+html[data-theme="dark"] #tdp-theme-toggle .icon-sun  { opacity: 1; transform: rotate(0deg) scale(1); }
+html[data-theme="dark"] #tdp-theme-toggle .icon-moon { opacity: 0; transform: rotate(90deg) scale(0.6); }
+html[data-theme="light"] #tdp-theme-toggle .icon-sun  { opacity: 0; transform: rotate(-90deg) scale(0.6); }
+html[data-theme="light"] #tdp-theme-toggle .icon-moon { opacity: 1; transform: rotate(0deg) scale(1); }
+
+/* ─── 26. Sections TOC navigation ─── */
+.sections-toc {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0 0 2rem;
+  list-style: none;
+  margin: 0;
+}
+
+.sections-toc li {
+  margin: 0;
+}
+
+.sections-toc a {
+  display: inline-block;
+  padding: 0.35rem 0.85rem;
+  border-radius: 99px;
+  border: 1px solid var(--tdp-border);
+  background: var(--tdp-surface-card);
+  color: var(--tdp-text-muted);
+  font-family: var(--tdp-font-body);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  transition: background 0.2s, border-color 0.2s, color 0.2s;
+}
+
+.sections-toc a:hover,
+.sections-toc a.is-active {
+  background: rgba(244, 191, 79, 0.08);
+  border-color: var(--tdp-border-gold);
+  color: var(--tdp-gold);
+}
+
+html[data-theme="light"] .sections-toc a {
+  background: var(--tdp-surface-card);
+  color: var(--tdp-text-muted);
+}
+
+html[data-theme="light"] .sections-toc a:hover,
+html[data-theme="light"] .sections-toc a.is-active {
+  background: rgba(160, 100, 8, 0.08);
+  border-color: rgba(160, 100, 8, 0.25);
+  color: var(--tdp-gold);
+}
+
+/* ─── 27. Accordion sections ─── */
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  cursor: pointer;
+  padding: 0.75rem 0;
+  user-select: none;
+  border-bottom: 1px solid var(--tdp-border);
+  transition: border-color 0.2s;
+}
+
+.section-header:hover {
+  border-color: var(--tdp-border-gold);
+}
+
+.section-header:hover .section-chevron {
+  color: var(--tdp-gold);
+}
+
+.section-header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.section-chevron {
+  flex-shrink: 0;
+  color: var(--tdp-text-soft);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), color 0.2s;
+}
+
+.landing-block.is-collapsed .section-chevron {
+  transform: rotate(-90deg);
+}
+
+.section-body {
+  overflow: hidden;
+  transition: max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease;
+}
+
+.landing-block.is-collapsed .section-body {
+  opacity: 0;
+}
+
+.section-body-inner {
+  padding-top: 1.5rem;
+}

--- a/index.html
+++ b/index.html
@@ -10,154 +10,209 @@ content_panel: false
 
 <div class="landing-composer">
 
+  <!-- TOC navigation -->
+  <nav aria-label="Indice sezioni">
+    <ul class="sections-toc">
+      <li><a href="#intro-title">Prodotto</a></li>
+      <li><a href="#features-title">Cosa trovi nell'app</a></li>
+      <li><a href="#flow-title">Flusso utente</a></li>
+      <li><a href="#gallery-title">Interfaccia reale</a></li>
+      <li><a href="#audience-title">Pubblico</a></li>
+      <li><a href="#cta-title">Entra nell'app</a></li>
+    </ul>
+  </nav>
+
+  <!-- Section 1: Prodotto — always open -->
   <section class="landing-block" aria-labelledby="intro-title">
-    <span class="section-label">Prodotto</span>
-    <h2 id="intro-title">Un'app che trasforma la presenza a teatro in progresso reale.</h2>
-    <p class="landing-intro-copy">
-      Turni di Palco collega eventi dal vivo, QR check-in, attività contestuali e crescita personale in un'esperienza
-      unica, semplice da leggere e coerente con il linguaggio del mobile.
-    </p>
-    <div class="landing-pill-row" aria-label="Punti chiave">
-      <span class="landing-pill">Check-in eventi</span>
-      <span class="landing-pill">Missioni contestuali</span>
-      <span class="landing-pill">Progressione carriera</span>
-      <span class="landing-pill">PWA multipagina</span>
-    </div>
-    <div class="intro-values">
-      <div class="intro-value">
-        <strong>Partecipa</strong>
-        <span>Ogni spettacolo diventa un'azione registrata nel tuo profilo.</span>
+    <div class="section-header">
+      <div class="section-header-text">
+        <span class="section-label">Prodotto</span>
+        <h2 id="intro-title">Un'app che trasforma la presenza a teatro in progresso reale.</h2>
       </div>
-      <div class="intro-value">
-        <strong>Gioca</strong>
-        <span>Missioni e contenuti mantengono viva l'esperienza oltre la serata.</span>
+      <svg class="section-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+    </div>
+    <div class="section-body">
+      <div class="section-body-inner">
+        <p class="landing-intro-copy">
+          Turni di Palco collega eventi dal vivo, QR check-in, attività contestuali e crescita personale in un'esperienza
+          unica, semplice da leggere e coerente con il linguaggio del mobile.
+        </p>
+        <div class="landing-pill-row" aria-label="Punti chiave">
+          <span class="landing-pill">Check-in eventi</span>
+          <span class="landing-pill">Missioni contestuali</span>
+          <span class="landing-pill">Progressione carriera</span>
+          <span class="landing-pill">PWA multipagina</span>
+        </div>
+        <div class="intro-values">
+          <div class="intro-value">
+            <strong>Partecipa</strong>
+            <span>Ogni spettacolo diventa un'azione registrata nel tuo profilo.</span>
+          </div>
+          <div class="intro-value">
+            <strong>Gioca</strong>
+            <span>Missioni e contenuti mantengono viva l'esperienza oltre la serata.</span>
+          </div>
+          <div class="intro-value">
+            <strong>Cresci</strong>
+            <span>Ruoli, reputazione e risultati formano un percorso leggibile nel tempo.</span>
+          </div>
+        </div>
       </div>
-      <div class="intro-value">
-        <strong>Cresci</strong>
-        <span>Ruoli, reputazione e risultati formano un percorso leggibile nel tempo.</span>
+    </div>
+  </section>
+
+  <!-- Section 2: Cosa trovi nell'app — collapsed -->
+  <section class="landing-block is-collapsed" aria-labelledby="features-title">
+    <div class="section-header">
+      <div class="section-header-text">
+        <span class="section-label">Cosa trovi nell'app</span>
+        <h2 id="features-title">Una struttura chiara, pensata come un prodotto mobile.</h2>
+      </div>
+      <svg class="section-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+    </div>
+    <div class="section-body">
+      <div class="section-body-inner">
+        <div class="feature-stack">
+          <article class="feature-panel">
+            <span class="feature-kicker">Dashboard</span>
+            <h3>Stato del profilo subito visibile.</h3>
+            <p>Ruolo, risorse, attività recenti e prossimi obiettivi convivono in un colpo d'occhio, senza elementi decorativi invasivi.</p>
+          </article>
+          <article class="feature-panel">
+            <span class="feature-kicker">Eventi</span>
+            <h3>Presenze e missioni nello stesso flusso.</h3>
+            <p>L'ingresso a teatro, la scansione QR e le attività collegate fanno parte della stessa esperienza, non di moduli separati.</p>
+          </article>
+          <article class="feature-panel">
+            <span class="feature-kicker">Carriera</span>
+            <h3>Progressione concreta, leggibile, cumulativa.</h3>
+            <p>Statistiche, reputazione e avanzamento del ruolo raccontano nel tempo cosa hai fatto davvero dentro il circuito culturale.</p>
+          </article>
+        </div>
       </div>
     </div>
   </section>
 
-  <section class="landing-block" aria-labelledby="features-title">
-    <div class="landing-block-head">
-      <span class="section-label">Cosa trovi nell'app</span>
-      <h2 id="features-title">Una struttura chiara, pensata come un prodotto mobile.</h2>
+  <!-- Section 3: Flusso utente — collapsed -->
+  <section class="landing-block is-collapsed" aria-labelledby="flow-title">
+    <div class="section-header">
+      <div class="section-header-text">
+        <span class="section-label">Flusso utente</span>
+        <h2 id="flow-title">Quattro passaggi netti, senza marketing fumoso.</h2>
+      </div>
+      <svg class="section-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
     </div>
-    <div class="feature-stack">
-      <article class="feature-panel">
-        <span class="feature-kicker">Dashboard</span>
-        <h3>Stato del profilo subito visibile.</h3>
-        <p>Ruolo, risorse, attività recenti e prossimi obiettivi convivono in un colpo d'occhio, senza elementi decorativi invasivi.</p>
-      </article>
-      <article class="feature-panel">
-        <span class="feature-kicker">Eventi</span>
-        <h3>Presenze e missioni nello stesso flusso.</h3>
-        <p>L'ingresso a teatro, la scansione QR e le attività collegate fanno parte della stessa esperienza, non di moduli separati.</p>
-      </article>
-      <article class="feature-panel">
-        <span class="feature-kicker">Carriera</span>
-        <h3>Progressione concreta, leggibile, cumulativa.</h3>
-        <p>Statistiche, reputazione e avanzamento del ruolo raccontano nel tempo cosa hai fatto davvero dentro il circuito culturale.</p>
-      </article>
-    </div>
-  </section>
-
-  <section class="landing-block" aria-labelledby="flow-title">
-    <div class="landing-block-head">
-      <span class="section-label">Flusso utente</span>
-      <h2 id="flow-title">Quattro passaggi netti, senza marketing fumoso.</h2>
-    </div>
-    <ol class="landing-flow">
-      <li>
-        <span class="landing-flow-index">01</span>
-        <div>
-          <h3>Scegli il ruolo</h3>
-          <p>All'avvio definisci una prospettiva narrativa che orienta missioni, tono e obiettivi personali.</p>
-        </div>
-      </li>
-      <li>
-        <span class="landing-flow-index">02</span>
-        <div>
-          <h3>Vai agli spettacoli</h3>
-          <p>La presenza dal vivo è il cuore dell'esperienza e attiva il collegamento con il tuo percorso digitale.</p>
-        </div>
-      </li>
-      <li>
-        <span class="landing-flow-index">03</span>
-        <div>
-          <h3>Completa attività collegate</h3>
-          <p>Quiz, missioni e micro-contenuti prolungano l'esperienza in modo leggero e contestuale.</p>
-        </div>
-      </li>
-      <li>
-        <span class="landing-flow-index">04</span>
-        <div>
-          <h3>Accumula risultati</h3>
-          <p>Esperienza, reputazione e ricompense costruiscono una continuità che valorizza la partecipazione ricorrente.</p>
-        </div>
-      </li>
-    </ol>
-  </section>
-
-  <section class="landing-block" aria-labelledby="gallery-title">
-    <div class="landing-block-head">
-      <span class="section-label">Interfaccia reale</span>
-      <h2 id="gallery-title">Le schermate contano: qui si vede davvero il prodotto.</h2>
-      <p class="landing-support-copy">Dashboard, eventi, shop e carriera mostrano un'interfaccia dark, ordinata e coerente con il mobile.</p>
-    </div>
-    <div class="showcase-grid">
-      <figure class="showcase-card">
-        <div class="phone-frame">
-          <img src="assets/images/Screenshot 2026-03-17 120648.png" alt="Dashboard con progressione, reputazione e attività recenti" loading="lazy">
-        </div>
-        <figcaption>Dashboard personale con stato carriera, risorse e attività in evidenza.</figcaption>
-      </figure>
-      <figure class="showcase-card">
-        <div class="phone-frame">
-          <img src="assets/images/Screenshot 2026-03-17 121756.png" alt="Schermata eventi con missioni e disponibilità del circuito" loading="lazy">
-        </div>
-        <figcaption>Vista eventi e missioni disponibili collegate agli spettacoli del circuito.</figcaption>
-      </figure>
-      <figure class="showcase-card">
-        <div class="phone-frame">
-          <img src="assets/images/Screenshot 2026-03-17 122258.png" alt="Shop interno con premi, risorse e oggetti digitali" loading="lazy">
-        </div>
-        <figcaption>Shop interno per riscattare risorse e premi collegati alla progressione.</figcaption>
-      </figure>
-      <figure class="showcase-card">
-        <div class="phone-frame">
-          <img src="assets/images/Screenshot 2026-03-17 122845.png" alt="Schermata carriera con statistiche, reputazione e avanzamento" loading="lazy">
-        </div>
-        <figcaption>Schermata carriera con reputazione, caratteristiche e avanzamento del ruolo scelto.</figcaption>
-      </figure>
+    <div class="section-body">
+      <div class="section-body-inner">
+        <ol class="landing-flow">
+          <li>
+            <span class="landing-flow-index">01</span>
+            <div>
+              <h3>Scegli il ruolo</h3>
+              <p>All'avvio definisci una prospettiva narrativa che orienta missioni, tono e obiettivi personali.</p>
+            </div>
+          </li>
+          <li>
+            <span class="landing-flow-index">02</span>
+            <div>
+              <h3>Vai agli spettacoli</h3>
+              <p>La presenza dal vivo è il cuore dell'esperienza e attiva il collegamento con il tuo percorso digitale.</p>
+            </div>
+          </li>
+          <li>
+            <span class="landing-flow-index">03</span>
+            <div>
+              <h3>Completa attività collegate</h3>
+              <p>Quiz, missioni e micro-contenuti prolungano l'esperienza in modo leggero e contestuale.</p>
+            </div>
+          </li>
+          <li>
+            <span class="landing-flow-index">04</span>
+            <div>
+              <h3>Accumula risultati</h3>
+              <p>Esperienza, reputazione e ricompense costruiscono una continuità che valorizza la partecipazione ricorrente.</p>
+            </div>
+          </li>
+        </ol>
+      </div>
     </div>
   </section>
 
-  <section class="landing-block" aria-labelledby="audience-title">
-    <div class="landing-block-head">
-      <span class="section-label">Pubblico</span>
-      <h2 id="audience-title">Tre ingressi possibili, un'unica promessa: rendere il teatro più attivo e memorabile.</h2>
+  <!-- Section 4: Interfaccia reale — collapsed -->
+  <section class="landing-block is-collapsed" aria-labelledby="gallery-title">
+    <div class="section-header">
+      <div class="section-header-text">
+        <span class="section-label">Interfaccia reale</span>
+        <h2 id="gallery-title">Le schermate contano: qui si vede davvero il prodotto.</h2>
+      </div>
+      <svg class="section-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
     </div>
-    <div class="audience-stack">
-      <article class="audience-panel">
-        <span class="audience-tag">Giovani</span>
-        <h3>Un linguaggio più vicino alle abitudini digitali.</h3>
-        <p>La cultura viene presentata come percorso, con obiettivi comprensibili e reward che danno continuità alla partecipazione.</p>
-      </article>
-      <article class="audience-panel">
-        <span class="audience-tag">Appassionati</span>
-        <h3>Un modo per seguire il circuito in modo più profondo.</h3>
-        <p>Ogni spettacolo non finisce all'uscita dalla sala, ma resta collegato a missioni, memoria e crescita personale.</p>
-      </article>
-      <article class="audience-panel">
-        <span class="audience-tag">Scuole e operatori</span>
-        <h3>Uno strumento per attivare, misurare e fidelizzare.</h3>
-        <p>La presenza agli eventi può essere accompagnata da percorsi e obiettivi che rendono più forte il legame con il territorio.</p>
-      </article>
+    <div class="section-body">
+      <div class="section-body-inner">
+        <p class="landing-support-copy">Dashboard, eventi, shop e carriera mostrano un'interfaccia dark, ordinata e coerente con il mobile.</p>
+        <div class="showcase-grid">
+          <figure class="showcase-card">
+            <div class="phone-frame">
+              <img src="assets/images/Screenshot 2026-03-17 120648.png" alt="Dashboard con progressione, reputazione e attività recenti" loading="lazy">
+            </div>
+            <figcaption>Dashboard personale con stato carriera, risorse e attività in evidenza.</figcaption>
+          </figure>
+          <figure class="showcase-card">
+            <div class="phone-frame">
+              <img src="assets/images/Screenshot 2026-03-17 121756.png" alt="Schermata eventi con missioni e disponibilità del circuito" loading="lazy">
+            </div>
+            <figcaption>Vista eventi e missioni disponibili collegate agli spettacoli del circuito.</figcaption>
+          </figure>
+          <figure class="showcase-card">
+            <div class="phone-frame">
+              <img src="assets/images/Screenshot 2026-03-17 122258.png" alt="Shop interno con premi, risorse e oggetti digitali" loading="lazy">
+            </div>
+            <figcaption>Shop interno per riscattare risorse e premi collegati alla progressione.</figcaption>
+          </figure>
+          <figure class="showcase-card">
+            <div class="phone-frame">
+              <img src="assets/images/Screenshot 2026-03-17 122845.png" alt="Schermata carriera con statistiche, reputazione e avanzamento" loading="lazy">
+            </div>
+            <figcaption>Schermata carriera con reputazione, caratteristiche e avanzamento del ruolo scelto.</figcaption>
+          </figure>
+        </div>
+      </div>
     </div>
   </section>
 
+  <!-- Section 5: Pubblico — collapsed -->
+  <section class="landing-block is-collapsed" aria-labelledby="audience-title">
+    <div class="section-header">
+      <div class="section-header-text">
+        <span class="section-label">Pubblico</span>
+        <h2 id="audience-title">Tre ingressi possibili, un'unica promessa: rendere il teatro più attivo e memorabile.</h2>
+      </div>
+      <svg class="section-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+    </div>
+    <div class="section-body">
+      <div class="section-body-inner">
+        <div class="audience-stack">
+          <article class="audience-panel">
+            <span class="audience-tag">Giovani</span>
+            <h3>Un linguaggio più vicino alle abitudini digitali.</h3>
+            <p>La cultura viene presentata come percorso, con obiettivi comprensibili e reward che danno continuità alla partecipazione.</p>
+          </article>
+          <article class="audience-panel">
+            <span class="audience-tag">Appassionati</span>
+            <h3>Un modo per seguire il circuito in modo più profondo.</h3>
+            <p>Ogni spettacolo non finisce all'uscita dalla sala, ma resta collegato a missioni, memoria e crescita personale.</p>
+          </article>
+          <article class="audience-panel">
+            <span class="audience-tag">Scuole e operatori</span>
+            <h3>Uno strumento per attivare, misurare e fidelizzare.</h3>
+            <p>La presenza agli eventi può essere accompagnata da percorsi e obiettivi che rendono più forte il legame con il territorio.</p>
+          </article>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 6: CTA — always visible (no accordion) -->
   <section class="landing-block landing-block-cta" aria-labelledby="cta-title">
     <div class="landing-cta-panel">
       <div class="landing-cta-copy">


### PR DESCRIPTION
## Summary
- Dual **light/dark theme** with CSS token overrides; animated sun/moon toggle button fixed bottom-right
- FOUC-free: inline `<script>` in `<head>` reads `localStorage` and sets `data-theme` before CSS loads
- **Accordion TOC**: landing sections 2–5 start collapsed; pill-nav at top lets users jump to any section (auto-expands it); smooth `maxHeight` animation
- `IntersectionObserver` highlights the active TOC pill as the user scrolls

## Test plan
- [ ] Toggle dark→light→dark: colors switch correctly, preference is persisted on reload
- [ ] Verify no flash of wrong theme on page load (both themes)
- [ ] Click each TOC pill: section expands and page scrolls to it
- [ ] Click section header directly: toggles expand/collapse with animation
- [ ] Image lightbox still works after restructure
- [ ] Check on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)