### PR TITLE
Fix: window.alert on SIGNED_OUT + hardcoded past date fallback

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -156,7 +156,7 @@ export function useAuth(
         const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
             if (!mounted) return;
             if (event === 'SIGNED_OUT') {
-                window.alert('Sessione scaduta. Effettua nuovamente l\'accesso.');
+                setAuthError('Sessione scaduta. Effettua nuovamente l\'accesso.');
                 onLogout();
                 return;
             }

--- a/tools/import-spazio-rossellini-events.js
+++ b/tools/import-spazio-rossellini-events.js
@@ -65,7 +65,11 @@ const formatDate = (details, fallback) => {
       return `${String(day).padStart(2, '0')} ${monthLabel} ${year}`;
     }
   }
-  return '01 Gen 2026';
+  // Fallback to today's date to avoid events being immediately cleaned up
+  const today = new Date();
+  const day = String(today.getDate()).padStart(2, '0');
+  const monthLabel = MONTHS_IT[today.getMonth()] ?? 'Gen';
+  return `${day} ${monthLabel} ${today.getFullYear()}`;
 };
 
 const formatTime = (details, fallback) => {


### PR DESCRIPTION
Closes #620
Closes #550

## What
- **#620**: In `apps/mobile/src/hooks/useAuth.ts`, the blocking `window.alert` on `SIGNED_OUT` has been replaced with a call to the existing `setAuthError` state setter, so the PWA no longer shows a native modal when Supabase fires `SIGNED_OUT` (session expiry, logout from another tab, etc.). The logout flow already redirects to the welcome screen where the message can surface via existing error-display UI.
- **#550**: In `tools/import-spazio-rossellini-events.js`, the date fallback was a hardcoded past date (`01 Gen 2026`), causing events with failed date parsing to be immediately eligible for cleanup. Replaced with today's date.

## How
Minimal one-line swap for #620; small refactor of the fallback computation for #550.