### PR TITLE
Fix 8 mobile bugs: null safety, auth stability, validation

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -576,7 +576,7 @@ export function AppShell() {
 
       case 'support':
         return canViewAiSupport
-          ? <SupportChat userName={state.profile.name} onBack={() => nav.navigate('account-settings')} />
+          ? <SupportChat userName={state.profile.name} userId={authUserId} onBack={() => nav.navigate('account-settings')} />
           : <AccountSettings userName={state.profile.name} email={state.profile.email}
               showAiSupport={canViewAiSupport} showTicketPrototype={canViewTicketQrPrototype}
               leaderboardVisible={state.profile.leaderboardVisible}

--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -35,8 +35,8 @@ export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
   useEffect(() => { isScanningRef.current = isScanning; }, [isScanning]);
 
   const stopCamera = () => {
-    clearTimeout(scanTimeoutRef.current!); scanTimeoutRef.current = null;
-    clearTimeout(resumeTimeoutRef.current!); resumeTimeoutRef.current = null;
+    if (scanTimeoutRef.current) clearTimeout(scanTimeoutRef.current); scanTimeoutRef.current = null;
+    if (resumeTimeoutRef.current) clearTimeout(resumeTimeoutRef.current); resumeTimeoutRef.current = null;
     resumeScanRef.current = null;
     if (streamRef.current) { streamRef.current.getTracks().forEach(t => t.stop()); streamRef.current = null; }
     if (videoRef.current) videoRef.current.srcObject = null;

--- a/apps/mobile/src/components/screens/Signup.tsx
+++ b/apps/mobile/src/components/screens/Signup.tsx
@@ -26,7 +26,7 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
     const newErrors: Record<string, string> = {};
     if (!name) newErrors.name = 'Nome richiesto';
     if (!email) newErrors.email = 'Email richiesta';
-    if (!password) newErrors.password = 'Password richiesta';
+    if (!password) newErrors.password = 'Password richiesta'; else if (password.length < 8) newErrors.password = 'La password deve avere almeno 8 caratteri';
     if (password !== confirmPassword) newErrors.confirmPassword = 'Le password non corrispondono';
     if (!acceptTerms) newErrors.terms = 'Devi accettare i termini e la privacy';
     if (Object.keys(newErrors).length > 0) { setErrors(newErrors); return; }

--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -21,6 +21,7 @@ type ChatSession = { id: string; createdAt: number; updatedAt: number; messages:
 
 interface SupportChatProps {
   userName: string;
+  userId?: string;
   onBack: () => void;
 }
 
@@ -29,7 +30,7 @@ const MAX_SESSIONS = 10;
 const MAX_MESSAGES_PER_SESSION = 120;
 const ISSUE_DRAFT_MARKER = 'ISSUE_DRAFT:';
 
-export function SupportChat({ userName, onBack }: SupportChatProps) {
+export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
   const displayName = userName || 'Utente';
   const greetingMessage = useMemo(() => buildSupportMessage('assistant',
     `Ciao ${displayName}! Sono Maxwell, pronto a darti una mano. Come posso aiutarti?`), [displayName]);
@@ -55,7 +56,7 @@ export function SupportChat({ userName, onBack }: SupportChatProps) {
   }, [messages, isLoading]);
 
   useEffect(() => {
-    const stored = loadChatHistory(displayName);
+    const stored = loadChatHistory(displayName, userId);
     if (stored.length) {
       setChatSessions(stored);
       setActiveSessionId(stored[0].id);
@@ -66,7 +67,7 @@ export function SupportChat({ userName, onBack }: SupportChatProps) {
       setChatSessions([session]);
       setActiveSessionId(sessionId);
       setMessages(session.messages);
-      saveChatHistory(displayName, [session]);
+      saveChatHistory(displayName, [session], userId);
     }
     hasLoadedRef.current = true;
   }, [displayName, greetingMessage]);
@@ -77,7 +78,7 @@ export function SupportChat({ userName, onBack }: SupportChatProps) {
     if (!hasLoadedRef.current || !activeSessionId) return;
     setChatSessions(prev => {
       const next = updateSessionList(prev, activeSessionId, messages);
-      saveChatHistory(displayName, next);
+      saveChatHistory(displayName, next, userId);
       return next;
     });
   }, [messages, activeSessionId, displayName]);
@@ -156,7 +157,7 @@ export function SupportChat({ userName, onBack }: SupportChatProps) {
     setChatSessions(next);
     setActiveSessionId(sessionId);
     setMessages(session.messages);
-    saveChatHistory(displayName, next);
+    saveChatHistory(displayName, next, userId);
     setIsHistoryOpen(false);
   };
 
@@ -419,7 +420,8 @@ function buildSupportMessage(role: SupportMessage['role'], content: string): Sup
   return { id: buildMessageId(), role, content, createdAt: Date.now() };
 }
 
-function getHistoryKey(displayName: string) {
+function getHistoryKey(displayName: string, userId?: string) {
+  if (userId) return `${HISTORY_KEY_PREFIX}${userId}`;
   return `${HISTORY_KEY_PREFIX}${displayName.trim().toLowerCase().replace(/\s+/g, '-') || 'utente'}`;
 }
 
@@ -442,10 +444,10 @@ function validateSupportMessage(raw: unknown): SupportMessage | null {
   return { id, role, content, createdAt };
 }
 
-function loadChatHistory(displayName: string): ChatSession[] {
+function loadChatHistory(displayName: string, userId?: string): ChatSession[] {
   if (typeof window === 'undefined') return [];
   try {
-    const raw = window.localStorage.getItem(getHistoryKey(displayName));
+    const raw = window.localStorage.getItem(getHistoryKey(displayName, userId));
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
@@ -469,10 +471,10 @@ function loadChatHistory(displayName: string): ChatSession[] {
   } catch { return []; }  
 }
 
-function saveChatHistory(displayName: string, sessions: ChatSession[]) {
+function saveChatHistory(displayName: string, sessions: ChatSession[], userId?: string) {
   if (typeof window === 'undefined') return;
   const trimmed = [...sessions].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, MAX_SESSIONS);
-  try { window.localStorage.setItem(getHistoryKey(displayName), JSON.stringify(trimmed)); } catch { /* noop */ }
+  try { window.localStorage.setItem(getHistoryKey(displayName, userId), JSON.stringify(trimmed)); } catch { /* noop */ }
 }
 
 function trimMessages(messages: SupportMessage[]) {

--- a/apps/mobile/src/gameplay/minigames.ts
+++ b/apps/mobile/src/gameplay/minigames.ts
@@ -23,7 +23,6 @@ export type MinigameOutcome = {
   type: MinigameType;
   score: number;
   rating: MinigameRating;
-  accuracy: number;
   roundScores: number[];
   attempts: number;
   durationMs: number;
@@ -101,6 +100,13 @@ const FALLBACK_CONFIG: MinigameConfig = {
   ],
 };
 
+/**
+ * Check whether a minigame activity is available for the given role.
+ *
+ * When `roleId` is `null` or `undefined` (i.e. no role selected yet):
+ * - Activities without an `allowedRoles` restriction return `true` (available to everyone).
+ * - Activities restricted to specific roles return `false` (role required).
+ */
 export function isMinigameAvailableForRole(activityId: string, roleId?: RoleId | null): boolean {
   const config = MINIGAME_BY_ACTIVITY[activityId] ?? FALLBACK_CONFIG;
   if (!config.allowedRoles?.length) return true;
@@ -142,13 +148,11 @@ export function computeOutcome(
   const safeScores = roundScores.length ? roundScores : [0];
   const total = safeScores.reduce((sum, value) => sum + value, 0);
   const score = Math.round(total / safeScores.length);
-  const accuracy = Math.round(score);
   const rating = ratingFromScore(score);
 
   return {
     type,
     score,
-    accuracy,
     rating,
     roundScores,
     attempts: Math.max(1, Math.round(meta?.attempts ?? 1)),

--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { supabase, isSupabaseConfigured } from '../lib/supabase';
 import { resolveDisplayName } from '../lib/profile-utils';
 import { PlayerProfile } from '../state/store';
@@ -96,6 +96,11 @@ export function useAuth(
         onLogout();
     }, [onLogout]);
 
+    const profileNameRef = useRef(profile.name);
+    const profileEmailRef = useRef(profile.email);
+    useEffect(() => { profileNameRef.current = profile.name; }, [profile.name]);
+    useEffect(() => { profileEmailRef.current = profile.email; }, [profile.email]);
+
     const applyUserProfileFromAuth = useCallback(
         (
             user: { email?: string | null; user_metadata?: Record<string, unknown> } | null | undefined,
@@ -109,22 +114,22 @@ export function useAuth(
                 return;
             }
 
-            const email = user.email ?? profile.email;
+            const email = user.email ?? profileEmailRef.current;
             const displayName = resolveDisplayName({
                 name: (user.user_metadata?.name as string | undefined),
                 metadata: user.user_metadata,
                 email,
-                fallback: options?.fallbackName ?? profile.name,
+                fallback: options?.fallbackName ?? profileNameRef.current,
             });
 
-            const shouldSetName = shouldUpdateName(profile.name, email, displayName);
+            const shouldSetName = shouldUpdateName(profileNameRef.current, email, displayName);
             updateProfile(shouldSetName ? { name: displayName, email } : { email });
 
             if (options?.navigateTo) {
                 onAuthChange(options.navigateTo, options.navigateReplace);
             }
         },
-        [profile.name, profile.email, updateProfile, onAuthChange],
+        [updateProfile, onAuthChange],
     );
 
     useEffect(() => {

--- a/apps/mobile/src/lib/event-linking.ts
+++ b/apps/mobile/src/lib/event-linking.ts
@@ -46,9 +46,13 @@ export function readPendingEventFromUrl(locationHref: string): ParsedEventLink |
 }
 
 export function stripEventLinkParams(locationHref: string): string {
-  const url = new URL(locationHref);
-  url.searchParams.delete('event_id');
-  url.searchParams.delete('eid');
-  url.searchParams.delete('role_id');
-  return url.toString();
+  try {
+    const url = new URL(locationHref);
+    url.searchParams.delete('event_id');
+    url.searchParams.delete('eid');
+    url.searchParams.delete('role_id');
+    return url.toString();
+  } catch {
+    return locationHref;
+  }
 }

--- a/apps/mobile/src/router/NavigatorContext.tsx
+++ b/apps/mobile/src/router/NavigatorContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useCallback, useRef, useEffect } from 'react';
+import React, { createContext, useContext, useCallback } from 'react';
 import { Screen, Tab, LegalReturnScreen } from '../types/navigation';
 import { useNavigation } from '../hooks/useNavigation';
 
@@ -74,16 +74,6 @@ export function NavigatorProvider({
     scannedEventId, setScannedEventId,
     selectedActivityId, setSelectedActivityId,
   } = useNavigation(initialEvents, { isScreenEnabled, isTabEnabled });
-
-  const historyRef = useRef<Screen[]>([currentScreen]);
-
-  useEffect(() => {
-    const history = historyRef.current;
-    if (history[history.length - 1] !== currentScreen) {
-      history.push(currentScreen);
-      if (history.length > 20) history.shift();
-    }
-  }, [currentScreen]);
 
   const navigate = useCallback((screen: Screen) => {
     setCurrentScreen(screen);


### PR DESCRIPTION
## Summary
- **#565**: Replace `clearTimeout(ref.current!)` non-null assertions with proper null checks in QRScanner
- **#564**: Stabilize `useAuth` effect by moving profile values to refs, preventing auth listener unsubscribe/re-subscribe on every profile change
- **#563**: Wrap `new URL()` in `stripEventLinkParams` with try-catch, returning original string on invalid URLs
- **#562**: Add JSDoc to `isMinigameAvailableForRole` documenting null `roleId` behavior
- **#561**: Remove redundant `accuracy` field from `MinigameOutcome` (was always `Math.round(score)`, never consumed externally)
- **#560**: Key SupportChat localStorage history by `userId` instead of display name, with fallback to display name when no userId
- **#559**: Remove dead `historyRef` code in NavigatorContext (accumulated screen history that was never read)
- **#558**: Add `password.length >= 8` validation in Signup form (UI hint already existed, but code only checked for non-empty)

## Test plan
- [ ] QRScanner: verify camera start/stop works without runtime errors
- [ ] Auth: verify login/signup flows work and auth listener does not flicker on profile changes
- [ ] Event linking: pass an invalid URL string to `stripEventLinkParams` and confirm no crash
- [ ] Minigames: verify `computeOutcome` returns correct shape without `accuracy` field
- [ ] SupportChat: verify chat history persists correctly per user ID
- [ ] Navigation: verify screen transitions still work after removing historyRef
- [ ] Signup: verify password shorter than 8 characters shows validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)