### PR TITLE
fix(mobile): reset file input after upload error to allow retry

### DIFF
--- a/apps/mobile/src/components/screens/Profile.tsx
+++ b/apps/mobile/src/components/screens/Profile.tsx
@@ -111,7 +111,7 @@ function ProfileAvatar({
     setIsUploading(true);
     try { await onUploadProfileImage(file); }
     catch { alert('Errore durante il caricamento dell\'immagine.'); }
-    finally { setIsUploading(false); }
+    finally { setIsUploading(false); event.target.value = ''; }
   };
 
   return (


### PR DESCRIPTION
Closes #752

## Summary
- Added `event.target.value = ''` in the `finally` block of `handleFileChange` in `Profile.tsx`
- This ensures the file input is always reset after an upload attempt, whether it succeeds or fails
- Without this fix, re-selecting the same file after an error would not fire the `change` event, leaving users stuck

## Test plan
- [ ] Upload a profile image successfully → new image appears
- [ ] Trigger an upload error (e.g., pick an invalid file) → select the same file again → upload dialog fires correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)