### PR TITLE
Log auth errors in getUserEmail (closes #546)

### DIFF
--- a/apps/pwa/src/dashboard.ts
+++ b/apps/pwa/src/dashboard.ts
@@ -23,7 +23,11 @@ async function fetchFeatureFlags(): Promise<FeatureFlag[]> {
 
 async function getUserEmail(): Promise<string> {
   if (!supabase) return "—";
-  const { data } = await supabase.auth.getUser();
+  const { data, error } = await supabase.auth.getUser();
+  if (error) {
+    console.warn("[dashboard] getUser failed, treating as unauthenticated:", error.message);
+    return "—";
+  }
   return data.user?.email ?? "—";
 }
 


### PR DESCRIPTION
## Summary

Fixes #546 — `getUserEmail` in `apps/pwa/src/dashboard.ts` destructured `error` from `supabase.auth.getUser()` but never logged or surfaced it, so auth failures were invisible.

## Change

Destructure `error` and log it via `console.warn` when present before returning the `"—"` placeholder. Behavior on success is unchanged.

## Test plan
- [ ] Open PWA dashboard with a valid session: email renders as before.
- [ ] Invalidate session (e.g., clear cookies) and reload: warning appears in console, UI still falls back to `—`.