### PR TITLE
Add missing welcome branch in useQrLanding (closes #737)

### DIFF
--- a/apps/mobile/src/hooks/useQrLanding.ts
+++ b/apps/mobile/src/hooks/useQrLanding.ts
@@ -22,6 +22,8 @@ export function useQrLanding(_authReady: boolean, _isAuthValid: boolean, onLandi
 
         if (!isInstalled && !dismissed) {
             onLanding('install');
+        } else {
+            onLanding('welcome');
         }
 
         try {


### PR DESCRIPTION
## Summary

`useQrLanding` declared `'welcome' | 'install'` as the callback target type, but the `'welcome'` branch was never implemented. When a user arrived via QR with the app already installed (or the install banner already dismissed), `onLanding` was never called and `hasHandledQrLanding.current` was set to `true` anyway, permanently blocking any subsequent handling.

**Fix:** add `else { onLanding('welcome'); }` so navigation to the welcome screen happens for installed users.

## Test plan

- [ ] Open `?from=qr` in browser (not standalone) → should navigate to install screen
- [ ] Open `?from=qr` in standalone (installed PWA) → should navigate to welcome
- [ ] Open `?from=qr` after dismissing install banner → should navigate to welcome
- [ ] Without QR params → no navigation triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)