### PR TITLE
Fix mobile component bugs (#558-#565)

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -576,7 +576,7 @@ export function AppShell() {
 
       case 'support':
         return canViewAiSupport
-          ? <SupportChat userName={state.profile.name} onBack={() => nav.navigate('account-settings')} />
+          ? <SupportChat userName={state.profile.name} userId={authUserId ?? undefined} onBack={() => nav.navigate('account-settings')} />
           : <AccountSettings userName={state.profile.name} email={state.profile.email}
               showAiSupport={canViewAiSupport} showTicketPrototype={canViewTicketQrPrototype}
               leaderboardVisible={state.profile.leaderboardVisible}

--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -35,8 +35,8 @@ export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
   useEffect(() => { isScanningRef.current = isScanning; }, [isScanning]);
 
   const stopCamera = () => {
-    clearTimeout(scanTimeoutRef.current!); scanTimeoutRef.current = null;
-    clearTimeout(resumeTimeoutRef.current!); resumeTimeoutRef.current = null;
+    if (scanTimeoutRef.current != null) { clearTimeout(scanTimeoutRef.current); scanTimeoutRef.current = null; }
+    if (resumeTimeoutRef.current != null) { clearTimeout(resumeTimeoutRef.current); resumeTimeoutRef.current = null; }
     resumeScanRef.current = null;
     if (streamRef.current) { streamRef.current.getTracks().forEach(t => t.stop()); streamRef.current = null; }
     if (videoRef.current) videoRef.current.srcObject = null;

--- a/apps/mobile/src/components/screens/Signup.tsx
+++ b/apps/mobile/src/components/screens/Signup.tsx
@@ -27,6 +27,7 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
     if (!name) newErrors.name = 'Nome richiesto';
     if (!email) newErrors.email = 'Email richiesta';
     if (!password) newErrors.password = 'Password richiesta';
+    else if (password.length < 8) newErrors.password = 'Almeno 8 caratteri';
     if (password !== confirmPassword) newErrors.confirmPassword = 'Le password non corrispondono';
     if (!acceptTerms) newErrors.terms = 'Devi accettare i termini e la privacy';
     if (Object.keys(newErrors).length > 0) { setErrors(newErrors); return; }

--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -21,6 +21,7 @@ type ChatSession = { id: string; createdAt: number; updatedAt: number; messages:
 
 interface SupportChatProps {
   userName: string;
+  userId?: string;
   onBack: () => void;
 }
 
@@ -29,8 +30,9 @@ const MAX_SESSIONS = 10;
 const MAX_MESSAGES_PER_SESSION = 120;
 const ISSUE_DRAFT_MARKER = 'ISSUE_DRAFT:';
 
-export function SupportChat({ userName, onBack }: SupportChatProps) {
+export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
   const displayName = userName || 'Utente';
+  const historyId = userId || displayName;
   const greetingMessage = useMemo(() => buildSupportMessage('assistant',
     `Ciao ${displayName}! Sono Maxwell, pronto a darti una mano. Come posso aiutarti?`), [displayName]);
   const isMobile = useIsMobile();
@@ -55,7 +57,7 @@ export function SupportChat({ userName, onBack }: SupportChatProps) {
   }, [messages, isLoading]);
 
   useEffect(() => {
-    const stored = loadChatHistory(displayName);
+    const stored = loadChatHistory(historyId);
     if (stored.length) {
       setChatSessions(stored);
       setActiveSessionId(stored[0].id);
@@ -66,10 +68,10 @@ export function SupportChat({ userName, onBack }: SupportChatProps) {
       setChatSessions([session]);
       setActiveSessionId(sessionId);
       setMessages(session.messages);
-      saveChatHistory(displayName, [session]);
+      saveChatHistory(historyId, [session]);
     }
     hasLoadedRef.current = true;
-  }, [displayName, greetingMessage]);
+  }, [historyId, greetingMessage]);
 
   useEffect(() => () => { abortControllerRef.current?.abort(); }, []);
 
@@ -77,10 +79,10 @@ export function SupportChat({ userName, onBack }: SupportChatProps) {
     if (!hasLoadedRef.current || !activeSessionId) return;
     setChatSessions(prev => {
       const next = updateSessionList(prev, activeSessionId, messages);
-      saveChatHistory(displayName, next);
+      saveChatHistory(historyId, next);
       return next;
     });
-  }, [messages, activeSessionId, displayName]);
+  }, [messages, activeSessionId, historyId]);
 
   const hasInput = input.trim().length > 0;
   const activeSession = useMemo(
@@ -156,7 +158,7 @@ export function SupportChat({ userName, onBack }: SupportChatProps) {
     setChatSessions(next);
     setActiveSessionId(sessionId);
     setMessages(session.messages);
-    saveChatHistory(displayName, next);
+    saveChatHistory(historyId, next);
     setIsHistoryOpen(false);
   };
 
@@ -419,8 +421,8 @@ function buildSupportMessage(role: SupportMessage['role'], content: string): Sup
   return { id: buildMessageId(), role, content, createdAt: Date.now() };
 }
 
-function getHistoryKey(displayName: string) {
-  return `${HISTORY_KEY_PREFIX}${displayName.trim().toLowerCase().replace(/\s+/g, '-') || 'utente'}`;
+function getHistoryKey(id: string) {
+  return `${HISTORY_KEY_PREFIX}${id.trim().toLowerCase().replace(/\s+/g, '-') || 'utente'}`;
 }
 
 function validateSupportMessage(raw: unknown): SupportMessage | null {

--- a/apps/mobile/src/gameplay/minigames.ts
+++ b/apps/mobile/src/gameplay/minigames.ts
@@ -101,6 +101,14 @@ const FALLBACK_CONFIG: MinigameConfig = {
   ],
 };
 
+/**
+ * Check whether a minigame is available for the given role.
+ *
+ * When `roleId` is `null` or `undefined` (e.g. the user has not selected a
+ * role yet), the function returns `true` only if the minigame has no
+ * role restrictions (`allowedRoles` is empty or missing). If the minigame
+ * is restricted to specific roles and no role is provided, it returns `false`.
+ */
 export function isMinigameAvailableForRole(activityId: string, roleId?: RoleId | null): boolean {
   const config = MINIGAME_BY_ACTIVITY[activityId] ?? FALLBACK_CONFIG;
   if (!config.allowedRoles?.length) return true;
@@ -123,15 +131,14 @@ export function getMinigameConfig(activityId: string, roleId?: RoleId | null): M
 
 export function computeRoundScore(target: number, hit: number, tolerance: number) {
   const delta = Math.abs(target - hit);
-  const accuracy = Math.max(0, 100 - delta * 2);
-  const score = Math.round(accuracy);
+  const score = Math.round(Math.max(0, 100 - delta * 2));
   let label = 'Da migliorare';
 
   if (delta <= tolerance) label = 'Perfetto';
   else if (delta <= tolerance * 2) label = 'Ottimo';
   else if (delta <= tolerance * 3) label = 'Buono';
 
-  return { score, accuracy, delta, label };
+  return { score, delta, label };
 }
 
 export function computeOutcome(
@@ -142,13 +149,12 @@ export function computeOutcome(
   const safeScores = roundScores.length ? roundScores : [0];
   const total = safeScores.reduce((sum, value) => sum + value, 0);
   const score = Math.round(total / safeScores.length);
-  const accuracy = Math.round(score);
   const rating = ratingFromScore(score);
 
   return {
     type,
     score,
-    accuracy,
+    accuracy: score,
     rating,
     roundScores,
     attempts: Math.max(1, Math.round(meta?.attempts ?? 1)),

--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { supabase, isSupabaseConfigured } from '../lib/supabase';
 import { resolveDisplayName } from '../lib/profile-utils';
 import { PlayerProfile } from '../state/store';
@@ -127,6 +127,12 @@ export function useAuth(
         [profile.name, profile.email, updateProfile, onAuthChange],
     );
 
+    const applyUserProfileRef = useRef(applyUserProfileFromAuth);
+    useEffect(() => { applyUserProfileRef.current = applyUserProfileFromAuth; }, [applyUserProfileFromAuth]);
+
+    const onLogoutRef = useRef(onLogout);
+    useEffect(() => { onLogoutRef.current = onLogout; }, [onLogout]);
+
     useEffect(() => {
         if (!supabase) return;
         let mounted = true;
@@ -134,7 +140,7 @@ export function useAuth(
         supabase.auth.getSession().then(({ data, error }) => {
             if (!mounted || error) return;
             if (data.session?.user) {
-                applyUserProfileFromAuth(data.session.user, {
+                applyUserProfileRef.current(data.session.user, {
                     navigateTo: 'home',
                 });
             }
@@ -143,18 +149,18 @@ export function useAuth(
         const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
             if (!mounted) return;
             if (event === 'SIGNED_OUT') {
-                onLogout();
+                onLogoutRef.current();
                 return;
             }
             if (event === 'PASSWORD_RECOVERY') {
-                applyUserProfileFromAuth(session?.user, {
+                applyUserProfileRef.current(session?.user, {
                     navigateTo: 'change-password',
                     navigateReplace: true,
                 });
                 return;
             }
             if (session?.user) {
-                applyUserProfileFromAuth(session.user, {
+                applyUserProfileRef.current(session.user, {
                     navigateTo: 'home',
                 });
             }
@@ -164,7 +170,7 @@ export function useAuth(
             mounted = false;
             authListener?.subscription.unsubscribe();
         };
-    }, [supabase, applyUserProfileFromAuth, onLogout]);
+    }, [supabase]);
 
     return {
         authError,

--- a/apps/mobile/src/lib/event-linking.ts
+++ b/apps/mobile/src/lib/event-linking.ts
@@ -46,9 +46,13 @@ export function readPendingEventFromUrl(locationHref: string): ParsedEventLink |
 }
 
 export function stripEventLinkParams(locationHref: string): string {
-  const url = new URL(locationHref);
-  url.searchParams.delete('event_id');
-  url.searchParams.delete('eid');
-  url.searchParams.delete('role_id');
-  return url.toString();
+  try {
+    const url = new URL(locationHref);
+    url.searchParams.delete('event_id');
+    url.searchParams.delete('eid');
+    url.searchParams.delete('role_id');
+    return url.toString();
+  } catch {
+    return locationHref;
+  }
 }

--- a/apps/mobile/src/router/NavigatorContext.tsx
+++ b/apps/mobile/src/router/NavigatorContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useCallback, useRef, useEffect } from 'react';
+import React, { createContext, useContext, useCallback } from 'react';
 import { Screen, Tab, LegalReturnScreen } from '../types/navigation';
 import { useNavigation } from '../hooks/useNavigation';
 
@@ -74,16 +74,6 @@ export function NavigatorProvider({
     scannedEventId, setScannedEventId,
     selectedActivityId, setSelectedActivityId,
   } = useNavigation(initialEvents, { isScreenEnabled, isTabEnabled });
-
-  const historyRef = useRef<Screen[]>([currentScreen]);
-
-  useEffect(() => {
-    const history = historyRef.current;
-    if (history[history.length - 1] !== currentScreen) {
-      history.push(currentScreen);
-      if (history.length > 20) history.shift();
-    }
-  }, [currentScreen]);
 
   const navigate = useCallback((screen: Screen) => {
     setCurrentScreen(screen);


### PR DESCRIPTION
## Summary
- **#565**: Replace `clearTimeout(ref.current!)` non-null assertion with explicit null check in QRScanner
- **#564**: Stabilize auth effect with `useRef` for `applyUserProfileFromAuth` and `onLogout` to prevent re-subscribe on every profile change
- **#563**: Wrap `new URL()` in try-catch with fallback returning original string in `stripEventLinkParams`
- **#562**: Add JSDoc documenting `isMinigameAvailableForRole` behavior when `roleId` is `null`/`undefined`
- **#561**: Remove redundant `accuracy` variable (was always identical to `score`) in minigame scoring functions
- **#560**: Key chat history by `authUserId` instead of display name in SupportChat to prevent data loss on name change
- **#559**: Remove dead `historyRef` code and unused `useRef`/`useEffect` imports in NavigatorContext
- **#558**: Add `password.length >= 8` validation in Signup (UI already shows "Almeno 8 caratteri")

## Test plan
- [ ] QR scanner starts/stops without errors
- [ ] Auth login/signup works without excessive re-renders
- [ ] Chat history persists correctly across sessions
- [ ] Minigame scoring produces correct results
- [ ] Signup rejects passwords shorter than 8 characters
- [ ] Navigation works correctly after historyRef removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)