### PR TITLE
Fix: add Content Security Policy meta tags to both index.html files

### DIFF
--- a/apps/mobile/index.html
+++ b/apps/mobile/index.html
@@ -7,6 +7,10 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self' https:; frame-ancestors 'self'; upgrade-insecure-requests"
+    />
     <meta name="description" content="Turni di Palco - App di gamification teatrale per ATCL Lazio" />
     <title>Turni di Palco</title>
     <meta name="theme-color" content="#05070d" />

--- a/apps/pwa/index.html
+++ b/apps/pwa/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self' https:; frame-ancestors 'self'; upgrade-insecure-requests"
+    />
     <meta name="theme-color" content="#05070d" />
     <meta name="description" content="Turni di Palco - App di gamification teatrale per ATCL Lazio" />
     <title>Dev Dashboard — Turni di Palco</title>


### PR DESCRIPTION
Closes #534

## What
Add a defense-in-depth `Content-Security-Policy` meta tag to both
`apps/mobile/index.html` and `apps/pwa/index.html`. Before this change
there was no CSP whatsoever, so any XSS would have unrestricted access
to all origins.

## How
The meta tag uses a pragmatic policy that allows the origins currently
required by the apps while still tightening the attack surface:

- `default-src 'self'` — deny by default
- `script-src 'self' 'unsafe-inline'` — needed because the bundled index.html
  already contains an inline bootstrap script in the mobile app
- `style-src 'self' 'unsafe-inline'` — required by styled-components / Tailwind-JIT style injection
- `img-src 'self' data: blob: https:` — allows Unsplash, Supabase storage and data URIs
- `font-src 'self' data:`
- `connect-src 'self' https: wss:` — Supabase REST + realtime (wss), plus ATCL / allorigins feeds
- `frame-src 'self' https:` — iubenda privacy policy embeds
- `object-src 'none'`, `base-uri 'self'`, `form-action 'self' https:`, `frame-ancestors 'self'`, `upgrade-insecure-requests`

The policy is intentionally not the strictest possible (it still allows
`'unsafe-inline'` for scripts and a broad https `connect-src`) because
the current app relies on inline bootstrap scripts and dynamic Supabase
URLs via `VITE_SUPABASE_URL`. Tightening further would require wiring
hashes/nonces and enumerating runtime Supabase hosts, which is out of
scope for this minimal fix.

## Test plan
- [ ] Build both apps (`npm run build:pwa`, `npm run build:mobile`) and load the preview; verify no CSP console violations on core flows (login, dashboard, QR scan, navigation).