### PR TITLE
Fix: dev-gate no longer rejects on transient sign-in errors

### DIFF
--- a/apps/pwa/src/services/dev-gate.ts
+++ b/apps/pwa/src/services/dev-gate.ts
@@ -112,7 +112,7 @@ export async function requireDevAccess(): Promise<boolean> {
   const gate = renderGate(root);
   if (data.user) setMessage(gate.message, "Account non autorizzato per la dev dashboard.", "error");
 
-  return new Promise<boolean>((resolve, reject) => {
+  return new Promise<boolean>((resolve) => {
     gate.form.addEventListener("submit", async (e) => {
       e.preventDefault();
       setBusy(gate, true);
@@ -141,10 +141,9 @@ export async function requireDevAccess(): Promise<boolean> {
         setMessage(gate.message, "Accesso autorizzato.", "success");
         root.innerHTML = "";
         resolve(true);
-      } catch (err) {
+      } catch {
         setBusy(gate, false);
         setMessage(gate.message, "Errore imprevisto. Riprova.", "error");
-        reject(err);
       }
     });
   });


### PR DESCRIPTION
Closes #675

## What
`apps/pwa/src/services/dev-gate.ts` rejected the outer promise from the
form `submit` listener whenever sign-in threw. The listener stays
registered so the user can still retry in the UI — but the caller
(`start()` in `main.ts`) had already awaited a now-rejected promise,
producing `Uncaught (in promise)` and leaving the app boot broken.

## How
Remove `reject` from the Promise executor signature and drop the
unused `err` binding in the `catch`. The UI already shows an error
message via `setMessage`, and the user can retry by submitting the
form again. The promise only resolves once the user authenticates
successfully.

## Test plan
- [ ] With Supabase reachable, submit wrong password: error message shows, submit works again, no unhandled rejection.
- [ ] With Supabase offline (throws), submit: same behavior — error shows, retry works.
- [ ] Correct credentials still resolve to dashboard.