### PR TITLE
Fix: register mobile service worker in production

### DIFF
--- a/apps/mobile/public/sw.js
+++ b/apps/mobile/public/sw.js
@@ -1,0 +1,46 @@
+const CACHE_VERSION = "mobile-v1";
+const PRECACHE_URLS = ["/mobile/", "/mobile/index.html"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_VERSION)
+      .then((cache) => cache.addAll(PRECACHE_URLS))
+      .catch(() => undefined)
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((k) => k !== CACHE_VERSION)
+          .map((k) => caches.delete(k))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") return;
+
+  // Navigation requests (HTML): network-first so new builds are never blocked
+  // by a stale cached HTML entry pointing at hashed chunks.
+  if (event.request.mode === "navigate") {
+    event.respondWith(
+      fetch(event.request).catch(() =>
+        caches
+          .match(event.request)
+          .then((cached) => cached || caches.match("/mobile/"))
+      )
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => cached || fetch(event.request))
+  );
+});

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -22,4 +22,12 @@ if ("serviceWorker" in navigator && isLocalHost) {
   }
 }
 
+if ("serviceWorker" in navigator && import.meta.env.PROD && !isLocalHost) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker
+      .register("/mobile/sw.js", { scope: "/mobile/" })
+      .catch(() => undefined);
+  });
+}
+
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
Closes #533

## Summary
- Adds `apps/mobile/public/sw.js` mirroring the strategy used in `apps/pwa/public/sw.js` (precache shell, network-first navigation, cache-first for other GETs).
- Registers the SW from `apps/mobile/src/main.tsx` only when `import.meta.env.PROD` is true and the host is not localhost, so the dev flow (which unregisters SWs) is untouched.

## Test plan
- [ ] `npm run build:mobile` succeeds
- [ ] Deployed build registers `/mobile/sw.js` (DevTools > Application > Service Workers)
- [ ] Localhost dev session still unregisters existing SWs