### PR TITLE
fix(dev-access): return 500 when required Supabase env vars are missing

### DIFF
--- a/supabase/functions/dev-access/index.ts
+++ b/supabase/functions/dev-access/index.ts
@@ -91,6 +91,11 @@ serve(async (req) => {
   const anonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
   const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
 
+  if (!supabaseUrl || !anonKey || !serviceRoleKey) {
+    console.error('[dev-access] Missing Supabase env vars');
+    return jsonResponse({ allowed: false, reason: 'Missing Supabase env vars' }, 500);
+  }
+
   const allowedRoles = parseEnvList(Deno.env.get('DEV_ALLOWED_ROLES') ?? 'dev');
   const allowedEmails = parseEnvList(Deno.env.get('DEV_ALLOWED_EMAILS') ?? '');
 


### PR DESCRIPTION
Closes #796

Add an early guard that returns a 500 `Missing Supabase env vars` response if `SUPABASE_URL`, `SUPABASE_ANON_KEY`, or `SUPABASE_SERVICE_ROLE_KEY` are not set. Previously, empty-string fallbacks caused `createClient('', '', ...)` to proceed and fail later with an opaque 401 'Utente non autenticato'.

Matches the pattern already used by `cleanup-events`, `event-links`, `ticket-activation`, and `import-spazio-rossellini`.