### PR TITLE
Fix: remove unimplemented NavigateOptions.replace

### DIFF
--- a/apps/mobile/src/router/NavigatorContext.tsx
+++ b/apps/mobile/src/router/NavigatorContext.tsx
@@ -2,10 +2,6 @@ import React, { createContext, useContext, useCallback } from 'react';
 import { Screen, Tab, LegalReturnScreen } from '../types/navigation';
 import { useNavigation } from '../hooks/useNavigation';
 
-type NavigateOptions = {
-  replace?: boolean;
-};
-
 interface NavigatorContextValue {
   // Current state
   screen: Screen;
@@ -16,7 +12,7 @@ interface NavigatorContextValue {
   selectedActivityId: string;
 
   // Navigation actions
-  navigate: (screen: Screen, options?: NavigateOptions) => void;
+  navigate: (screen: Screen) => void;
   switchTab: (tab: Tab) => void;
   goBack: () => void;
 
@@ -75,13 +71,8 @@ export function NavigatorProvider({
     selectedActivityId, setSelectedActivityId,
   } = useNavigation(initialEvents, { isScreenEnabled, isTabEnabled });
 
-  const navigate = useCallback((screen: Screen, options?: NavigateOptions) => {
-    if (options?.replace) {
-      // Replace: clear history by resetting to the target screen
-      setCurrentScreen(screen);
-    } else {
-      setCurrentScreen(screen);
-    }
+  const navigate = useCallback((screen: Screen) => {
+    setCurrentScreen(screen);
   }, [setCurrentScreen]);
 
   const switchTab = useCallback((tab: Tab) => {


### PR DESCRIPTION
Closes #679

## What
`navigate(screen, { replace: true })` and `navigate(screen)` were
semantically identical: both branches of the `if (options?.replace)`
ran `setCurrentScreen(screen)`. There is no navigation history stack
to "replace" (just a `currentScreen` state + `SCREENS_WITH_BACK`
map), and no call site passes `replace: true`. The option was a
residue of an API that was planned but never implemented.

## How
Drop the `NavigateOptions` type and simplify `navigate` to a single
`(screen: Screen) => void`. The context interface is updated to match.

## Test plan
- [ ] Mobile typecheck still passes.
- [ ] All existing `nav.navigate('...')` call sites keep working (none passes an options object).