### PR TITLE
Revert: rimuovi commit diretto su main (scheduled_tasks.lock)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"d60515e2-c1ae-475d-8ebd-ee289a93a416","pid":19160,"acquiredAt":1776410609110}


### PR DESCRIPTION
Reverta il commit `aae615a` ('Scheludeld task set') che è stato pushato direttamente su main senza PR, in violazione della policy del repo.

## Cosa
Rimuove `.claude/scheduled_tasks.lock` aggiunto direttamente su main da un agente.

## Perché
Nessun commit deve atterrare su `main` senza passare per una PR. Questo commit è sfuggito al controllo — viene revertato.