### PR TITLE
Fix CORS: add Vercel origin to Maxwell and Control Plane

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -32,7 +32,7 @@ services:
   - key: VITE_SUPABASE_URL
     sync: false
   - key: AI_SUPPORT_ALLOWED_ORIGINS
-    value: https://turni-di-palco-fq85.onrender.com,https://turni-di-palco-fq85.onrender.com/mobile
+    value: https://turni-di-palco-fq85.onrender.com,https://turni-di-palco-fq85.onrender.com/mobile,https://turni-di-palco.vercel.app
   - key: GROQ_API_KEY
     sync: false
   - key: GROQ_MODEL
@@ -61,7 +61,7 @@ services:
   - key: RENDER_SERVICE_IDS_JSON
     sync: false
   - key: CONTROL_PLANE_ALLOWED_ORIGINS
-    value: https://turni-di-palco-fq85.onrender.com,https://turni-di-palco-fq85.onrender.com/mobile
+    value: https://turni-di-palco-fq85.onrender.com,https://turni-di-palco-fq85.onrender.com/mobile,https://turni-di-palco.vercel.app
   - key: CONTROL_PLANE_ALLOWED_EMAILS
     sync: false
   - key: CONTROL_PLANE_RATE_LIMIT_PER_MIN


### PR DESCRIPTION
## Summary

- Aggiunge `https://turni-di-palco.vercel.app` a `AI_SUPPORT_ALLOWED_ORIGINS` (Maxwell)
- Aggiunge `https://turni-di-palco.vercel.app` a `CONTROL_PLANE_ALLOWED_ORIGINS`

## Problema

Le richieste da `turni-di-palco.vercel.app` verso Maxwell venivano bloccate dal CORS:
```
Access to fetch at 'https://maxwell-ai-support.onrender.com/api/ai/chat' from origin
'https://turni-di-palco.vercel.app' has been blocked by CORS policy
```

## Test plan

- [ ] Dopo il redeploy, verificare che `/api/ai/chat` risponda correttamente dal dominio Vercel
- [ ] Nessuna regressione sulle origini Render esistenti

🤖 Generated with [Claude Code](https://claude.com/claude-code)