### PR TITLE
fix(mobile): add preview:https script for Render deploy

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -40,6 +40,7 @@
   },
   "scripts": {
     "dev": "node ../../tools/with-https-env.js vite --host 0.0.0.0 --port 4174 --strictPort --clearScreen false",
+    "preview:https": "vite preview",
     "dev:with-ai": "node ../../tools/dev-mobile.js",
     "build": "vite build",
     "lint": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
## Summary
- Aggiunto script `preview:https` in `apps/mobile/package.json` — Render lo chiama con `npm run preview:https -- --host 0.0.0.0 --port $PORT ...`
- Lo script è semplicemente `vite preview`; i flag vengono passati da Render via `--`
- Non serve `with-https-env.js` in produzione perché Render gestisce l'SSL al load balancer

## Test plan
- [ ] Deploy su Render va a buon fine senza `Missing script: "preview:https"`
- [ ] L'app mobile è raggiungibile sulla porta configurata

🤖 Generated with [Claude Code](https://claude.com/claude-code)