### PR TITLE
Clear localhost port when rewriting endpoint to production host (closes #739)

### DIFF
--- a/apps/mobile/src/services/ai.ts
+++ b/apps/mobile/src/services/ai.ts
@@ -103,6 +103,7 @@ function normalizeEndpoint(endpoint: string) {
       isLocalHost(url.hostname)
     ) {
       url.hostname = currentHost;
+      url.port = ''; // clear localhost port when rewriting to production host
       if (window.location.protocol === 'https:') {
         url.protocol = 'https:';
       }


### PR DESCRIPTION
## Summary

`normalizeEndpoint` rewrote `url.hostname` from `localhost` to the production host but left `url.port` intact (e.g. `8787`), resulting in `https://mobile.example.com:8787/api/ai/chat` — an unreachable endpoint in production.

**Fix:** add `url.port = ''` immediately after overwriting `url.hostname`, so the rewritten URL has no port. The existing guard below (`if (!url.port && DEFAULT_PORT && isLocalHost(url.hostname))`) still correctly adds the port back for genuine localhost environments.

## Test plan

- [ ] With `VITE_AI_ENDPOINT=http://localhost:8787/api/ai/chat` and app on production host → fetch goes to `https://production-host/api/ai/chat` (no port)
- [ ] With app on `localhost` → port is still added from `DEFAULT_PORT`
- [ ] AI Support chat still functional in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)