### PR TITLE
fix(edge): replace raw error with generic message in ticket-activation

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -304,7 +304,7 @@ serve(async (req: Request) => {
 
     return jsonResponse({ error: 'Invalid action' }, 400);
   } catch (err) {
-    console.error(err);
-    return jsonResponse({ error: err instanceof Error ? err.message : 'Unknown error' }, 500);
+    console.error('[ticket-activation] unexpected error:', err);
+    return jsonResponse({ error: 'Activation failed' }, 500);
   }
 });


### PR DESCRIPTION
Closes #768

## Summary
- Changed the top-level catch in `supabase/functions/ticket-activation/index.ts` (line 308) to log the full error server-side and return the fixed string `'Activation failed'` to the client
- Raw `err.message` (which can contain stack fragments, internal identifiers, or Deno runtime details) is no longer sent over the wire

## Test plan
- [ ] Valid ticket activation succeeds as before
- [ ] An unexpected runtime error returns 500 with `{ error: 'Activation failed' }`; full error visible in Supabase function logs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)