### PR TITLE
fix(edge): align delete-my-account CORS default origin to turnidipalco.it

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -2,7 +2,7 @@
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.48.0';
 
-const allowedOrigin = Deno.env.get('SITE_URL') || 'https://turni-di-palco.vercel.app';
+const allowedOrigin = Deno.env.get('SITE_URL') ?? 'https://turnidipalco.it';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': allowedOrigin,


### PR DESCRIPTION
Closes #778

## Summary
- Changed `delete-my-account/index.ts` CORS fallback from `'https://turni-di-palco.vercel.app'` to `'https://turnidipalco.it'`, matching every other edge function in the repo
- Also changed `||` to `??` so an empty-string `SITE_URL` env var doesn't silently fall through to the wrong default

## Test plan
- [ ] Account deletion from `turnidipalco.it` succeeds (no CORS error) when `SITE_URL` is unset
- [ ] Explicit `SITE_URL` env var still overrides the fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)