### PR TITLE
Fix: attributo lang="en" su app italiana

### DIFF
--- a/apps/mobile/index.html
+++ b/apps/mobile/index.html
@@ -1,6 +1,6 @@
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="it">
   <head>
     <meta charset="UTF-8" />
     <meta


### PR DESCRIPTION
Closes #532

## What
Changed `lang="en"` to `lang="it"` in `apps/mobile/index.html`.

## How
Single-line change to the `<html>` element's `lang` attribute. The app is entirely in Italian; `lang="en"` caused screen readers to pronounce Italian text with English pronunciation and was a WCAG violation.

## Test plan
- Open the mobile app and inspect the HTML element in DevTools — `lang` should be `it`
- Screen reader tools should now correctly identify the language as Italian