### PR TITLE
Fix: enforce profiles.reputation cap server-side

### DIFF
--- a/supabase/migrations/20260417_reputation_cap_constraint.sql
+++ b/supabase/migrations/20260417_reputation_cap_constraint.sql
@@ -1,0 +1,20 @@
+-- Issue #528 — enforce reputation cap at the database layer
+--
+-- RPCs already clamp reputation to [0,100] via least()/greatest(), but the
+-- column itself accepted any integer, which meant a stray UPDATE (direct SQL,
+-- future edge function, misconfigured policy) could push it past the intended
+-- 0..100 range. Add a CHECK constraint so the cap is enforced server-side
+-- regardless of the write path.
+
+-- Clamp any existing out-of-range rows before adding the constraint, so the
+-- migration is idempotent even if test data drifted above 100 or below 0.
+UPDATE public.profiles
+   SET reputation = LEAST(100, GREATEST(0, reputation))
+ WHERE reputation < 0 OR reputation > 100;
+
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_reputation_range_check;
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_reputation_range_check
+  CHECK (reputation BETWEEN 0 AND 100);


### PR DESCRIPTION
Closes #528

## Summary
- Adds migration `20260417_reputation_cap_constraint.sql` that introduces a `CHECK (reputation BETWEEN 0 AND 100)` constraint on `public.profiles`.
- Clamps any existing out-of-range rows beforehand so the migration is idempotent on drifted data.
- RPCs (`register_turn_*`, `purchase_shop_item`, decay) already used `least(100, ...)`/`greatest(0, ...)`; this adds the missing DB-level guarantee so future write paths cannot bypass the cap.

## Test plan
- [ ] Migration applies cleanly on a fresh/restored DB
- [ ] Direct `UPDATE profiles SET reputation = 150` is rejected by Postgres
- [ ] Existing register-turn and shop flows still succeed (they already clamp to 100)