### PR TITLE
fix(mobile): parse manual-ticket code safely to preserve colons in ticket id

### DIFF
--- a/apps/mobile/src/handlers/useQrHandlers.ts
+++ b/apps/mobile/src/handlers/useQrHandlers.ts
@@ -93,7 +93,13 @@ export function useQrHandlers(deps: QrHandlerDeps) {
 
     // Manual ticket entry (requires pre-registered ticket via Python generator)
     if (code.startsWith('manual-ticket:')) {
-      const [, eventId, ticketNumber] = code.split(':');
+      // Split only on the first two colons so that a colon inside the ticket
+      // number or event id is preserved rather than silently truncated.
+      const prefixLen = 'manual-ticket:'.length;
+      const rest = code.slice(prefixLen);
+      const sep = rest.indexOf(':');
+      const eventId = sep === -1 ? rest : rest.slice(0, sep);
+      const ticketNumber = sep === -1 ? '' : rest.slice(sep + 1);
       if (!eventId || !ticketNumber) return { ok: false as const, error: 'Dati manuali incompleti.' };
 
       const normalizedEventId = eventId.trim();


### PR DESCRIPTION
Closes #775

## Summary
- Replaced `code.split(':')` destructuring in `useQrHandlers.ts` with an `indexOf`-based split on only the first colon after the `manual-ticket:` prefix
- Previously, `split(':')` on `manual-ticket:<eventId>:<ticketNumber>` would silently truncate the ticket number at any subsequent colon in its value
- Now the entire remainder after the second colon is treated as the ticket number, preserving any colons it may contain

## Test plan
- [ ] Manual ticket activation works for normal ticket numbers (no colons)
- [ ] Ticket numbers containing colons are parsed correctly without truncation
- [ ] Incomplete codes (missing eventId or ticketNumber) still return the "Dati manuali incompleti" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)