### PR TITLE
Fix: ProgressBar setTimeout cleanup on unmount

### DIFF
--- a/apps/mobile/src/components/ui/ProgressBar.tsx
+++ b/apps/mobile/src/components/ui/ProgressBar.tsx
@@ -20,11 +20,14 @@ export function ProgressBar({
   // Animate fill from 0 to percentage on mount / value change
   const [displayWidth, setDisplayWidth] = useState(0);
   useEffect(() => {
-    const id = requestAnimationFrame(() => {
-      const timer = setTimeout(() => setDisplayWidth(percentage), 30);
-      return () => clearTimeout(timer);
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const rafId = requestAnimationFrame(() => {
+      timer = setTimeout(() => setDisplayWidth(percentage), 30);
     });
-    return () => cancelAnimationFrame(id);
+    return () => {
+      cancelAnimationFrame(rafId);
+      if (timer !== null) clearTimeout(timer);
+    };
   }, [percentage]);
 
   const heights = {


### PR DESCRIPTION
Closes #678

## What
The effect in `apps/mobile/src/components/ui/ProgressBar.tsx` combined
`requestAnimationFrame` + `setTimeout`, but returned the `clearTimeout`
cleanup from inside the RAF callback. `requestAnimationFrame` does not
consume cleanup returns, so `setTimeout` was never cleared. If the
component unmounted between the RAF tick and the 30 ms `setTimeout`,
`setDisplayWidth` ran on an unmounted component — React "state update
on unmounted component" warning and a small leak.

## How
Capture the timer id in the outer effect scope and clear it from the
`useEffect` cleanup alongside `cancelAnimationFrame`.

## Test plan
- [ ] Mount a ProgressBar and unmount within ~30 ms; no React warning in console.
- [ ] Visually the bar still animates on mount / value change.