### PR TITLE
Fix: stop falling through to local ticket activation when server responded

### DIFF
--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -494,7 +494,7 @@ export async function activateTicketHash(
 
   try {
     const remote = await activateRemotely(normalizedHash, normalizedUserId);
-    
+
     if (remote?.ok) {
       const currentRecord = localActivationStore.get(normalizedHash);
       localActivationStore.set(normalizedHash, {
@@ -515,14 +515,22 @@ export async function activateTicketHash(
     if (remote?.error) {
       return { ok: false, error: remote.error };
     }
+
+    // Supabase is configured and the server answered, but the response
+    // did not match any success or explicit-error branch. Do not fall
+    // through to the local fallback, which would mark the ticket as
+    // activated without server confirmation.
+    if (remote !== null) {
+      return { ok: false, error: 'Risposta server inattesa durante l\'attivazione ticket.' };
+    }
   } catch (error) {
     if (shouldLogActivationError(error)) {
       console.error('Remote activation failed:', error);
     }
     if (supabase && isSupabaseConfigured) {
-      return { 
-        ok: false, 
-        error: error instanceof Error ? error.message : 'Errore durante la comunicazione con il server.' 
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : 'Errore durante la comunicazione con il server.'
       };
     }
   }


### PR DESCRIPTION
Closes #683

## What
`activateTicketHash` used to fall through to the `localActivationStore`
fallback when `activateRemotely` returned an object with `ok=false`,
`alreadyActivated=false`, and no `error` field. The fallback is meant
for offline / demo mode (`activateRemotely` returns `null` when
Supabase is not configured). A malformed / ambiguous server response
therefore caused the ticket to be marked "activated" client-side
without server confirmation — client/server drift that could mask
bugs and would only surface later when `registerTurn` ran.

## How
After the success / already-activated / error branches, add a guard:
if `remote !== null` (i.e. Supabase was configured and the server
did answer), return an explicit `"Risposta server inattesa"` error
instead of falling through. The `remote === null` case (Supabase not
configured) still reaches the local-only fallback as before.

## Test plan
- [ ] Mock `activateRemotely` to return `{}`: function returns `{ ok: false, error: 'Risposta server inattesa…' }`, local store unchanged.
- [ ] Mock `activateRemotely` to return `null` (no Supabase) with a pre-seeded local record: fallback still activates as before.
- [ ] Normal success / alreadyActivated / error paths: unchanged behaviour.