### PR TITLE
chore(vscode): set locale to Italian

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "locale": "it",
   "cSpell.language": "it,en",
   "workbench.colorTheme": "Default Dark Modern",
   "workbench.editorAssociations": {


### PR DESCRIPTION
## Summary
- Aggiunge `"locale": "it"` in `.vscode/settings.json` per impostare l'interfaccia VS Code in italiano

🤖 Generated with [Claude Code](https://claude.ai/claude-code)