### PR TITLE
Reject outer Promise on watchdog timeout, not just report (closes #747)

### DIFF
--- a/apps/mobile/src/services/mobile-watchdog.ts
+++ b/apps/mobile/src/services/mobile-watchdog.ts
@@ -30,21 +30,33 @@ function buildTimeoutDetails(operation: string, timeoutMs: number) {
   return `Watchdog timeout: ${operation} exceeded ${timeoutMs}ms`;
 }
 
+export class WatchdogTimeoutError extends Error {
+  constructor(operation: string, timeoutMs: number) {
+    super(buildTimeoutDetails(operation, timeoutMs));
+    this.name = 'WatchdogTimeoutError';
+  }
+}
+
 export async function withMobileWatchdog<T>(
   task: () => Promise<T>,
   { operation, timeoutMs, title, message }: MobileWatchdogOptions
 ): Promise<T> {
-  const timeoutId = scheduleWatchdogTimeout(() => {
-    reportCriticalError({
-      title: title ?? DEFAULT_ERROR_TITLE,
-      message: message ?? DEFAULT_ERROR_MESSAGE,
-      details: buildTimeoutDetails(operation, timeoutMs),
-    });
-  }, timeoutMs);
+  let timeoutId: ReturnType<typeof setTimeout> | number | undefined;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = scheduleWatchdogTimeout(() => {
+      reportCriticalError({
+        title: title ?? DEFAULT_ERROR_TITLE,
+        message: message ?? DEFAULT_ERROR_MESSAGE,
+        details: buildTimeoutDetails(operation, timeoutMs),
+      });
+      reject(new WatchdogTimeoutError(operation, timeoutMs));
+    }, timeoutMs);
+  });
 
   try {
-    return await task();
+    return await Promise.race([task(), timeoutPromise]);
   } finally {
-    clearWatchdogTimeout(timeoutId);
+    if (timeoutId !== undefined) clearWatchdogTimeout(timeoutId);
   }
 }


### PR DESCRIPTION
## Summary

`withMobileWatchdog` showed a critical-error overlay when the timeout fired but the underlying `task()` Promise kept running silently in the background. A late success could fire success callbacks after the user had already been told the operation failed — leading to duplicate uploads/activations and stale UI.

**Fix:** replace `await task()` with `Promise.race([task(), timeoutPromise])` where `timeoutPromise` rejects with a new `WatchdogTimeoutError` (also exported) after calling `reportCriticalError`. The `finally` block still clears the timer when the task wins the race. No call-site changes needed — callers already propagate errors from `withMobileWatchdog`.

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| Task completes within timeout | ✅ resolves, clears timer | ✅ same |
| Task exceeds timeout | ⚠️ overlay shown, task still runs | ✅ overlay shown, outer Promise rejects immediately |
| Task fails with its own error | ✅ throws, clears timer | ✅ same |

## Test plan

- [ ] Normal upload / ticket activation completes without error overlay
- [ ] Simulating a slow network (throttle to 1 kbps) → overlay appears and the operation is treated as failed (no late success callback)
- [ ] TypeScript check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)