### PR TITLE
Fix light theme and TOC alignment/active state

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -199,20 +199,36 @@
       /* ── TOC active link highlight on scroll ── */
       var tocLinks = document.querySelectorAll('.sections-toc a[href^="#"]');
       if (tocLinks.length) {
-        var observer = new IntersectionObserver(function (entries) {
-          entries.forEach(function (entry) {
-            if (entry.isIntersecting) {
-              tocLinks.forEach(function (a) {
-                a.classList.toggle('is-active', a.getAttribute('href') === '#' + entry.target.id);
-              });
+        function updateActiveToc() {
+          var best = null;
+          var bestTop = -Infinity;
+          tocLinks.forEach(function (a) {
+            var target = document.querySelector(a.getAttribute('href'));
+            if (!target) return;
+            var top = target.getBoundingClientRect().top;
+            /* pick the heading closest to (and still above) viewport center */
+            if (top <= window.innerHeight * 0.55 && top > bestTop) {
+              bestTop = top;
+              best = a;
             }
           });
-        }, { threshold: 0.25 });
+          /* fallback: if nothing is above center, highlight the topmost one */
+          if (!best) {
+            var minTop = Infinity;
+            tocLinks.forEach(function (a) {
+              var target = document.querySelector(a.getAttribute('href'));
+              if (!target) return;
+              var top = target.getBoundingClientRect().top;
+              if (top < minTop) { minTop = top; best = a; }
+            });
+          }
+          tocLinks.forEach(function (a) {
+            a.classList.toggle('is-active', a === best);
+          });
+        }
 
-        tocLinks.forEach(function (a) {
-          var target = document.querySelector(a.getAttribute('href'));
-          if (target) observer.observe(target);
-        });
+        window.addEventListener('scroll', updateActiveToc, { passive: true });
+        updateActiveToc();
 
         /* TOC click: expand section if collapsed, then scroll */
         tocLinks.forEach(function (a) {
@@ -225,6 +241,7 @@
               var hdr = block.querySelector('.section-header');
               if (hdr) hdr.click();
             }
+            setTimeout(updateActiveToc, 450); /* re-check after expand animation */
           });
         });
       }

--- a/assets/css/pages-theme.css
+++ b/assets/css/pages-theme.css
@@ -1545,6 +1545,50 @@ html[data-theme="light"] .curtain-right {
   background: linear-gradient(to bottom, #3d0b18, #200610);
 }
 
+/* Hero text always stays light — hero bg is always dark */
+html[data-theme="light"] .project-name {
+  color: #f5ede6 !important;
+}
+
+html[data-theme="light"] .project-tagline {
+  color: rgba(245, 237, 230, 0.72) !important;
+}
+
+html[data-theme="light"] .hero-kicker {
+  color: rgba(244, 191, 79, 0.8);
+}
+
+/* Landing block and content panel — light backgrounds */
+html[data-theme="light"] .landing-block {
+  background: linear-gradient(160deg, #fffaf6 0%, #fdf5ef 100%);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+}
+
+html[data-theme="light"] .landing-block:not(.landing-block-cta):hover {
+  border-color: rgba(160, 100, 8, 0.18);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(160, 100, 8, 0.06);
+}
+
+html[data-theme="light"] .content-panel {
+  background: linear-gradient(175deg, #fffaf6, #fdf4ed);
+  border-top-color: rgba(160, 100, 8, 0.14);
+}
+
+/* Inner value/feature/audience cards — slightly whiter to stand out from block bg */
+html[data-theme="light"] .intro-value,
+html[data-theme="light"] .feature-panel,
+html[data-theme="light"] .audience-panel {
+  background: rgba(255, 255, 255, 0.72);
+  border-color: rgba(0, 0, 0, 0.07);
+}
+
+html[data-theme="light"] .intro-value:hover,
+html[data-theme="light"] .feature-panel:hover,
+html[data-theme="light"] .audience-panel:hover {
+  background: #fff;
+  border-color: rgba(160, 100, 8, 0.18);
+}
+
 html[data-theme="light"] .feature-panel,
 html[data-theme="light"] .audience-panel {
   background: var(--tdp-surface-card);
@@ -1639,7 +1683,7 @@ html[data-theme="light"] #tdp-theme-toggle .icon-moon { opacity: 1; transform: r
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  padding: 0 0 2rem;
+  padding: 0 0 0.75rem 2.25rem; /* left indent matches landing-block inner padding */
   list-style: none;
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- **Light theme**: card `.landing-block` e `.content-panel` usavano background hardcoded dark — ora usano sfondi caldi chiari
- **Hero text**: `.project-name`, `.project-tagline`, `.hero-kicker` forzati a restare chiari (il header hero è sempre scuro indipendentemente dal tema)
- **Card interne**: `.intro-value`, `.feature-panel`, `.audience-panel` ottengono bg bianco con bordi corretti in light mode
- **TOC allineamento**: aggiunto indent sinistro `2.25rem` ai pill per allinearli al testo delle sezioni
- **TOC active state**: sostituito `IntersectionObserver` (buggato dopo click) con scroll listener che sceglie sempre l'heading più vicino al centro del viewport

## Test plan
- [ ] Tema chiaro: card con sfondo chiaro, testo leggibile
- [ ] Titolo hero visibile in entrambi i temi
- [ ] Pill TOC allineate con il contenuto delle sezioni
- [ ] Active pill si aggiorna correttamente scrollando e cliccando

🤖 Generated with [Claude Code](https://claude.com/claude-code)