### PR TITLE
Fix: Mobile vite.config.ts server.port (3000) conflicts with dev script port (4174)

### DIFF
--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -120,7 +120,7 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       host: true,
-      port: 3000,
+      port: 4174,
       https: httpsOption,
       allowedHosts,
       open: true,


### PR DESCRIPTION
Closes #621

## What
Updates `apps/mobile/vite.config.ts` `server.port` from 3000 to 4174 so it matches the `--port 4174` value used in the npm `dev` script.

## How
Changed a single port literal. Running `vite` directly without the npm wrapper now binds to 4174, consistent with `preview.port` and the proxy assumptions.