### PR TITLE
fix(import-spazio-rossellini): do not leak raw errors to client

### DIFF
--- a/supabase/functions/import-spazio-rossellini/index.ts
+++ b/supabase/functions/import-spazio-rossellini/index.ts
@@ -188,7 +188,8 @@ serve(async (req) => {
 
     const { error } = await supabase.from('events').upsert(rows, { onConflict: 'id' });
     if (error) {
-      return jsonResponse({ error: error.message }, 500);
+      console.error('[import-spazio-rossellini] upsert error', error);
+      return jsonResponse({ error: 'Upsert failed' }, 500);
     }
 
     return jsonResponse({
@@ -198,6 +199,7 @@ serve(async (req) => {
       upserted: rows.length,
     });
   } catch (error) {
-    return jsonResponse({ error: error instanceof Error ? error.message : 'Errore' }, 500);
+    console.error('[import-spazio-rossellini] unexpected error', error);
+    return jsonResponse({ error: 'Internal server error' }, 500);
   }
 });


### PR DESCRIPTION
Closes #794

Replace raw error messages in both the upsert error path and outer catch handler with generic messages. Full errors still logged server-side.

Mirrors the pattern from ticket-activation (#768) and event-links (#765).