### PR TITLE
fix(pwa): network-first HTML fetch to prevent stale-cache blank screen

### DIFF
--- a/apps/pwa/public/sw.js
+++ b/apps/pwa/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = "pwa-v1";
+const CACHE_VERSION = "pwa-v2";
 const PRECACHE_URLS = ["/"];
 
 self.addEventListener("install", (event) => {
@@ -23,6 +23,18 @@ self.addEventListener("activate", (event) => {
 
 self.addEventListener("fetch", (event) => {
   if (event.request.method !== "GET") return;
+
+  // Navigation requests (HTML pages): network-first so Vite deploys with new
+  // chunk hashes are never blocked by a stale cached HTML entry.
+  if (event.request.mode === "navigate") {
+    event.respondWith(
+      fetch(event.request).catch(() =>
+        caches.match(event.request).then((cached) => cached || caches.match("/"))
+      )
+    );
+    return;
+  }
+
   event.respondWith(
     caches.match(event.request).then((cached) => cached || fetch(event.request))
   );


### PR DESCRIPTION
## Summary
- Bump `CACHE_VERSION` da `pwa-v1` a `pwa-v2` per invalidare la cache vecchia che conteneva un `index.html` che referenziava il chunk `index-CRLNQSQT.js` (non più presente sul server dopo il deploy)
- Aggiunto handler **network-first** per le richieste di navigazione HTML: il browser scarica sempre la versione aggiornata dall'origine; la cache è usata solo come fallback offline

## Test plan
- [ ] Aprire la PWA con il vecchio SW ancora attivo → al refresh il SW si aggiorna e la pagina carica correttamente
- [ ] Simulare offline dopo un deploy: la pagina fallback da cache viene servita
- [ ] Verificare assenza dell'errore `404 /assets/index-CRLNQSQT.js` in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)