### PR TITLE
Fix HTTPS config dead branch and silent auth error in dashboard (clos…

### DIFF
--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -40,7 +40,7 @@ function resolveHttps(): ServerOptions | undefined {
     }
   }
 
-  return flag ? ({} as ServerOptions) : ({} as ServerOptions);
+  return flag ? ({} as ServerOptions) : undefined;
 }
 
 const DEFAULT_ALLOWED_HOSTS = ['turni-di-palco-fq85.onrender.com'];

--- a/apps/pwa/src/dashboard.ts
+++ b/apps/pwa/src/dashboard.ts
@@ -31,7 +31,11 @@ async function fetchFeatureFlags(): Promise<FeatureFlag[] | null> {
 
 async function getUserEmail(): Promise<string> {
   if (!supabase) return "—";
-  const { data } = await supabase.auth.getUser();
+  const { data, error } = await supabase.auth.getUser();
+  if (error) {
+    console.warn("[dashboard] getUserEmail: auth error", error.message);
+    return "Sessione scaduta";
+  }
   return data.user?.email ?? "—";
 }
 


### PR DESCRIPTION
…es #535, #546)

- vite.config.ts resolveHttps(): return undefined (not {}) when HTTPS flag is false, so Vite doesn't activate TLS unexpectedly (#535)
- dashboard.ts getUserEmail(): destructure error from getUser(), log warning and return 'Sessione scaduta' string instead of silently returning '—' (#546)