### PR TITLE
Fix tools bugs: #581 #582 #583 #584

### DIFF
--- a/tools/ai-codex.js
+++ b/tools/ai-codex.js
@@ -48,8 +48,23 @@ if (shouldPrint) {
   process.exit(0);
 }
 
+/** Parse a shell-like argument string, respecting single and double quotes. */
+function parseShellArgs(str) {
+  const args = [];
+  const re = /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S+)/g;
+  let m;
+  while ((m = re.exec(str)) !== null) {
+    let arg = m[1];
+    if ((arg.startsWith('"') && arg.endsWith('"')) || (arg.startsWith("'") && arg.endsWith("'"))) {
+      arg = arg.slice(1, -1);
+    }
+    args.push(arg);
+  }
+  return args;
+}
+
 const codexBin = process.env.CODEX_BIN ?? "codex";
-const codexArgs = process.env.CODEX_ARGS ? process.env.CODEX_ARGS.split(" ") : [];
+const codexArgs = process.env.CODEX_ARGS ? parseShellArgs(process.env.CODEX_ARGS) : [];
 const child = spawn(codexBin, codexArgs, { stdio: ["pipe", "inherit", "inherit"] });
 
 child.on("error", (error) => {

--- a/tools/ai-support-server.js
+++ b/tools/ai-support-server.js
@@ -17,7 +17,21 @@ const port =
 const host = resolveHost();
 const codexBin = resolveCodexBin();
 const ghBin = resolveGhBin();
-const codexArgs = process.env.CODEX_ARGS ? process.env.CODEX_ARGS.split(' ') : [];
+/** Parse a shell-like argument string, respecting single and double quotes. */
+function parseShellArgs(str) {
+  const args = [];
+  const re = /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S+)/g;
+  let m;
+  while ((m = re.exec(str)) !== null) {
+    let arg = m[1];
+    if ((arg.startsWith('"') && arg.endsWith('"')) || (arg.startsWith("'") && arg.endsWith("'"))) {
+      arg = arg.slice(1, -1);
+    }
+    args.push(arg);
+  }
+  return args;
+}
+const codexArgs = process.env.CODEX_ARGS ? parseShellArgs(process.env.CODEX_ARGS) : [];
 const maxBodySize = 1_000_000;
 const verbose =
   process.env.AI_SUPPORT_VERBOSE !== '0' &&

--- a/tools/bundle-css.js
+++ b/tools/bundle-css.js
@@ -27,5 +27,6 @@ files.forEach(file => {
     }
 });
 
+fs.mkdirSync(path.dirname(outputFile), { recursive: true });
 fs.writeFileSync(outputFile, content);
 console.log(`Created ${outputFile} (${content.length} bytes)`);

--- a/tools/dev-mobile.js
+++ b/tools/dev-mobile.js
@@ -28,9 +28,17 @@ const aiProc = spawn('node', [aiSupportPath], {
   env: process.env,
 });
 
+aiProc.on('error', (err) => {
+  console.error(`[dev-mobile] Failed to start AI support server: ${err.message}`);
+});
+
 const viteProc = spawn('node', [withHttpsPath, ...viteArgs], {
   stdio: 'inherit',
   env: process.env,
+});
+
+viteProc.on('error', (err) => {
+  console.error(`[dev-mobile] Failed to start Vite: ${err.message}`);
 });
 
 let shuttingDown = false;

--- a/tools/sync-mobile.js
+++ b/tools/sync-mobile.js
@@ -16,7 +16,7 @@ const {
   readFileSync,
   writeFileSync,
 } = require('node:fs');
-const { join } = require('node:path');
+const { join, relative } = require('node:path');
 
 const ROOT = join(__dirname, '..');
 const SRC = join(ROOT, 'apps/mobile/build');
@@ -41,7 +41,7 @@ function dirChecksum(dir) {
       if (entry.isDirectory()) {
         walk(full);
       } else {
-        hash.update(full.replace(dir, ''));
+        hash.update(relative(dir, full));
         hash.update(readFileSync(full));
       }
     }


### PR DESCRIPTION
## Summary
- **#584**: `bundle-css.js` now creates the output directory before writing, preventing crashes when `shared/styles/` does not exist
- **#583**: `sync-mobile.js` uses `path.relative()` instead of `String.replace()` for checksum path normalization, ensuring consistent hashes across platforms
- **#582**: `dev-mobile.js` adds `.on('error')` handlers on both spawned child processes to prevent unhandled exceptions
- **#581**: `ai-codex.js` and `ai-support-server.js` replace naive `CODEX_ARGS.split(' ')` with a `parseShellArgs()` function that respects quoted strings

## Test plan
- [ ] Run `node tools/bundle-css.js` from a clean checkout (no `shared/styles/` dir) and verify it creates the directory and output file
- [ ] Run `node tools/sync-mobile.js` on different OS platforms and verify checksums are consistent
- [ ] Verify `npm run dev:mobile` starts without unhandled error events
- [ ] Set `CODEX_ARGS='--flag "hello world"'` and verify arguments are parsed correctly

Closes #581, closes #582, closes #583, closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)