### PR TITLE
fix(pwa): add missing vite-env.d.ts to resolve import.meta.env TS errors

### DIFF
--- a/apps/pwa/src/vite-env.d.ts
+++ b/apps/pwa/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- Crea `apps/pwa/src/vite-env.d.ts` con `/// <reference types="vite/client" />`
- Risolve 4 errori TypeScript (`TS2339: Property 'env' does not exist on type 'ImportMeta'`) in `src/services/dev-gate.ts` e `src/services/supabase.ts`
- Allinea il comportamento della PWA a quello già presente in `apps/mobile/src/vite-env.d.ts`

## Test plan
- [ ] `cd apps/pwa && npx tsc --noEmit` → output vuoto (zero errori)
- [ ] `npm run build:pwa` → build completata con successo

🤖 Generated with [Claude Code](https://claude.com/claude-code)