### PR TITLE
Fix: validate profile image type/size before upload

### DIFF
--- a/apps/mobile/src/services/storage.ts
+++ b/apps/mobile/src/services/storage.ts
@@ -2,12 +2,23 @@ import { supabase } from '../lib/supabase';
 import { withMobileWatchdog } from './mobile-watchdog';
 
 const PROFILE_UPLOAD_WATCHDOG_MS = 30000;
+const ALLOWED_IMAGE_EXTS = new Set(['jpg', 'jpeg', 'png', 'webp']);
+const ALLOWED_IMAGE_MIME_PREFIX = 'image/';
+const MAX_PROFILE_IMAGE_BYTES = 5 * 1024 * 1024;
 
 export async function uploadProfileImage(userId: string, file: File): Promise<string> {
   return withMobileWatchdog(async () => {
     if (!supabase) throw new Error('Supabase non configurato');
 
-    const fileExt = file.name.split('.').pop();
+    if (!file.type.startsWith(ALLOWED_IMAGE_MIME_PREFIX)) {
+      throw new Error('Formato immagine non valido');
+    }
+    if (file.size > MAX_PROFILE_IMAGE_BYTES) {
+      throw new Error('Immagine troppo grande (max 5MB)');
+    }
+
+    const rawExt = file.name.includes('.') ? file.name.split('.').pop()?.toLowerCase() ?? '' : '';
+    const fileExt = ALLOWED_IMAGE_EXTS.has(rawExt) ? rawExt : 'jpg';
     const fileName = `${userId}/profile.${fileExt}`;
 
     const { error } = await supabase.storage
@@ -15,6 +26,7 @@ export async function uploadProfileImage(userId: string, file: File): Promise<st
       .upload(fileName, file, {
         cacheControl: '3600',
         upsert: true,
+        contentType: file.type,
       });
 
     if (error) throw error;


### PR DESCRIPTION
Closes #682

## What
`uploadProfileImage` trusted `file.name.split('.').pop()` unchecked:

- A file with no dot produced `userId/profile.undefined` paths
  (split('.') returns the full name so `fileExt` ends up being the
  whole name when there's no dot; for a file named e.g. `IMG_1234`
  that was the string `IMG_1234`, for an empty name, empty).
- No MIME / allow-list check, so an attacker could upload
  `profile.html` and have it served as `text/html` from a public
  bucket (stored XSS).
- No size cap, so arbitrarily large files could be pushed.

## How
- Reject when `file.type` does not start with `image/`.
- Cap at 5 MB (`MAX_PROFILE_IMAGE_BYTES`).
- Lowercase the extension and fall back to `jpg` when missing or not
  in the allow-list `{jpg, jpeg, png, webp}`.
- Pass `contentType: file.type` on upload so Supabase does not infer
  it from the filename.

## Test plan
- [ ] Upload jpg/png/webp: still works, URL returned.
- [ ] Upload a file >5 MB: rejected with "Immagine troppo grande".
- [ ] Upload a file with `type: 'text/html'`: rejected with "Formato immagine non valido".
- [ ] Upload a file named `noextension`: stored as `{userId}/profile.jpg`.