### PR TITLE
Claude/fix-theme-toc

### DIFF
--- a/assets/css/pages-theme.css
+++ b/assets/css/pages-theme.css
@@ -1733,10 +1733,22 @@ html[data-theme="light"] .sections-toc a.is-active {
   justify-content: space-between;
   gap: 1rem;
   cursor: pointer;
-  padding: 0.75rem 0;
+  padding: 0.5rem 0 0.75rem;
   user-select: none;
   border-bottom: 1px solid var(--tdp-border);
   transition: border-color 0.2s;
+}
+
+/* h2 is now a direct child of section-header */
+.section-header h2 {
+  margin: 0;
+  font-family: var(--tdp-font-display);
+  font-style: italic;
+  font-size: clamp(1.35rem, 2.4vw, 1.9rem);
+  font-weight: 800;
+  line-height: 1.12;
+  letter-spacing: -0.025em;
+  color: var(--tdp-text);
 }
 
 .section-header:hover {
@@ -1745,12 +1757,6 @@ html[data-theme="light"] .sections-toc a.is-active {
 
 .section-header:hover .section-chevron {
   color: var(--tdp-gold);
-}
-
-.section-header-text {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
 }
 
 .section-chevron {

--- a/index.html
+++ b/index.html
@@ -24,11 +24,9 @@ content_panel: false
 
   <!-- Section 1: Prodotto — always open -->
   <section class="landing-block" aria-labelledby="intro-title">
+    <span class="section-label">Prodotto</span>
     <div class="section-header">
-      <div class="section-header-text">
-        <span class="section-label">Prodotto</span>
-        <h2 id="intro-title">Un'app che trasforma la presenza a teatro in progresso reale.</h2>
-      </div>
+      <h2 id="intro-title">Un'app che trasforma la presenza a teatro in progresso reale.</h2>
       <svg class="section-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
     </div>
     <div class="section-body">
@@ -63,11 +61,9 @@ content_panel: false
 
   <!-- Section 2: Cosa trovi nell'app — collapsed -->
   <section class="landing-block is-collapsed" aria-labelledby="features-title">
+    <span class="section-label">Cosa trovi nell'app</span>
     <div class="section-header">
-      <div class="section-header-text">
-        <span class="section-label">Cosa trovi nell'app</span>
-        <h2 id="features-title">Una struttura chiara, pensata come un prodotto mobile.</h2>
-      </div>
+      <h2 id="features-title">Una struttura chiara, pensata come un prodotto mobile.</h2>
       <svg class="section-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
     </div>
     <div class="section-body">
@@ -95,11 +91,9 @@ content_panel: false
 
   <!-- Section 3: Flusso utente — collapsed -->
   <section class="landing-block is-collapsed" aria-labelledby="flow-title">
+    <span class="section-label">Flusso utente</span>
     <div class="section-header">
-      <div class="section-header-text">
-        <span class="section-label">Flusso utente</span>
-        <h2 id="flow-title">Quattro passaggi netti, senza marketing fumoso.</h2>
-      </div>
+      <h2 id="flow-title">Quattro passaggi netti, senza marketing fumoso.</h2>
       <svg class="section-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
     </div>
     <div class="section-body">
@@ -140,11 +134,9 @@ content_panel: false
 
   <!-- Section 4: Interfaccia reale — collapsed -->
   <section class="landing-block is-collapsed" aria-labelledby="gallery-title">
+    <span class="section-label">Interfaccia reale</span>
     <div class="section-header">
-      <div class="section-header-text">
-        <span class="section-label">Interfaccia reale</span>
-        <h2 id="gallery-title">Le schermate contano: qui si vede davvero il prodotto.</h2>
-      </div>
+      <h2 id="gallery-title">Le schermate contano: qui si vede davvero il prodotto.</h2>
       <svg class="section-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
     </div>
     <div class="section-body">
@@ -182,11 +174,9 @@ content_panel: false
 
   <!-- Section 5: Pubblico — collapsed -->
   <section class="landing-block is-collapsed" aria-labelledby="audience-title">
+    <span class="section-label">Pubblico</span>
     <div class="section-header">
-      <div class="section-header-text">
-        <span class="section-label">Pubblico</span>
-        <h2 id="audience-title">Tre ingressi possibili, un'unica promessa: rendere il teatro più attivo e memorabile.</h2>
-      </div>
+      <h2 id="audience-title">Tre ingressi possibili, un'unica promessa: rendere il teatro più attivo e memorabile.</h2>
       <svg class="section-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
     </div>
     <div class="section-body">


### PR DESCRIPTION
- Move section-label above section-header so clickable row is h2+chevron only
- Chevron now vertically centered to the title line, not to label+title height
- Add h2 typography rules directly on .section-header h2