### PR TITLE
Fix: custom .env parser non rimuove virgolette dai valori

### DIFF
--- a/tools/import-spazio-rossellini-events.js
+++ b/tools/import-spazio-rossellini-events.js
@@ -20,7 +20,7 @@ const loadEnv = () => {
     const index = trimmed.indexOf('=');
     if (index === -1) return;
     const key = trimmed.slice(0, index).trim();
-    const value = trimmed.slice(index + 1).trim();
+    const value = trimmed.slice(index + 1).trim().replace(/^["']|["']$/g, '');
     if (!process.env[key]) {
       process.env[key] = value;
     }


### PR DESCRIPTION
Closes #544

## What
The custom `.env` file parser in `tools/import-spazio-rossellini-events.js` did not strip surrounding quotes from values, causing `URL="https://example.com"` to be parsed as `"https://example.com"` (with literal quotes), leading to failed HTTP requests.

## How
Added `.replace(/^["']|["']$/g, '')` to the parsed value to strip any surrounding single or double quotes, matching the behaviour of the `dotenv` library.