### PR TITLE
Use fixed profile.jpg path to prevent orphan storage objects (closes #741)

### DIFF
--- a/apps/mobile/src/services/storage.ts
+++ b/apps/mobile/src/services/storage.ts
@@ -2,7 +2,6 @@ import { supabase } from '../lib/supabase';
 import { withMobileWatchdog } from './mobile-watchdog';
 
 const PROFILE_UPLOAD_WATCHDOG_MS = 30000;
-const ALLOWED_IMAGE_EXTS = new Set(['jpg', 'jpeg', 'png', 'webp']);
 const ALLOWED_IMAGE_MIME_PREFIX = 'image/';
 const MAX_PROFILE_IMAGE_BYTES = 5 * 1024 * 1024;
 
@@ -17,9 +16,9 @@ export async function uploadProfileImage(userId: string, file: File): Promise<st
       throw new Error('Immagine troppo grande (max 5MB)');
     }
 
-    const rawExt = file.name.includes('.') ? file.name.split('.').pop()?.toLowerCase() ?? '' : '';
-    const fileExt = ALLOWED_IMAGE_EXTS.has(rawExt) ? rawExt : 'jpg';
-    const fileName = `${userId}/profile.${fileExt}`;
+    // Always use a fixed path so upsert truly overwrites the previous image
+    // regardless of the source file extension, preventing orphan objects.
+    const fileName = `${userId}/profile.jpg`;
 
     const { error } = await supabase.storage
       .from('profile-images')


### PR DESCRIPTION
## Summary

`uploadProfileImage` built the storage path from the uploaded file's extension (`profile.png`, `profile.jpg`, …). Because Supabase `upsert: true` only overwrites the exact matching path, uploading a PNG after a JPEG left `profile.jpeg` as an orphan — accumulating storage cost and confusing any code that constructs the URL with a fixed extension.

**Fix:** always write to `${userId}/profile.jpg` regardless of source extension. The `contentType` field is still set from `file.type` so MIME handling is preserved. The now-unused `ALLOWED_IMAGE_EXTS` set is also removed.

## Test plan

- [ ] Upload a PNG profile image → stored as `userId/profile.jpg`, URL returned
- [ ] Upload a second PNG → overwrites the first, no duplicate object
- [ ] Upload a JPEG after a PNG → single `profile.jpg` object, no orphan PNG
- [ ] File-type and size validation still rejects non-image files and files > 5 MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)