### PR TITLE
fix: append cache-bust param to profile avatar URL (closes #786)

### DIFF
--- a/apps/mobile/src/services/storage.ts
+++ b/apps/mobile/src/services/storage.ts
@@ -38,7 +38,8 @@ export async function uploadProfileImage(userId: string, file: File): Promise<st
       throw new Error('Impossibile ottenere l\'URL pubblico');
     }
 
-    return urlData.publicUrl;
+    const separator = urlData.publicUrl.includes('?') ? '&' : '?';
+    return `${urlData.publicUrl}${separator}v=${Date.now()}`;
   }, {
     operation: 'uploadProfileImage',
     timeoutMs: PROFILE_UPLOAD_WATCHDOG_MS,


### PR DESCRIPTION
Closes #786

The fixed-filename upload path (`{userId}/profile.jpg`) combined with `cacheControl: 3600` meant browsers and CDNs served a stale avatar for up to an hour after upload. Now the returned public URL carries a `v=<timestamp>` query param so each successful upload cache-busts without touching bucket cache settings.