### PR TITLE
fix(mobile): add displayName/userId to SupportChat save effect deps

### DIFF
--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -82,7 +82,7 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
       saveChatHistory(displayName, next, userId);
       return next;
     });
-  }, [messages, activeSessionId, historyId]);
+  }, [messages, activeSessionId, historyId, displayName, userId]);
 
   const hasInput = input.trim().length > 0;
   const activeSession = useMemo(


### PR DESCRIPTION
Closes #754

## Summary
- Added `displayName` and `userId` to the dependency array of the auto-save `useEffect` in `SupportChat.tsx` (line 85)
- Without these deps, saves after a `displayName`/`userId` change used the stale closure values, writing to the wrong storage key and splitting chat history
- This is the save-side counterpart to the fix applied to the load side in issue #560

## Test plan
- [ ] Chat history persists correctly across sessions
- [ ] If user metadata refreshes mid-session (e.g. TOKEN_REFRESHED), saves continue to use the correct key
- [ ] No empty chat on reload after a mid-session profile update

🤖 Generated with [Claude Code](https://claude.com/claude-code)