### PR TITLE
fix(#433): add index, limit query, and refactor my_turn_stats view

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3535,7 +3535,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           const [userRes, profileRes, turnsRes] = await Promise.all([
             supabase!.auth.getUser(),
             supabase!.from('profiles').select('*').eq('id', authUserId).maybeSingle(),
-            supabase!.from('turns').select('*').eq('user_id', authUserId).order('created_at', { ascending: false }),
+            supabase!.from('turns').select('*').eq('user_id', authUserId).order('created_at', { ascending: false }).limit(100),
           ]);
 
           if (!isMounted) return;

--- a/supabase/migrations/20260402_fix_sync_performance.sql
+++ b/supabase/migrations/20260402_fix_sync_performance.sql
@@ -1,0 +1,23 @@
+-- Fix #433: sync performance for users with many turns
+-- 1. Composite index for ordered per-user queries
+CREATE INDEX IF NOT EXISTS turns_user_created_at_idx
+  ON public.turns(user_id, created_at DESC);
+
+-- 2. Refactor my_turn_stats to use a single table scan instead of 3 sub-SELECTs
+CREATE OR REPLACE VIEW public.my_turn_stats AS
+SELECT
+  user_id,
+  COUNT(*)::int AS total_turns,
+  COUNT(*) FILTER (
+    WHERE created_at >= date_trunc('month', now())
+      AND created_at < date_trunc('month', now()) + INTERVAL '1 month'
+  )::int AS turns_this_month,
+  COUNT(DISTINCT theatre) FILTER (
+    WHERE theatre IS NOT NULL AND theatre <> ''
+  )::int AS unique_theatres
+FROM public.turns
+WHERE user_id = auth.uid()
+GROUP BY user_id;
+
+-- Re-grant select so existing permissions are preserved
+GRANT SELECT ON public.my_turn_stats TO authenticated;


### PR DESCRIPTION
## Summary

- Aggiunge indice composito `(user_id, created_at DESC)` su `turns` per query ordinate per utente
- Limita la query di sync iniziale a 100 turni (`.limit(100)`) — risolve il fetch completo senza paginazione
- Refactor della view `my_turn_stats`: da 3 sub-`SELECT COUNT(*)` (3 full scan) a un singolo `GROUP BY` con `COUNT(*) FILTER` (1 scan)

## Cambio

- `supabase/migrations/20260402_fix_sync_performance.sql` — indice + view refactored
- `apps/mobile/src/state/store.tsx` — aggiunto `.limit(100)` al query turns in `loadRemoteState()`

## Test

- Verificare che `my_turn_stats` ritorni valori corretti dopo il refactor
- Verificare che la schermata profilo carichi correttamente le statistiche
- Testare sync con utente con >100 turni: deve caricare solo i 100 più recenti

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)