### PR TITLE
Fix useAuth re-subscription and align Supabase package version

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -178,7 +178,6 @@ export function useAuth(
             mounted = false;
             authListener?.subscription.unsubscribe();
         };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- supabase is a module-level constant
     }, [applyUserProfileFromAuth, onLogout]);
 
     return {

--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -178,7 +178,8 @@ export function useAuth(
             mounted = false;
             authListener?.subscription.unsubscribe();
         };
-    }, [supabase, applyUserProfileFromAuth, onLogout]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- supabase is a module-level constant
+    }, [applyUserProfileFromAuth, onLogout]);
 
     return {
         authError,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "apps/mobile/**/*.{ts,tsx}": "eslint --fix"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.39.0",
+    "@supabase/supabase-js": "^2.50.0",
     "ajv": "^8.18.0",
     "dotenv": "^16.3.1"
   },


### PR DESCRIPTION
## Summary

- **#523** `apps/mobile/src/hooks/useAuth.ts`: removed `supabase` from the `useEffect` dependency array. Since `supabase` is a module-level constant that never changes, listing it caused `applyUserProfileFromAuth` identity changes (when the callback was recreated) to trigger a full unsubscribe/resubscribe cycle on the auth listener, risking missed auth events during the brief gap.
- **#541** `package.json` (root): bumped `@supabase/supabase-js` from `^2.39.0` to `^2.50.0` to match the version used by all workspace apps (`apps/pwa`, `apps/mobile`), avoiding subtle runtime differences from mismatched library versions.

## Test plan

- [ ] Login/logout flow still works correctly in mobile app
- [ ] Profile name change does not cause double auth subscription
- [ ] No TypeScript or lint errors from removing supabase dep

🤖 Generated with [Claude Code](https://claude.com/claude-code)