### PR TITLE
Fix: error.message non sicuro, paginazione e log senza limite

### DIFF
--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -123,10 +123,11 @@ serve(async (req) => {
       }
     )
     
-  } catch (error: any) {
-    console.error('❌ Errore durante la pulizia:', error.message)
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error('❌ Errore durante la pulizia:', msg)
     return new Response(
-      JSON.stringify({ error: error.message }),
+      JSON.stringify({ error: msg }),
       { 
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         status: 500 

--- a/supabase/functions/import-spazio-rossellini/index.ts
+++ b/supabase/functions/import-spazio-rossellini/index.ts
@@ -100,11 +100,13 @@ const fetchCategorySlugs = async () => {
   return slugs;
 };
 
+const MAX_PAGINATION_PAGES = 50;
+
 const fetchAllEvents = async () => {
   const events: SpazioEvent[] = [];
   let nextUrl: string | null = EVENTS_API_URL;
   const visited = new Set<string>();
-  while (nextUrl && !visited.has(nextUrl)) {
+  while (nextUrl && !visited.has(nextUrl) && visited.size < MAX_PAGINATION_PAGES) {
     visited.add(nextUrl);
     const res = await fetch(nextUrl);
     if (!res.ok) throw new Error(`Events API fetch failed: ${res.status}`);

--- a/supabase/functions/mobile-logs/index.ts
+++ b/supabase/functions/mobile-logs/index.ts
@@ -143,7 +143,7 @@ serve(async (req: Request) => {
       ? body.clientUserId.trim().slice(0, 200)
       : null;
 
-    const rawLogs = Array.isArray(body.logs) ? body.logs : [];
+    const rawLogs = Array.isArray(body.logs) ? body.logs.slice(0, 100) : [];
     const normalizedLogs = rawLogs
       .map((entry, index) => normalizeLogEntry(entry, index))
       .filter((entry): entry is NormalizedLogEntry => !!entry);


### PR DESCRIPTION
Closes #551, #553, #554

## What

**#551** (`supabase/functions/cleanup-events/index.ts`): Changed `catch (error: any)` to `catch (error: unknown)` and used `error instanceof Error ? error.message : String(error)` to safely extract the message. Previously, `error.message` would be `undefined` if the thrown value was not an `Error` instance.

**#554** (`supabase/functions/mobile-logs/index.ts`): Added `.slice(0, 100)` on `body.logs` before processing. Without a limit, a malicious client could send millions of log entries in a single request.

**#553** (`supabase/functions/import-spazio-rossellini/index.ts`): Added a `MAX_PAGINATION_PAGES = 50` constant and added `visited.size < MAX_PAGINATION_PAGES` to the while-loop condition in `fetchAllEvents()`. A misconfigured API returning circular pagination links could previously cause an infinite loop.

## How
Minimal changes to each of the three affected functions.