### PR TITLE
fix(edge): replace raw Supabase errors with generic message in event-links

### DIFF
--- a/supabase/functions/event-links/index.ts
+++ b/supabase/functions/event-links/index.ts
@@ -132,7 +132,8 @@ serve(async (req) => {
       .maybeSingle<EventRow>();
 
     if (error) {
-      return json({ valid: false, error: error.message }, 500);
+      console.error('[event-links] validate_event_id db error:', error);
+      return json({ valid: false, error: 'Errore interno del server.' }, 500);
     }
 
     if (!data) {
@@ -165,7 +166,8 @@ serve(async (req) => {
       .maybeSingle<{ id: string }>();
 
     if (error) {
-      return json({ error: error.message }, 500);
+      console.error('[event-links] create_deep_link db error:', error);
+      return json({ error: 'Errore interno del server.' }, 500);
     }
 
     if (!data) {
@@ -202,7 +204,8 @@ serve(async (req) => {
       .maybeSingle<EventRow>();
 
     if (error) {
-      return json({ resolved: false, error: error.message }, 500);
+      console.error('[event-links] resolve_deep_link db error:', error);
+      return json({ resolved: false, error: 'Errore interno del server.' }, 500);
     }
 
     if (!data) {


### PR DESCRIPTION
Closes #765

## Summary
- All three 500-response paths in `supabase/functions/event-links/index.ts` (lines 135, 168, 205) now log the raw error server-side via `console.error` and return the generic Italian message `'Errore interno del server.'` to the client
- Raw `error.message` strings (which can expose schema names, SQL details, or internal paths) are no longer sent over the wire

## Test plan
- [ ] Valid event ID resolves successfully
- [ ] Invalid event ID returns 404 with "Evento non trovato" (unchanged)
- [ ] DB error path returns 500 with generic message; raw error visible in Supabase function logs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)