### PR TITLE
Fix: spazio-rossellini import fetches indipendenti in parallelo

### DIFF
--- a/supabase/functions/import-spazio-rossellini/index.ts
+++ b/supabase/functions/import-spazio-rossellini/index.ts
@@ -176,9 +176,11 @@ serve(async (req) => {
   const supabase = createClient(supabaseUrl, serviceKey);
 
   try {
-    const sitemapUrls = await fetchSitemapUrls();
-    const categorySlugs = await fetchCategorySlugs();
-    const apiEvents = await fetchAllEvents();
+    const [sitemapUrls, categorySlugs, apiEvents] = await Promise.all([
+      fetchSitemapUrls(),
+      fetchCategorySlugs(),
+      fetchAllEvents(),
+    ]);
     const matched = apiEvents.filter((event) =>
       sitemapUrls.has(normalizeUrl(event.url ?? ''))
     );


### PR DESCRIPTION
Closes #552

## What
Three independent fetch calls (`fetchSitemapUrls`, `fetchCategorySlugs`, `fetchAllEvents`) were running sequentially.

## How
Wrapped them in a single `Promise.all` so the three remote calls run concurrently.