### PR TITLE
fix(mobile): remove method/action from login form to prevent native POST

### DIFF
--- a/apps/mobile/src/components/screens/Login.tsx
+++ b/apps/mobile/src/components/screens/Login.tsx
@@ -49,7 +49,7 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword, errorMessag
           <p className="text-base text-[#b8b2b3]">Inizia la tua carriera teatrale</p>
         </div>
 
-        <form onSubmit={handleSubmit} method="post" action="/login" autoComplete="on"
+        <form onSubmit={handleSubmit} autoComplete="on"
           className="mt-8 flex w-full max-w-[300px] flex-col gap-6 mx-auto">
 
           <FormField label="Email" htmlFor="login-email" error={errors.email}>


### PR DESCRIPTION
Closes #753

## Summary
- Removed `method="post"` and `action="/login"` attributes from the login form in `Login.tsx`
- These attributes served no purpose for a client-side SPA form and posed a security risk
- Without this fix, if JS fails to boot or `e.preventDefault()` is skipped, the browser would POST credentials to `/login` (a non-existent route), potentially leaking them in server logs

## Test plan
- [ ] Login form submits correctly via `handleSubmit`
- [ ] Hitting Enter in the form does not navigate away from the SPA
- [ ] No native form POST occurs under any loading condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)