### PR TITLE
fix(mobile): suppress misleading session-expired error on voluntary logout

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -92,13 +92,19 @@ export function useAuth(
         onAuthChange('welcome'); // Flow will continue to role-selection
     }, [onAuthChange, updateProfile]);
 
+    // Set to true immediately before a voluntary signOut so the SIGNED_OUT
+    // listener can skip the misleading "session expired" error message.
+    const isVoluntaryLogoutRef = useRef(false);
+
     const handleLogoutAction = useCallback(async () => {
         setAuthError(null);
         if (supabase) {
             try {
+                isVoluntaryLogoutRef.current = true;
                 await supabase.auth.signOut();
             } catch {
                 // signOut failure must not block local logout
+                isVoluntaryLogoutRef.current = false;
             }
         }
         onLogout();
@@ -162,7 +168,14 @@ export function useAuth(
         const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
             if (!mounted) return;
             if (event === 'SIGNED_OUT') {
-                setAuthError('Sessione scaduta. Effettua nuovamente l\'accesso.');
+                // Only show the "session expired" message for involuntary
+                // sign-outs (e.g. token revoked by server). Voluntary logouts
+                // (initiated via handleLogoutAction) set isVoluntaryLogoutRef
+                // before calling signOut() so we skip the misleading banner.
+                if (!isVoluntaryLogoutRef.current) {
+                    setAuthError('Sessione scaduta. Effettua nuovamente l\'accesso.');
+                }
+                isVoluntaryLogoutRef.current = false;
                 onLogoutRef.current();
                 return;
             }


### PR DESCRIPTION
Closes #804

## Summary
- Added `isVoluntaryLogoutRef` flag in `useAuth.ts`
- `handleLogoutAction` sets it to `true` before calling `supabase.auth.signOut()` and resets to `false` on error
- The `SIGNED_OUT` listener now only sets `authError` to the 'session expired' message when the flag is false (i.e. the sign-out was involuntary — token expired/revoked)
- Voluntary logouts proceed silently without showing a misleading error on the login screen

## Test plan
- [ ] Tapping 'Esci' logs out without showing any error message on the login screen
- [ ] An involuntary sign-out (token revoked) still shows 'Sessione scaduta. Effettua nuovamente l'accesso.'

🤖 Generated with [Claude Code](https://claude.com/claude-code)