### PR TITLE
Gate ticket-activation console.log behind import.meta.env.DEV (closes #740)

### DIFF
--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -197,7 +197,7 @@ async function getAccessTokenForFunctions(): Promise<string> {
     !sessionToken || !expiresAt || expiresAt <= nowSeconds + TOKEN_REFRESH_SKEW_SECONDS;
 
   if (!shouldRefresh && sessionToken) {
-    console.log('[ticket-activation] Using cached token, hasToken:', true, 'remaining_s:', expiresAt - nowSeconds);
+    if (import.meta.env.DEV) console.log('[ticket-activation] Using cached token, hasToken:', true, 'remaining_s:', expiresAt - nowSeconds);
     return sessionToken;
   }
 
@@ -213,7 +213,7 @@ async function getAccessTokenForFunctions(): Promise<string> {
     throw new Error(SESSION_REQUIRED_MESSAGE);
   }
 
-  console.log('[ticket-activation] Using refreshed token, hasToken:', true);
+  if (import.meta.env.DEV) console.log('[ticket-activation] Using refreshed token, hasToken:', true);
   return refreshedToken;
 }
 
@@ -223,7 +223,7 @@ async function invokeTicketActivation(body: Record<string, unknown>) {
   }
 
   const token = await getAccessTokenForFunctions();
-  console.log('[ticket-activation] Invoking function, hasToken:', !!token, 'action:', (body as Record<string, unknown>).action);
+  if (import.meta.env.DEV) console.log('[ticket-activation] Invoking function, hasToken:', !!token, 'action:', (body as Record<string, unknown>).action);
   let response = await supabase.functions.invoke('ticket-activation', {
     headers: { Authorization: `Bearer ${token}` },
     body,


### PR DESCRIPTION
## Summary

Three unconditional `console.log` calls in `apps/mobile/src/services/ticket-activation.ts` printed token presence, TTL remaining, and action names on every ticket activation — even in production. The rest of the codebase already gates similar logs behind `import.meta.env.DEV`.

**Fix:** prefix each of the three calls with `if (import.meta.env.DEV)`.

## Test plan

- [ ] In `npm run dev`, activation logs still appear in the browser console
- [ ] In a production build (`npm run build`), no ticket-activation logs are emitted
- [ ] Ticket activation flow works correctly in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)