### PR TITLE
Fix feature flag error handling, runtime validation, and leaderboard polling

### DIFF
--- a/apps/mobile/src/components/screens/Leaderboard.tsx
+++ b/apps/mobile/src/components/screens/Leaderboard.tsx
@@ -21,7 +21,7 @@ export function Leaderboard({ onSelectEntry }: LeaderboardProps) {
       if (!cancelled) setHasBootstrapped(true);
     };
     void runInitialRefresh();
-    const intervalId = window.setInterval(() => { void refreshLeaderboard(); }, 15000);
+    const intervalId = window.setInterval(() => { void refreshLeaderboard(); }, 60000);
     return () => { cancelled = true; window.clearInterval(intervalId); };
   }, [refreshLeaderboard]);
 

--- a/apps/pwa/src/dashboard.ts
+++ b/apps/pwa/src/dashboard.ts
@@ -11,14 +11,22 @@ function escapeHtml(str: string): string {
     .replace(/'/g, "&#39;");
 }
 
-async function fetchFeatureFlags(): Promise<FeatureFlag[]> {
-  if (!supabase) return [];
+function isFeatureFlag(item: unknown): item is FeatureFlag {
+  if (!item || typeof item !== "object") return false;
+  const r = item as Record<string, unknown>;
+  return typeof r.key === "string" && typeof r.enabled === "boolean" &&
+    typeof r.label === "string" && typeof r.description === "string";
+}
+
+// Returns null on fetch error (to distinguish from empty list)
+async function fetchFeatureFlags(): Promise<FeatureFlag[] | null> {
+  if (!supabase) return null;
   const { data, error } = await supabase
     .from("mobile_feature_flags")
     .select("key, enabled, label, description")
     .order("key");
-  if (error) return [];
-  return (data ?? []) as FeatureFlag[];
+  if (error) return null;
+  return (data ?? []).filter(isFeatureFlag);
 }
 
 async function getUserEmail(): Promise<string> {
@@ -143,6 +151,10 @@ export function renderDashboard(root: HTMLElement): void {
   void fetchFeatureFlags().then((flags) => {
     const container = root.querySelector<HTMLElement>("[data-flags]");
     if (!container) return;
+    if (flags === null) {
+      container.innerHTML = `<p class="text-sm text-red-400 py-4">Errore nel caricamento dei feature flag.</p>`;
+      return;
+    }
     if (!flags.length) {
       container.innerHTML = `<p class="text-sm text-neutral-500 py-4">Nessun feature flag trovato.</p>`;
       return;


### PR DESCRIPTION
## Summary

- **#548** `dashboard.ts fetchFeatureFlags()`: now returns `null` on fetch error (instead of `[]`), allowing the UI to show a distinct error message rather than "Nessun feature flag trovato"
- **#549** `dashboard.ts`: replaced `as FeatureFlag[]` unsafe cast with an `isFeatureFlag()` runtime validator that checks each field's type before accepting the data
- **#527** `Leaderboard.tsx`: increased polling interval from 15 s to 60 s, reducing unnecessary battery drain and network traffic on mobile devices

## Test plan

- [ ] With Supabase unreachable, dev dashboard should show "Errore nel caricamento dei feature flag." instead of "Nessun feature flag trovato."
- [ ] With Supabase reachable and flags present, flag list renders correctly
- [ ] With Supabase reachable and no flags, empty state message shows
- [ ] Leaderboard auto-refreshes every ~60 s (not every 15 s)
- [ ] Navigating away and back cancels old interval (no doubled requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)