### PR TITLE
fix(mobile): replace window.confirm with AlertDialog in AccountSettings

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.6",
     "@radix-ui/react-popover": "^1.1.6",
     "@radix-ui/react-scroll-area": "^1.2.3",
     "@radix-ui/react-select": "^2.1.6",

--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -10,6 +10,10 @@ import { getPermission, requestPermission, type NotificationPermissionState } fr
 import { checkAiSupportAvailability } from '../../services/ai';
 import { CopyrightNotice } from '../ui/CopyrightNotice';
 import { GEO_CONSENT_KEY } from '../../constants/privacy';
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from '../ui/alert-dialog';
 
 interface AccountSettingsProps {
   userName: string;
@@ -48,35 +52,73 @@ export function AccountSettings({
   const { geoConsent, grantGeoConsent, denyGeoConsent } = useGeoConsent();
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
-  const handleResetTutorial = () => {
-    if (typeof window === 'undefined') return;
-    const ok = window.confirm('Vuoi rivedere il tutorial di benvenuto? Apparirà alla prossima apertura della home.');
-    if (ok) onResetTutorial();
-  };
+  // In-app confirm dialog state (replaces window.confirm for all destructive actions)
+  type ConfirmPending = 'tutorial' | 'reset' | 'delete' | null;
+  const [confirmPending, setConfirmPending] = useState<ConfirmPending>(null);
 
-  const handleReset = () => {
-    if (typeof window === 'undefined') return;
-    const ok = window.confirm(
-      'Vuoi davvero resettare i progressi? Questa modifica è irreversibile: cancelleremo turni, badge e statistiche e ti riporteremo alla scelta del ruolo.'
-    );
-    if (ok) onResetProgress();
-  };
+  const handleResetTutorial = () => setConfirmPending('tutorial');
+  const handleReset = () => setConfirmPending('reset');
+  const handleDeleteAccount = () => setConfirmPending('delete');
 
-  const handleDeleteAccount = async () => {
-    if (typeof window === 'undefined') return;
-    const ok = window.confirm(
-      'Stai per eliminare definitivamente il tuo account e tutti i dati associati (turni, badge, statistiche, immagine profilo). Questa operazione è irreversibile. Continuare?'
-    );
-    if (!ok) return;
-    setDeleteError(null);
-    try {
-      await onDeleteAccount();
-    } catch (err) {
-      setDeleteError(err instanceof Error ? err.message : 'Impossibile eliminare il profilo. Riprova.');
+  const handleConfirm = async () => {
+    const action = confirmPending;
+    setConfirmPending(null);
+    if (action === 'tutorial') {
+      onResetTutorial();
+    } else if (action === 'reset') {
+      onResetProgress();
+    } else if (action === 'delete') {
+      setDeleteError(null);
+      try {
+        await onDeleteAccount();
+      } catch (err) {
+        setDeleteError(err instanceof Error ? err.message : 'Impossibile eliminare il profilo. Riprova.');
+      }
     }
   };
 
+  const confirmConfig: Record<NonNullable<ConfirmPending>, { title: string; description: string; actionLabel: string; destructive?: boolean }> = {
+    tutorial: {
+      title: 'Rivedere il tutorial?',
+      description: 'Apparirà alla prossima apertura della home.',
+      actionLabel: 'Conferma',
+    },
+    reset: {
+      title: 'Resettare i progressi?',
+      description: 'Questa modifica è irreversibile: cancelleremo turni, badge e statistiche e ti riporteremo alla scelta del ruolo.',
+      actionLabel: 'Resetta',
+      destructive: true,
+    },
+    delete: {
+      title: 'Eliminare account?',
+      description: 'Stai per eliminare definitivamente il tuo account e tutti i dati associati (turni, badge, statistiche, immagine profilo). Questa operazione è irreversibile.',
+      actionLabel: 'Elimina account',
+      destructive: true,
+    },
+  };
+
   return (
+    <>
+    <AlertDialog open={confirmPending !== null} onOpenChange={open => { if (!open) setConfirmPending(null); }}>
+      <AlertDialogContent className="bg-[#1a1617] border-[#2d2728] text-white">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{confirmPending ? confirmConfig[confirmPending].title : ''}</AlertDialogTitle>
+          <AlertDialogDescription className="text-[#b8b2b3]">
+            {confirmPending ? confirmConfig[confirmPending].description : ''}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel className="bg-transparent border-[#2d2728] text-[#b8b2b3] hover:bg-[#2d2728] hover:text-white">Annulla</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            className={confirmPending && confirmConfig[confirmPending].destructive
+              ? 'bg-[#a82847] hover:bg-[#8c1c38] text-white border-0'
+              : 'bg-[#f4bf4f] hover:bg-[#d4a030] text-[#0f0d0e] border-0'}>
+            {confirmPending ? confirmConfig[confirmPending].actionLabel : ''}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
     <Screen
       withBottomNavPadding={false}
       className="relative items-start justify-start"
@@ -141,6 +183,7 @@ export function AccountSettings({
         </div>
       </div>
     </Screen>
+    </>
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
       "name": "turni-mobile",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-alert-dialog": "^1.1.6",
         "@radix-ui/react-popover": "^1.1.6",
         "@radix-ui/react-scroll-area": "^1.2.3",
         "@radix-ui/react-select": "^2.1.6",
@@ -838,6 +839,52 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",


### PR DESCRIPTION
Closes #807
Closes #808
Closes #809

## Summary
- Added `AlertDialog` import from `../ui/alert-dialog` (Radix UI) in `AccountSettings.tsx`
- Replaced all three `window.confirm` calls (reset tutorial, reset progress, delete account) with a shared `confirmPending` state that drives a single `AlertDialog`
- Each action has its own config (title, description, action label, destructive flag); destructive actions render a red action button
- Fragment wrapper used to render the dialog portal alongside the `<Screen>`
- No blocking native confirm dialogs remain in this component

## Test plan
- [ ] "Rivedere tutorial" button opens in-app dialog; confirming triggers tutorial reset; cancelling does nothing
- [ ] "Resetta progressi" button opens dialog with red confirm button; confirming resets progress
- [ ] "Elimina account" button opens dialog with red confirm button; confirming deletes account
- [ ] Dialog closes on overlay click or Annulla button
- [ ] No `window.confirm` fires in any path

🤖 Generated with [Claude Code](https://claude.com/claude-code)