### PR TITLE
Fix HTTPS config dead branch and surface auth errors in dashboard

### DIFF
--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -40,7 +40,7 @@ function resolveHttps(): ServerOptions | undefined {
     }
   }
 
-  return flag ? ({} as ServerOptions) : ({} as ServerOptions);
+  return flag ? ({} as ServerOptions) : undefined;
 }
 
 const DEFAULT_ALLOWED_HOSTS = ['turni-di-palco-fq85.onrender.com'];

--- a/apps/pwa/src/dashboard.ts
+++ b/apps/pwa/src/dashboard.ts
@@ -31,7 +31,11 @@ async function fetchFeatureFlags(): Promise<FeatureFlag[] | null> {
 
 async function getUserEmail(): Promise<string> {
   if (!supabase) return "—";
-  const { data } = await supabase.auth.getUser();
+  const { data, error } = await supabase.auth.getUser();
+  if (error) {
+    console.warn("[dashboard] getUserEmail: auth error", error.message);
+    return "Sessione scaduta";
+  }
   return data.user?.email ?? "—";
 }
 


### PR DESCRIPTION
## Summary

- **#535** `apps/mobile/vite.config.ts resolveHttps()`: the final `return` statement had two identical branches — `flag ? {} : {}`. When HTTPS is disabled (`flag=false`), now correctly returns `undefined` so Vite does not activate TLS. The `flag=true` branch still returns `{}` to let Vite use its own certificate generation as a fallback when no explicit cert files are provided.
- **#546** `apps/pwa/src/dashboard.ts getUserEmail()`: destructure `error` from `supabase.auth.getUser()`, log a warning to the console, and return `"Sessione scaduta"` in the UI so developers know their session is expired rather than seeing a silent `"—"`.

## Test plan

- [ ] Start mobile dev server without HTTPS env vars — confirm no TLS errors
- [ ] Set `HTTPS=true` without cert files — confirm dev server starts (Vite handles cert generation)
- [ ] Set `HTTPS=false` — confirm `resolveHttps()` returns `undefined`
- [ ] Open dev dashboard with an expired/invalid session — confirm the email area shows "Sessione scaduta" instead of "—"
- [ ] Open dev dashboard with a valid session — confirm email shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)