### PR TITLE
Fix: unhandled rejection in dashboard feature flags fetch

### DIFF
--- a/apps/pwa/src/dashboard.ts
+++ b/apps/pwa/src/dashboard.ts
@@ -164,6 +164,11 @@ export function renderDashboard(root: HTMLElement): void {
       return;
     }
     container.innerHTML = flags.map(flagRow).join("");
+  }).catch(() => {
+    const container = root.querySelector<HTMLElement>("[data-flags]");
+    if (container) {
+      container.innerHTML = `<p class="text-sm text-red-400 py-4">Errore nel caricamento dei feature flag.</p>`;
+    }
   });
 
   // Sign out


### PR DESCRIPTION
Closes #674

## What
`apps/pwa/src/dashboard.ts` calls `fetchFeatureFlags()` with `void` but
had no `.catch()`. Even though `fetchFeatureFlags` returns `null` on
a Supabase error, any synchronous throw inside the `.then()` (e.g.
`container.innerHTML` failing on a detached node) would become an
unhandled promise rejection.

## How
Append a `.catch()` that mirrors the null-flags branch: paints an
error message into the same `[data-flags]` container. This also
aligns the style with `getUserEmail()` immediately above, which
already has a `.catch()`.

## Test plan
- [ ] Open the dev dashboard with a broken Supabase config; feature flags block shows the error UI instead of logging an unhandled rejection.