### PR TITLE
Fix: fetch sequenziali in import diventano paralleli

### DIFF
--- a/tools/import-spazio-rossellini-events.js
+++ b/tools/import-spazio-rossellini-events.js
@@ -191,9 +191,11 @@ const upsertEvents = async (rows) => {
 };
 
 const run = async () => {
-  const sitemapUrls = await fetchSitemapUrls();
-  const categorySlugs = await fetchCategorySlugs();
-  const apiEvents = await fetchAllEvents();
+  const [sitemapUrls, categorySlugs, apiEvents] = await Promise.all([
+    fetchSitemapUrls(),
+    fetchCategorySlugs(),
+    fetchAllEvents(),
+  ]);
   const filtered = apiEvents.filter((event) =>
     sitemapUrls.has(normalizeUrl(event.url ?? ''))
   );


### PR DESCRIPTION
Closes #552

## What
The three independent fetches in `tools/import-spazio-rossellini-events.js` (`fetchSitemapUrls`, `fetchCategorySlugs`, `fetchAllEvents`) were called sequentially, making the import tool unnecessarily slow.

## How
Replaced the three sequential `await` calls with a single `Promise.all([...])`. The Supabase function already used this pattern; this aligns the tools script to match.