### PR TITLE
Fix: porta 8787 offuscata con String.fromCharCode

### DIFF
--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -44,7 +44,7 @@ function resolveHttps(): ServerOptions | undefined {
 }
 
 const DEFAULT_ALLOWED_HOSTS = ['turni-di-palco-fq85.onrender.com'];
-const DEFAULT_AI_SUPPORT_PORT = Number.parseInt(String.fromCharCode(56, 55, 56, 55), 10);
+const DEFAULT_AI_SUPPORT_PORT = 8787;
 
 function resolveAllowedHosts(env: Record<string, string>) {
   const raw =


### PR DESCRIPTION
Closes #536

## What
Replaced `Number.parseInt(String.fromCharCode(56, 55, 56, 55), 10)` with the literal `8787` in `apps/mobile/vite.config.ts`.

## How
Single-line change. The obfuscation provided no security benefit and hindered readability for developers auditing the config.