### PR TITLE
Fix stale closures, unreachable fallback, unsafe assertions and missing cleanup

### DIFF
--- a/apps/mobile/src/components/screens/EventConfirmation.tsx
+++ b/apps/mobile/src/components/screens/EventConfirmation.tsx
@@ -29,7 +29,7 @@ export function EventConfirmation({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [boostRequested, setBoostRequested] = useState(false);
   const [confirmResult, setConfirmResult] = useState<Extract<ConfirmTurnResult, { ok: true }> | null>(null);
-  const successTimeoutRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
+  const successTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
     return () => {

--- a/apps/mobile/src/components/screens/EventConfirmation.tsx
+++ b/apps/mobile/src/components/screens/EventConfirmation.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Card } from '../ui/Card';
 import { Button } from '../ui/Button';
 import { Badge } from '../ui/Badge';
@@ -29,6 +29,14 @@ export function EventConfirmation({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [boostRequested, setBoostRequested] = useState(false);
   const [confirmResult, setConfirmResult] = useState<Extract<ConfirmTurnResult, { ok: true }> | null>(null);
+  const successTimeoutRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (successTimeoutRef.current !== null) window.clearTimeout(successTimeoutRef.current);
+    };
+  }, []);
+
   const roleId = (role?.id ?? 'attore') as RoleId;
   const isOffline = typeof navigator !== 'undefined' && navigator.onLine === false;
 
@@ -51,7 +59,7 @@ export function EventConfirmation({
       if (!result.ok) { window.alert(result.error); return; }
       setConfirmResult(result);
       setIsSuccess(true);
-      window.setTimeout(() => onSuccess(), 1500);
+      successTimeoutRef.current = window.setTimeout(() => onSuccess(), 1500);
     } catch (error) {
       window.alert(error instanceof Error ? error.message : 'Errore durante la registrazione turno.');
     } finally {

--- a/apps/mobile/src/hooks/useNotifications.ts
+++ b/apps/mobile/src/hooks/useNotifications.ts
@@ -5,27 +5,33 @@ export function useNotifications(upcomingEvent?: { id: string, name: string, dat
     const lastNotifiedBadgeId = useRef<string | null>(null);
     const lastNotifiedEventId = useRef<string | null>(null);
 
+    const newestNewBadgeId = newestNewBadge?.id;
+    const newestNewBadgeTitle = newestNewBadge?.title;
     useEffect(() => {
-        if (!newestNewBadge) return;
-        if (lastNotifiedBadgeId.current === newestNewBadge.id) return;
+        if (!newestNewBadgeId) return;
+        if (lastNotifiedBadgeId.current === newestNewBadgeId) return;
         if (getPermission() !== 'granted') return;
 
         notify('Nuovo badge sbloccato', {
-            body: newestNewBadge.title,
-            tag: `badge-${newestNewBadge.id}`,
+            body: newestNewBadgeTitle ?? '',
+            tag: `badge-${newestNewBadgeId}`,
         });
-        lastNotifiedBadgeId.current = newestNewBadge.id;
-    }, [newestNewBadge]);
+        lastNotifiedBadgeId.current = newestNewBadgeId;
+    }, [newestNewBadgeId, newestNewBadgeTitle]);
 
+    const upcomingEventId = upcomingEvent?.id;
+    const upcomingEventName = upcomingEvent?.name;
+    const upcomingEventDate = upcomingEvent?.date;
+    const upcomingEventTime = upcomingEvent?.time;
     useEffect(() => {
-        if (!upcomingEvent) return;
-        if (lastNotifiedEventId.current === upcomingEvent.id) return;
+        if (!upcomingEventId) return;
+        if (lastNotifiedEventId.current === upcomingEventId) return;
         if (getPermission() !== 'granted') return;
 
         notify('Nuovo evento in agenda', {
-            body: `${upcomingEvent.name} · ${upcomingEvent.date} ${upcomingEvent.time}`,
-            tag: `event-${upcomingEvent.id}`,
+            body: `${upcomingEventName} · ${upcomingEventDate} ${upcomingEventTime}`,
+            tag: `event-${upcomingEventId}`,
         });
-        lastNotifiedEventId.current = upcomingEvent.id;
-    }, [upcomingEvent]);
+        lastNotifiedEventId.current = upcomingEventId;
+    }, [upcomingEventId, upcomingEventName, upcomingEventDate, upcomingEventTime]);
 }

--- a/apps/mobile/src/lib/profile-utils.ts
+++ b/apps/mobile/src/lib/profile-utils.ts
@@ -38,8 +38,8 @@ export function resolveDisplayName({
   return (
     normalizeString(name) ||
     extractNameFromMetadata(metadata) ||
-    normalizeString(fallback) ||
     extractNameFromEmail(email) ||
+    normalizeString(fallback) ||
     'Utente'
   );
 }

--- a/apps/mobile/src/router/NavigatorContext.tsx
+++ b/apps/mobile/src/router/NavigatorContext.tsx
@@ -90,19 +90,20 @@ export function NavigatorProvider({
   }, [handleTabChange, onTabChange]);
 
   const goBack = useCallback(() => {
-    const backScreen = SCREENS_WITH_BACK[currentScreen];
+    const screen = currentScreenRef.current;
+    const backScreen = SCREENS_WITH_BACK[screen];
     if (backScreen) {
       setCurrentScreen(backScreen);
       return;
     }
     // For legal screens, return to where we came from
-    if (currentScreen === 'terms' || currentScreen === 'privacy') {
+    if (screen === 'terms' || screen === 'privacy') {
       setCurrentScreen(legalReturnScreen);
       return;
     }
     // Default: go to home tab
     handleTabChange('home');
-  }, [currentScreen, handleTabChange, legalReturnScreen, setCurrentScreen]);
+  }, [currentScreenRef, handleTabChange, legalReturnScreen, setCurrentScreen]);
 
   const openLegal = useCallback((screen: 'terms' | 'privacy', returnTo: LegalReturnScreen) => {
     setLegalReturnScreen(returnTo);

--- a/apps/pwa/src/services/dev-gate.ts
+++ b/apps/pwa/src/services/dev-gate.ts
@@ -69,11 +69,15 @@ function renderGate(root: HTMLElement): {
     </div>
   `;
 
-  const form = root.querySelector<HTMLFormElement>("[data-gate-form]")!;
-  const message = root.querySelector<HTMLElement>("[data-gate-message]")!;
-  const emailInput = root.querySelector<HTMLInputElement>('input[name="email"]')!;
-  const passwordInput = root.querySelector<HTMLInputElement>('input[name="password"]')!;
-  const submitButton = root.querySelector<HTMLButtonElement>("[data-gate-submit]")!;
+  const form = root.querySelector<HTMLFormElement>("[data-gate-form]");
+  const message = root.querySelector<HTMLElement>("[data-gate-message]");
+  const emailInput = root.querySelector<HTMLInputElement>('input[name="email"]');
+  const passwordInput = root.querySelector<HTMLInputElement>('input[name="password"]');
+  const submitButton = root.querySelector<HTMLButtonElement>("[data-gate-submit]");
+
+  if (!form || !message || !emailInput || !passwordInput || !submitButton) {
+    throw new Error('renderGate: template elements not found');
+  }
 
   return { form, message, emailInput, passwordInput, submitButton };
 }


### PR DESCRIPTION
## Summary

- **#525** `NavigatorContext.goBack`: replaced `currentScreen` state reference with `currentScreenRef.current` to prevent stale closure when `goBack` is cached by child components
- **#526** `useNotifications`: destructure object props into primitive variables (`id`, `name`, etc.) before using in `useEffect` deps array — prevents re-triggering on every render when parent recreates the array/object reference
- **#547** `dev-gate.ts renderGate()`: replaced 5 non-null assertions (`!`) with proper null checks; throws a descriptive error if template elements are missing
- **#631** `profile-utils.resolveDisplayName`: moved `extractNameFromEmail(email)` before `normalizeString(fallback)` so the email prefix is actually reachable when name/metadata are absent
- **#633** `EventConfirmation`: store `setTimeout` id in a `useRef` and clear it in a `useEffect` cleanup to prevent `onSuccess()` firing on an already-unmounted component

## Test plan

- [ ] Navigate back from several screens to confirm `goBack` lands on the correct previous screen (not a stale one)
- [ ] Confirm badge/event notifications are not duplicated on parent re-renders
- [ ] Load dev dashboard with a valid dev account — confirm login form renders without error
- [ ] Register a user with email only (no name/metadata) — confirm display name shows email prefix, not "Utente"
- [ ] In EventConfirmation, navigate away within 1500 ms of success — confirm `onSuccess` is NOT called

🤖 Generated with [Claude Code](https://claude.com/claude-code)