### PR TITLE
fix(app-version): wrap GitHub fetch in try/catch

### DIFF
--- a/supabase/functions/app-version/index.ts
+++ b/supabase/functions/app-version/index.ts
@@ -66,7 +66,13 @@ serve(async (req) => {
   }
 
   const url = `https://api.github.com/repos/${repo}/commits?per_page=${limit}`;
-  const response = await fetch(url, { headers });
+  let response: Response;
+  try {
+    response = await fetch(url, { headers });
+  } catch (err) {
+    console.error('[app-version] GitHub fetch failed', err);
+    return errorResponse('Impossibile caricare il changelog', 502);
+  }
   if (!response.ok) {
     return errorResponse('Impossibile caricare il changelog', response.status);
   }


### PR DESCRIPTION
Closes #795

Wrap the GitHub commits API `fetch` in a try/catch so that transient network failures (DNS, TLS, connection reset) return a clean 502 with the intended user-facing message instead of bubbling an uncaught exception that the handler turns into an opaque 500.