### PR TITLE
Fix: unhandled promise rejection in mobile SW cleanup

### DIFF
--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -7,12 +7,18 @@ import "../../../shared/styles/main.css";
 const isLocalHost = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]).has(window.location.hostname);
 
 if ("serviceWorker" in navigator && isLocalHost) {
-  navigator.serviceWorker.getRegistrations().then((registrations) => {
-    registrations.forEach((registration) => registration.unregister().catch(() => undefined));
-  });
+  navigator.serviceWorker
+    .getRegistrations()
+    .then((registrations) => {
+      registrations.forEach((registration) => registration.unregister().catch(() => undefined));
+    })
+    .catch(() => undefined);
 
   if ("caches" in window) {
-    caches.keys().then((keys) => Promise.all(keys.map((key) => caches.delete(key))).catch(() => undefined));
+    caches
+      .keys()
+      .then((keys) => Promise.all(keys.map((key) => caches.delete(key))))
+      .catch(() => undefined);
   }
 }
 


### PR DESCRIPTION
Closes #676

## What
`apps/mobile/src/main.tsx` cleans up service workers and caches on
localhost, but the outer `getRegistrations()` and `caches.keys()`
promises had no `.catch()`. A rejection from those outer calls (private
browsing, permission denied, storage quota) would surface as an
unhandled promise rejection at boot.

## How
Added `.catch(() => undefined)` on both outer chains. The inner
`unregister()` / `Promise.all(delete)` calls already swallowed their
own errors.

## Test plan
- [ ] `npm run build:mobile` still succeeds.
- [ ] Load the dev build on localhost in a private window; verify no "Uncaught (in promise)" in the console.