### PR TITLE
fix(mobile): omit origin param in openEventsMap to use device location

### DIFF
--- a/apps/mobile/src/lib/navigation-utils.ts
+++ b/apps/mobile/src/lib/navigation-utils.ts
@@ -15,13 +15,13 @@ export function openInMaps(theatre: string) {
 
 export function openEventsMap(theatres: string[]) {
     if (typeof window === 'undefined' || !theatres.length) return;
-    const origin = encodeURIComponent('My Location');
     const destination = encodeURIComponent(theatres[theatres.length - 1]);
     const waypoints = theatres
         .slice(0, -1)
         .map((value) => encodeURIComponent(value))
         .join('|');
-    const url = `https://www.google.com/maps/dir/?api=1&origin=${origin}&destination=${destination}${waypoints ? `&waypoints=${waypoints}` : ''
-        }`;
+    // Omit origin so Google Maps defaults to the device's current location.
+    // Passing 'My Location' as a literal string causes geocoding failures.
+    const url = `https://www.google.com/maps/dir/?api=1&destination=${destination}${waypoints ? `&waypoints=${waypoints}` : ''}`;
     window.location.href = url;
 }


### PR DESCRIPTION
Closes #761

## Summary
- Removed `origin=My%20Location` from the Google Maps Directions URL built by `openEventsMap` in `navigation-utils.ts`
- The Maps URL API cannot resolve the literal string "My Location" as a geocodable origin; it would either fail or resolve to a random unrelated place
- Omitting the `origin` parameter entirely causes Google Maps to default to the device's current GPS location, which is the intended behavior

## Test plan
- [ ] Tapping the multi-event map button opens Google Maps with directions starting from the user's actual current position
- [ ] Single-stop `openInMaps` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)