### PR TITLE
fix(mobile): show password-change success banner before navigating back

### DIFF
--- a/apps/mobile/src/components/screens/ChangePassword.tsx
+++ b/apps/mobile/src/components/screens/ChangePassword.tsx
@@ -65,7 +65,11 @@ export function ChangePassword({
       setPassword('');
       setConfirmPassword('');
       setSuccessMessage('Password aggiornata con successo.');
-      onBack();
+      setIsSubmitting(false);
+      setTimeout(() => {
+        onBack();
+      }, 1500);
+      return;
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : 'Errore sconosciuto');
     } finally {


### PR DESCRIPTION
Closes #797

Delay `onBack()` by 1.5s after a successful password change so the success banner (`successMessage`) is actually rendered before the component unmounts. Previously the state write was dead code because `onBack()` was called synchronously in the same tick.