### PR TITLE
fix(cleanup-events): do not leak raw error messages to client

### DIFF
--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -124,10 +124,9 @@ serve(async (req) => {
     )
 
   } catch (error: unknown) {
-    const msg = error instanceof Error ? error.message : String(error);
-    console.error('❌ Errore durante la pulizia:', msg)
+    console.error('❌ Errore durante la pulizia:', error)
     return new Response(
-      JSON.stringify({ error: msg }),
+      JSON.stringify({ error: 'Internal server error' }),
       {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         status: 500


### PR DESCRIPTION
Closes #793

Replace raw error message in the catch handler response with a generic message. Full error is still logged server-side via console.error.

Mirrors the pattern from ticket-activation (#768) and event-links (#765).