### PR TITLE
fix(mobile): use 30s error backoff TTL in promotions cache on fetch failure

### DIFF
--- a/apps/mobile/src/services/atcl-promotions.ts
+++ b/apps/mobile/src/services/atcl-promotions.ts
@@ -22,6 +22,7 @@ type RssItem = {
 type PromoSourceKey = 'atcl-rss' | 'rossellini-rss' | 'atcl-rest' | 'rossellini-rest';
 
 const REMOTE_CACHE_TTL_MS = 15 * 60 * 1000;
+const REMOTE_CACHE_ERROR_TTL_MS = 30 * 1000; // short backoff on failure so retries succeed quickly
 const RSS_ACCEPT_HEADER = 'application/rss+xml, application/xml;q=0.9, text/xml;q=0.8';
 const NEWS_TICKER_DEFAULT_LIMIT = 20;
 
@@ -112,9 +113,13 @@ async function loadRemotePromotionsSafe(): Promise<PromotionBySlot> {
       return data;
     })
     .catch(() => {
+      // Do not overwrite a valid cached result; use a short backoff TTL so
+      // the next call retries after network recovery instead of waiting 15 min.
       const fallback = remoteCacheData ?? {};
-      remoteCacheData = fallback;
-      remoteCacheExpiresAt = Date.now() + REMOTE_CACHE_TTL_MS;
+      if (!remoteCacheData) {
+        remoteCacheData = fallback;
+      }
+      remoteCacheExpiresAt = Date.now() + REMOTE_CACHE_ERROR_TTL_MS;
       return fallback;
     })
     .finally(() => {
@@ -147,9 +152,13 @@ async function loadRemoteFeedBundleSafe(): Promise<{ atclItems: RssItem[]; rosse
       return bundle;
     })
     .catch(() => {
+      // Do not overwrite a valid cached result; use a short backoff TTL so
+      // the next call retries after network recovery instead of waiting 15 min.
       const fallback = remoteFeedCacheData ?? { atclItems: [], rosselliniItems: [] };
-      remoteFeedCacheData = fallback;
-      remoteFeedCacheExpiresAt = Date.now() + REMOTE_CACHE_TTL_MS;
+      if (!remoteFeedCacheData) {
+        remoteFeedCacheData = fallback;
+      }
+      remoteFeedCacheExpiresAt = Date.now() + REMOTE_CACHE_ERROR_TTL_MS;
       return fallback;
     })
     .finally(() => {


### PR DESCRIPTION
Closes #766

## Summary
- Added `REMOTE_CACHE_ERROR_TTL_MS = 30 * 1000` constant in `atcl-promotions.ts`
- Both `.catch()` handlers (promotions and feed bundle) now set `remoteCacheExpiresAt` / `remoteFeedCacheExpiresAt` to the short 30s backoff TTL instead of the full 15-minute success TTL
- Existing cached data is never overwritten on failure; only an empty placeholder is stored when no prior cache exists
- After a transient network failure, the next call retries after 30s instead of being blocked for 15 minutes

## Test plan
- [ ] Promotions load correctly under normal conditions (15-min cache unchanged)
- [ ] After a network failure, promotions are retried within ~30s of the failure
- [ ] Pre-existing cached promotions survive a failed refresh (not replaced with empty object)

🤖 Generated with [Claude Code](https://claude.com/claude-code)