### PR TITLE
Windsurf/add-clean-gitignore-workflow

### DIFF
--- a/.github/workflows/clean-gitignore-files.yml
+++ b/.github/workflows/clean-gitignore-files.yml
@@ -1,6 +1,8 @@
 name: Clean Gitignore Files
 
 on:
+  push:
+    branches: [ main ]
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
Add a push trigger for the main branch in .github/workflows/clean-gitignore-files.yml so the workflow runs on pushes to main in addition to manual workflow_dispatch (which still accepts the branch input).