### PR TITLE
Strip internal parameter shape from ticket-activation 400 error (closes #518)

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -215,16 +215,7 @@ serve(async (req: Request) => {
         (action === 'activate_by_details' && (!payload?.eventID || !payload?.ticketNumber)) ||
         (action === 'activate_by_ticket_number' && !payload?.ticketNumber)
       ) {
-        return jsonResponse({
-          error: 'Missing required parameters',
-          received: {
-            action,
-            hasHash: !!hash,
-            hasPayload: !!payload,
-            hasTicketNumber: !!payload?.ticketNumber,
-            hasUserId: !!resolvedUserId,
-          },
-        }, 400);
+        return jsonResponse({ error: 'Missing required parameters' }, 400);
       }
 
       // 1. Resolve hash if using details or ticket number


### PR DESCRIPTION
## Summary

Fixes #518 — the ticket-activation edge function was returning a `received` object exposing internal parameter names (`hasHash`, `hasPayload`, `hasTicketNumber`, `hasUserId`) and the `action` on a 400 `Missing required parameters` error. This helps attackers map the API surface.

## Change

Return only `{ error: 'Missing required parameters' }`. Success payloads and other error branches are untouched.

## Test plan
- [ ] Call the function with missing parameters and confirm the 400 body contains only `{ error }`.
- [ ] Confirm authenticated happy-path activations still succeed (no change to the success path).