### PR TITLE
Normalize /api prefix in rate-limit key (closes #545)

### DIFF
--- a/apps/control-plane/src/server.mjs
+++ b/apps/control-plane/src/server.mjs
@@ -611,13 +611,18 @@ function extractClientIp(req) {
   return "unknown";
 }
 
+function normalizeRateLimitPath(path) {
+  if (typeof path !== "string" || !path) return "/";
+  return path.replace(/^\/api(?=\/|$)/, "") || "/";
+}
+
 function handleRateLimit(req, res, next, options) {
   const { state, limit, skipHealth = false } = options;
   if (req.method === "OPTIONS") return next();
   if (skipHealth && (req.path === "/health" || req.path.endsWith("/health"))) return next();
 
   const now = Date.now();
-  const key = `${extractClientIp(req)}:${req.path}`;
+  const key = `${extractClientIp(req)}:${normalizeRateLimitPath(req.path)}`;
   const entry = state.get(key);
 
   if (!entry || entry.resetAt <= now) {


### PR DESCRIPTION
## Summary

Fixes #545 — `handleRateLimit` in `apps/control-plane/src/server.mjs` built its rate-limit key from `req.path`, letting a client alternate between `/api/commands/execute` and `/commands/execute` to double the effective allowance.

## Change

Introduce `normalizeRateLimitPath` which strips a leading `/api` segment before the path is combined with the client IP. Both request shapes now map to the same bucket. Behavior of paths without `/api` is unchanged.

## Test plan
- [ ] Send alternating requests to `/api/commands/execute` and `/commands/execute` from the same IP and confirm the shared limit is enforced (429 after `limit` total calls).
- [ ] Confirm `/health` still bypasses rate limiting.
- [ ] Confirm non-`/api` endpoints still rate-limit per-path.