### PR TITLE
Fix: PWA promise rejection e null assertion non gestite

### DIFF
--- a/apps/pwa/src/dashboard.ts
+++ b/apps/pwa/src/dashboard.ts
@@ -134,6 +134,9 @@ export function renderDashboard(root: HTMLElement): void {
   void getUserEmail().then((email) => {
     const el = root.querySelector<HTMLElement>("[data-user-email]");
     if (el) el.textContent = email;
+  }).catch(() => {
+    const el = root.querySelector<HTMLElement>("[data-user-email]");
+    if (el) el.textContent = "—";
   });
 
   // Feature flags
@@ -149,7 +152,11 @@ export function renderDashboard(root: HTMLElement): void {
 
   // Sign out
   root.querySelector<HTMLButtonElement>("[data-signout]")?.addEventListener("click", async () => {
-    if (supabase) await supabase.auth.signOut();
+    try {
+      if (supabase) await supabase.auth.signOut();
+    } catch {
+      // sign-out failure must not block reload
+    }
     window.location.reload();
   });
 }

--- a/apps/pwa/src/main.ts
+++ b/apps/pwa/src/main.ts
@@ -5,7 +5,9 @@ import { renderDashboard } from "./dashboard";
 const start = async () => {
   const allowed = await requireDevAccess();
   if (!allowed) return;
-  renderDashboard(document.querySelector<HTMLElement>("#app")!);
+  const root = document.querySelector<HTMLElement>("#app");
+  if (!root) return;
+  renderDashboard(root);
 };
 
 void start();


### PR DESCRIPTION
Closes #514, #515, #516

## What
Three related error-handling fixes in the PWA app:

1. **#516** (`apps/pwa/src/main.ts`): Replaced non-null assertion `querySelector("#app")!` with an explicit null check. If the element is missing, the function returns early instead of crashing with a `TypeError`.

2. **#514** (`apps/pwa/src/dashboard.ts`): Added `.catch()` to the `getUserEmail()` promise chain. Previously, an auth failure produced an unhandled promise rejection and the email element remained showing "—" with no error logged.

3. **#515** (`apps/pwa/src/dashboard.ts`): Wrapped `supabase.auth.signOut()` in a `try/catch`. Previously, a network failure would throw, `window.location.reload()` would never be called, and the user would be stuck on the page with no feedback.

## How
Minimal changes: null guard in `main.ts`, `.catch()` callback in the email fetch chain, and `try/catch` around the sign-out call.