### PR TITLE
Navigate to home only on SIGNED_IN, not on every auth event (closes #748)

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -174,8 +174,12 @@ export function useAuth(
                 return;
             }
             if (session?.user) {
+                // Only navigate on an explicit sign-in transition.
+                // TOKEN_REFRESHED / USER_UPDATED / INITIAL_SESSION refresh
+                // the profile without interrupting the current screen.
+                const navigateTo = event === 'SIGNED_IN' ? 'home' : undefined;
                 applyUserProfileRef.current(session.user, {
-                    navigateTo: 'home',
+                    navigateTo,
                 });
             }
         });


### PR DESCRIPTION
## Summary

`onAuthStateChange` called `applyUserProfileFromAuth` with `navigateTo: 'home'` for **every** event carrying a `session.user` — including `TOKEN_REFRESHED`, `USER_UPDATED`, and `INITIAL_SESSION`. A background token refresh (~every hour) therefore silently dropped users back to the home screen regardless of where they were.

**Fix:** compute `navigateTo` conditionally — `'home'` only when `event === 'SIGNED_IN'`, `undefined` for all other events. The profile data (name, email) is still refreshed for every event; only the navigation is suppressed.

No type changes needed: `navigateTo` is already typed as optional, and `applyUserProfileFromAuth` already guards with `if (options?.navigateTo)`.

## Test plan

- [ ] Fresh login → navigates to home as expected
- [ ] Background token refresh (wait ~1 h or manually trigger) → stays on current screen
- [ ] Profile update → stays on current screen
- [ ] Password recovery flow → still navigates to change-password
- [ ] Sign-out → still calls onLogout

🤖 Generated with [Claude Code](https://claude.com/claude-code)