### PR TITLE
Fix: document root-level dependency overrides (#539)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ajv": "^8.18.0",
     "dotenv": "^16.3.1"
   },
+  "//overrides": "Security pins driven by Dependabot advisories. minimatch ^10.2.3 and rollup ^4.59.0 added in 3633dee (Feb 27 2026). picomatch 4.0.4 pinned in 97cf1b3 (Mar 26 2026) for CVE-2026-33672. All three are still consumed by transitive deps (eslint, vite, vitest, typescript-eslint) — do not remove without re-running npm audit.",
   "overrides": {
     "minimatch": "^10.2.3",
     "picomatch": "4.0.4",


### PR DESCRIPTION
Closes #539

## Summary

Adds an inline `//overrides` documentation key next to the `overrides` block in root `package.json`, explaining why each pin exists.

## Rationale

All three overrides are driven by Dependabot advisories and remain required:

| Override | Commit | Reason |
|---|---|---|
| `minimatch: ^10.2.3` | 3633dee (Feb 27 2026) | Dependabot alert on transitive ReDoS |
| `rollup: ^4.59.0` | 3633dee (Feb 27 2026) | Dependabot alert on transitive |
| `picomatch: 4.0.4` | 97cf1b3 (Mar 26 2026) | CVE-2026-33672 |

`npm ls` shows each is still consumed by transitive deps (eslint, vite, vitest, @typescript-eslint/*). `npm audit` reports 0 vulnerabilities with the overrides in place — removing them is unsafe without re-verifying every transitive advisory.

## Test plan

- [x] `npm install` succeeds at repo root
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm ls minimatch picomatch rollup` shows the pinned versions consumed by transitive deps