### PR TITLE
Implement #469: Minigiochi espansione Tempismo Luci + Livello Audio

### DIFF
--- a/apps/mobile/src/gameplay/minigames.ts
+++ b/apps/mobile/src/gameplay/minigames.ts
@@ -87,6 +87,30 @@ const MINIGAME_BY_ACTIVITY: Record<string, MinigameConfig> = {
       { target: 47, tolerance: 6, label: 'Snodo 3' },
     ],
   },
+  // Issue #469: Espansione minigiochi per ruoli specifici
+  sequenza_luci: {
+    type: 'timing',
+    title: 'Sequenza cue luci',
+    subtitle: 'Esegui una sequenza di cue luci in rapida successione. Precisione estrema richiesta.',
+    allowedRoles: ['luci'],
+    rounds: [
+      { target: 45, tolerance: 4, label: 'Cue Apertura' },
+      { target: 30, tolerance: 3, label: 'Cue Transizione' },
+      { target: 70, tolerance: 4, label: 'Cue Finale' },
+      { target: 55, tolerance: 3, label: 'Cue Blackout' },
+    ],
+  },
+  equalizzazione: {
+    type: 'audio',
+    title: 'Equalizzazione frequenze',
+    subtitle: 'Bilancia le frequenze basse, medie e alte per un mix perfetto.',
+    allowedRoles: ['fonico'],
+    rounds: [
+      { target: 35, tolerance: 5, label: 'Frequenze basse (batteria)' },
+      { target: 65, tolerance: 4, label: 'Frequenze medie (voce)' },
+      { target: 50, tolerance: 5, label: 'Frequenze alte (cymbal)' },
+    ],
+  },
 };
 
 const FALLBACK_CONFIG: MinigameConfig = {

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -499,6 +499,25 @@ export const activities: Activity[] = [
     cachetReward: 24,
     difficulty: 'Medio',
   },
+  // Issue #469: Espansione minigiochi per ruoli specifici
+  {
+    id: 'sequenza_luci',
+    title: 'Sequenza cue luci',
+    description: 'Esegui una sequenza di cue luci in rapida successione. Precisione estrema richiesta per tecnici luci.',
+    duration: '6 min',
+    xpReward: 75,
+    cachetReward: 35,
+    difficulty: 'Difficile',
+  },
+  {
+    id: 'equalizzazione',
+    title: 'Equalizzazione frequenze',
+    description: 'Bilancia le frequenze basse, medie e alte per un mix audio perfetto. Solo per fonici esperti.',
+    duration: '5 min',
+    xpReward: 70,
+    cachetReward: 32,
+    difficulty: 'Difficile',
+  },
 ];
 
 const DEFAULT_SHOP_CATALOG: ShopCatalogItem[] = [


### PR DESCRIPTION
## Implementazione Issue #469

Questa PR implementa l'espansione dei minigiochi richiesta nella issue #469.

### Aggiunte

- **Sequenza cue luci** (sequenza_luci):
  - Minigioco di tipo _timing_ dedicato al ruolo **Tecnico Luci**
  - 4 round con tolleranze ridotte (3-4) per maggiore difficoltà
  - Rewards: 75 XP, 35 cachet
  - Accessibile solo al ruolo luci`n
- **Equalizzazione frequenze** (equalizzazione):
  - Minigioco di tipo _audio_ dedicato al ruolo **Fonico**
  - 3 round per bilanciamento frequenze (basse, medie, alte)
  - Rewards: 70 XP, 32 cachet
  - Accessibile solo al ruolo onico`n
### File modificati

- pps/mobile/src/gameplay/minigames.ts - Aggiunte configurazioni minigiochi
- pps/mobile/src/state/store.tsx - Aggiunte attività con rewards

### Come testare

1. Selezionare il ruolo _Tecnico Luci_ → verificare la disponibilità di _Sequenza cue luci_
2. Selezionare il ruolo _Fonico_ → verificare la disponibilità di _Equalizzazione frequenze_
3. Verificare che gli altri ruoli NON vedano questi minigiochi

Closes #469