### PR TITLE
Fix: eventi a mezzanotte ricevono ora sbagliata

### DIFF
--- a/supabase/functions/import-spazio-rossellini/index.ts
+++ b/supabase/functions/import-spazio-rossellini/index.ts
@@ -47,7 +47,7 @@ const formatDate = (details?: SpazioEvent['start_date_details'], fallback?: stri
 };
 
 const formatTime = (details?: SpazioEvent['start_date_details'], fallback?: string) => {
-  if (details?.hour && details?.minutes != null) {
+  if (details?.hour != null && details?.minutes != null) {
     return `${String(details.hour).padStart(2, '0')}:${String(details.minutes).padStart(2, '0')}`;
   }
   if (fallback) {

--- a/tools/import-spazio-rossellini-events.js
+++ b/tools/import-spazio-rossellini-events.js
@@ -69,7 +69,7 @@ const formatDate = (details, fallback) => {
 };
 
 const formatTime = (details, fallback) => {
-  if (details?.hour && details?.minutes != null) {
+  if (details?.hour != null && details?.minutes != null) {
     return `${String(details.hour).padStart(2, '0')}:${String(details.minutes).padStart(2, '0')}`;
   }
   if (fallback) {


### PR DESCRIPTION
Closes #543

## What
Fixed a falsy check bug that caused events starting at midnight (hour = 0) to fall through to the default time "20:30".

## How
Changed `details?.hour` (falsy when 0) to `details?.hour != null` in both:
- `tools/import-spazio-rossellini-events.js`
- `supabase/functions/import-spazio-rossellini/index.ts`

This ensures events at midnight are correctly formatted as "00:MM" instead of "20:30".