### PR TITLE
fix(edge): correct default APP_REPO fallback in app-version function

### DIFF
--- a/supabase/functions/app-version/index.ts
+++ b/supabase/functions/app-version/index.ts
@@ -41,7 +41,7 @@ serve(async (req) => {
   }
 
   const appVersion = Deno.env.get('APP_VERSION') ?? '0.0.5';
-  const repo = Deno.env.get('APP_REPO') ?? 'Heartran/Turni-di-Palco';
+  const repo = Deno.env.get('APP_REPO') ?? 'ATCL-Lazio/Turni-di-Palco';
   const githubToken = Deno.env.get('GITHUB_TOKEN');
 
   let payload: { limit?: number } = {};


### PR DESCRIPTION
Closes #774

## Summary
- Changed the `APP_REPO` fallback in `supabase/functions/app-version/index.ts` from `'Heartran/Turni-di-Palco'` to `'ATCL-Lazio/Turni-di-Palco'`
- When `APP_REPO` env var is unset, the function was silently querying the wrong GitHub repo for releases, returning stale or 404 version data

## Test plan
- [ ] Version check returns the correct latest release from `ATCL-Lazio/Turni-di-Palco` when `APP_REPO` is unset
- [ ] Explicit `APP_REPO` env var still overrides the fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)