### PR TITLE
fix(mobile): append ICS anchor to DOM before click and remove after

### DIFF
--- a/apps/mobile/src/components/screens/EventDetails.tsx
+++ b/apps/mobile/src/components/screens/EventDetails.tsx
@@ -99,7 +99,10 @@ export function EventDetails({
     const anchor = document.createElement('a');
     anchor.href = url;
     anchor.download = `${event.name.replace(/[\\/:*?"<>|]+/g, '')}.ics`;
+    anchor.style.display = 'none';
+    document.body.appendChild(anchor);
     anchor.click();
+    document.body.removeChild(anchor);
     URL.revokeObjectURL(url);
   };
 


### PR DESCRIPTION
Closes #764

## Summary
- Added `anchor.style.display = 'none'` and `document.body.appendChild(anchor)` before `.click()` in `EventDetails.tsx`
- Added `document.body.removeChild(anchor)` immediately after `.click()` and before `URL.revokeObjectURL(url)` so the blob URL stays alive during the click
- Detached anchors are ignored by iOS Safari; appending to the DOM ensures the synthetic click triggers the download on all browsers

## Test plan
- [ ] Tap "Scarica .ics" on an event — file downloads correctly on Chrome/Android
- [ ] Same action on iOS Safari — file downloads correctly (was broken before)
- [ ] No zombie anchor elements left in the DOM after download

🤖 Generated with [Claude Code](https://claude.com/claude-code)