### PR TITLE
Fix: reset authError al logout e rimozione JWT prefix dai log

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -93,6 +93,7 @@ export function useAuth(
     }, [onAuthChange, updateProfile]);
 
     const handleLogoutAction = useCallback(async () => {
+        setAuthError(null);
         if (supabase) {
             try {
                 await supabase.auth.signOut();

--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -197,7 +197,7 @@ async function getAccessTokenForFunctions(): Promise<string> {
     !sessionToken || !expiresAt || expiresAt <= nowSeconds + TOKEN_REFRESH_SKEW_SECONDS;
 
   if (!shouldRefresh && sessionToken) {
-    console.log('[ticket-activation] Using cached token, length:', sessionToken.length, 'remaining_s:', expiresAt - nowSeconds, 'prefix:', sessionToken.slice(0, 20));
+    console.log('[ticket-activation] Using cached token, hasToken:', true, 'remaining_s:', expiresAt - nowSeconds);
     return sessionToken;
   }
 
@@ -213,7 +213,7 @@ async function getAccessTokenForFunctions(): Promise<string> {
     throw new Error(SESSION_REQUIRED_MESSAGE);
   }
 
-  console.log('[ticket-activation] Using refreshed token, length:', refreshedToken.length, 'prefix:', refreshedToken.slice(0, 20));
+  console.log('[ticket-activation] Using refreshed token, hasToken:', true);
   return refreshedToken;
 }
 
@@ -223,7 +223,7 @@ async function invokeTicketActivation(body: Record<string, unknown>) {
   }
 
   const token = await getAccessTokenForFunctions();
-  console.log('[ticket-activation] Invoking function, token length:', token.length, 'prefix:', token.slice(0, 20), 'action:', (body as Record<string, unknown>).action);
+  console.log('[ticket-activation] Invoking function, hasToken:', !!token, 'action:', (body as Record<string, unknown>).action);
   let response = await supabase.functions.invoke('ticket-activation', {
     headers: { Authorization: `Bearer ${token}` },
     body,


### PR DESCRIPTION
Closes #529, #531

## What

**#529** (`apps/mobile/src/hooks/useAuth.ts`): Added `setAuthError(null)` at the start of `handleLogoutAction`. Previously, if a user had a failed login attempt followed by logout, the error message would persist and appear on the next login attempt.

**#531** (`apps/mobile/src/services/ticket-activation.ts`): Removed the first 20 characters of JWT access tokens from `console.log` calls. Logging token prefixes is a security anti-pattern (visible to anyone with DevTools open). Replaced with `hasToken: true/!!token` booleans which provide the same diagnostic value without the security risk.

## How
Minimal, targeted changes to the two affected files.