### PR TITLE
Fix: bottone Password dimenticata naviga a change-password

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -402,7 +402,7 @@ export function AppShell() {
         return <Welcome onStart={() => nav.navigate('signup')} onLogin={() => nav.navigate('login')} />;
 
       case 'login':
-        return <Login onBack={() => nav.navigate('welcome')} onLogin={handleLogin} onSignup={() => nav.navigate('signup')} onForgotPassword={() => {}} errorMessage={authError} />;
+        return <Login onBack={() => nav.navigate('welcome')} onLogin={handleLogin} onSignup={() => nav.navigate('signup')} onForgotPassword={() => nav.navigate('change-password')} errorMessage={authError} />;
 
       case 'signup':
         return <Signup onBack={() => nav.navigate('welcome')} onSignup={handleSignup} onLogin={() => nav.navigate('login')} onViewTerms={() => nav.openLegal('terms', 'signup')} onViewPrivacy={() => nav.openLegal('privacy', 'signup')} errorMessage={authError} />;


### PR DESCRIPTION
Closes #530

## What
In `apps/mobile/src/components/AppShell.tsx`, the `Login` screen was rendered with `onForgotPassword={() => {}}`, turning the "Password dimenticata?" link into a no-op.

## How
Wire the handler to `nav.navigate('change-password')` so the user reaches the existing `ChangePassword` screen, which already exposes the reset-email flow (`supabase.auth.resetPasswordForEmail`).