### PR TITLE
Fix Supabase edge function bugs (#555, #556, #557)

### DIFF
--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -1,10 +1,11 @@
 /// <reference path="../@types/deno.d.ts" />
-import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
 }
 
 serve(async (req) => {

--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -97,8 +97,8 @@ serve(async (req: Request) => {
         // JWT uses base64url encoding; convert to standard base64 for atob
         const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
         const padded = b64 + '='.repeat((4 - b64.length % 4) % 4);
-        const payload = JSON.parse(atob(padded));
-        userId = typeof payload.sub === 'string' ? payload.sub : undefined;
+        const jwtPayload = JSON.parse(atob(padded));
+        userId = typeof jwtPayload.sub === 'string' ? jwtPayload.sub : undefined;
         console.log('[auth] JWT sub:', userId ?? '(missing)');
       } catch (decodeErr) {
         console.error('[auth] JWT decode failed:', (decodeErr as Error).message);


### PR DESCRIPTION
## Summary
- **#557**: Align `cleanup-events` Deno std version from `std@0.168.0` to `std@0.224.0` to match other functions (e.g. `ticket-activation`)
- **#556**: Add missing `Access-Control-Allow-Methods` CORS header in `cleanup-events` to align with `ticket-activation`
- **#555**: Rename shadowed `payload` variable to `jwtPayload` in `ticket-activation` JWT decoding block to avoid shadowing the request body destructured `payload`

## Test plan
- [ ] Verify `cleanup-events` function deploys and responds correctly to OPTIONS preflight requests
- [ ] Verify `ticket-activation` JWT auth flow still works correctly after variable rename
- [ ] Confirm no other references to the old `payload` variable exist in the JWT decode block

Closes #555, closes #556, closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)