### PR TITLE
Fix: align applyUserProfileFromAuth option with onAuthChange contract

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -115,7 +115,7 @@ export function useAuth(
             options?: {
                 fallbackName?: string;
                 navigateTo?: 'home' | 'change-password';
-                navigateReplace?: boolean;
+                isRecovery?: boolean;
             },
         ) => {
             if (!user) {
@@ -134,7 +134,7 @@ export function useAuth(
             updateProfile(shouldSetName ? { name: displayName, email } : { email });
 
             if (options?.navigateTo) {
-                onAuthChange(options.navigateTo, options.navigateReplace);
+                onAuthChange(options.navigateTo, options.isRecovery);
             }
         },
         [updateProfile, onAuthChange],
@@ -163,7 +163,7 @@ export function useAuth(
             if (event === 'PASSWORD_RECOVERY') {
                 applyUserProfileFromAuth(session?.user, {
                     navigateTo: 'change-password',
-                    navigateReplace: true,
+                    isRecovery: true,
                 });
                 return;
             }


### PR DESCRIPTION
Closes #680

## What
`applyUserProfileFromAuth` accepted an option called `navigateReplace`
but forwarded it to `onAuthChange(screen, isRecovery?: boolean)` as
the second positional argument. In the only call site
(`PASSWORD_RECOVERY`) the intended value happens to match
(`true`/`true`), so nothing broke visibly — but the naming was wrong
and any future caller passing `navigateReplace: true` in a normal
sign-in flow would have been silently treated as `isRecovery: true`
and incorrectly flipped `isPasswordRecovery` in `AppShell`.

## How
Rename the option to `isRecovery`. The `PASSWORD_RECOVERY` call site
was updated to match. No consumer of `applyUserProfileFromAuth` used
the old name elsewhere.

## Test plan
- [ ] Mobile typecheck passes.
- [ ] Password recovery flow still routes to `change-password` with `isPasswordRecovery = true`.
- [ ] Normal sign-in flow still routes to `home` without touching `isPasswordRecovery`.