### PR TITLE
fix(mobile-logs): do not leak raw error messages to client

### DIFF
--- a/supabase/functions/mobile-logs/index.ts
+++ b/supabase/functions/mobile-logs/index.ts
@@ -191,6 +191,6 @@ serve(async (req: Request) => {
     });
   } catch (error) {
     console.error('[mobile-logs] unexpected error', error);
-    return jsonResponse({ error: error instanceof Error ? error.message : 'Unknown error' }, 500);
+    return jsonResponse({ error: 'Internal server error' }, 500);
   }
 });


### PR DESCRIPTION
Closes #792

Replace raw `error.message` in the catch handler response with a generic message. Full error is still logged server-side via `console.error`.

Mirrors the fix pattern from `ticket-activation` (#768) and `event-links` (#765).