### PR TITLE
Add public leaderboard API (Supabase edge function + RPC)

### DIFF
--- a/supabase/functions/public-leaderboard/index.ts
+++ b/supabase/functions/public-leaderboard/index.ts
@@ -1,0 +1,112 @@
+/// <reference path="../@types/deno.d.ts" />
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.48.0';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'content-type',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+};
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 60;
+const rateBuckets = new Map<string, number[]>();
+
+type LeaderboardRow = {
+  rank: number;
+  name: string;
+  role_id: string | null;
+  xp_total: number;
+  reputation: number;
+  profile_image: string | null;
+  turns_count: number;
+};
+
+function json(body: Record<string, unknown>, status = 200, extraHeaders: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...corsHeaders,
+      'Content-Type': 'application/json',
+      ...extraHeaders,
+    },
+  });
+}
+
+function clientIp(req: Request): string {
+  const fwd = req.headers.get('x-forwarded-for');
+  if (fwd) return fwd.split(',')[0].trim();
+  return req.headers.get('cf-connecting-ip') ?? 'unknown';
+}
+
+function rateLimit(ip: string): { ok: boolean; retryAfter: number } {
+  const now = Date.now();
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  const hits = (rateBuckets.get(ip) ?? []).filter((t) => t > windowStart);
+  if (hits.length >= RATE_LIMIT_MAX) {
+    const retryAfter = Math.ceil((hits[0] + RATE_LIMIT_WINDOW_MS - now) / 1000);
+    return { ok: false, retryAfter: Math.max(1, retryAfter) };
+  }
+  hits.push(now);
+  rateBuckets.set(ip, hits);
+  return { ok: true, retryAfter: 0 };
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'GET') {
+    return json({ error: 'Metodo non consentito' }, 405);
+  }
+
+  const ip = clientIp(req);
+  const gate = rateLimit(ip);
+  if (!gate.ok) {
+    return json(
+      { error: 'Troppe richieste', retry_after: gate.retryAfter },
+      429,
+      { 'Retry-After': String(gate.retryAfter) },
+    );
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const anonKey = Deno.env.get('SUPABASE_ANON_KEY');
+  if (!supabaseUrl || !anonKey) {
+    return json({ error: 'Missing Supabase env vars' }, 500);
+  }
+
+  const url = new URL(req.url);
+  const rawLimit = url.searchParams.get('limit');
+  const parsed = Number(rawLimit ?? DEFAULT_LIMIT);
+  const limit = Number.isFinite(parsed)
+    ? Math.min(Math.max(Math.trunc(parsed), 1), MAX_LIMIT)
+    : DEFAULT_LIMIT;
+
+  const supabase = createClient(supabaseUrl, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  // @ts-ignore – RPC types are not generated here
+  const { data, error } = await supabase.rpc('get_public_leaderboard', { p_limit: limit });
+
+  if (error) {
+    return json({ error: error.message }, 500);
+  }
+
+  const rows = (data ?? []) as LeaderboardRow[];
+  return json(
+    {
+      generated_at: new Date().toISOString(),
+      limit,
+      count: rows.length,
+      entries: rows,
+    },
+    200,
+    { 'Cache-Control': 'public, max-age=60, s-maxage=60' },
+  );
+});

--- a/supabase/migrations/20260417120000_public_leaderboard_rpc.sql
+++ b/supabase/migrations/20260417120000_public_leaderboard_rpc.sql
@@ -1,0 +1,39 @@
+-- Public leaderboard RPC: anonymous-callable projection of the internal
+-- leaderboard, limited to non-sensitive columns and to users who have not
+-- opted out via GDPR Art. 21 (leaderboard_visible).
+
+create or replace function public.get_public_leaderboard(p_limit int default 50)
+returns table (
+  rank int,
+  name text,
+  role_id text,
+  xp_total int,
+  reputation int,
+  profile_image text,
+  turns_count int
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    (row_number() over (order by p.xp_total desc nulls last))::int as rank,
+    p.name,
+    p.role_id,
+    p.xp_total,
+    p.reputation,
+    p.profile_image,
+    (
+      select count(*)::int
+      from public.turns t
+      where t.user_id = p.id
+    ) as turns_count
+  from public.profiles p
+  where p.leaderboard_visible = true
+  order by p.xp_total desc nulls last
+  limit greatest(1, least(p_limit, 200));
+$$;
+
+revoke execute on function public.get_public_leaderboard(int) from public;
+grant execute on function public.get_public_leaderboard(int) to anon, authenticated;


### PR DESCRIPTION
- New RPC get_public_leaderboard: anon-callable, non-sensitive columns
  only, respects leaderboard_visible (GDPR Art. 21).
- New edge function public-leaderboard: open CORS, per-IP rate limit
  (60 req/min), GET with ?limit= (default 50, max 200), 60s cache hint.