### PR TITLE
Fix: services/notifications.ts is dead code, shadowing lib/notifications.ts

### DIFF
--- a/apps/mobile/src/services/notifications.ts
+++ b/apps/mobile/src/services/notifications.ts
@@ -1,7 +1,0 @@
-export async function requestPermission(): Promise<NotificationPermission | 'unsupported'> {
-  if (typeof window === 'undefined' || !('Notification' in window)) {
-    return 'unsupported';
-  }
-
-  return Notification.requestPermission();
-}


### PR DESCRIPTION
Closes #619

## What
Removes `apps/mobile/src/services/notifications.ts`, an unreferenced module that shadowed the real implementation in `apps/mobile/src/lib/notifications.ts`.

## How
Verified no imports reference `services/notifications`; deleted the file.