### PR TITLE
fix(mobile): use onLogoutRef.current() in SIGNED_OUT handler

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -163,7 +163,7 @@ export function useAuth(
             if (!mounted) return;
             if (event === 'SIGNED_OUT') {
                 setAuthError('Sessione scaduta. Effettua nuovamente l\'accesso.');
-                onLogout();
+                onLogoutRef.current();
                 return;
             }
             if (event === 'PASSWORD_RECOVERY') {


### PR DESCRIPTION
Closes #767

## Summary
- Changed `onLogout()` to `onLogoutRef.current()` in the `SIGNED_OUT` branch of the `onAuthStateChange` listener in `useAuth.ts` (line 166)
- `onLogoutRef` is already maintained up-to-date at lines 146–147; using it ensures the latest callback is always invoked, not the stale closure captured when the effect first ran

## Test plan
- [ ] Signing out correctly triggers the logout handler and navigates away
- [ ] If the consumer updates its `onLogout` prop after mount, a SIGNED_OUT event still calls the latest handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)