### PR TITLE
fix(mobile): gate 401 console.warn calls behind import.meta.env.DEV

### DIFF
--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -240,7 +240,7 @@ async function invokeTicketActivation(body: Record<string, unknown>) {
 
   // Retry once with a refreshed token if gateway rejects the request.
   if (response.error && getFunctionErrorStatus(response.error) === 401) {
-    console.warn('[ticket-activation] 401 on first attempt, status:', getFunctionErrorStatus(response.error), 'error:', response.error);
+    if (import.meta.env.DEV) console.warn('[ticket-activation] 401 on first attempt, status:', getFunctionErrorStatus(response.error), 'error:', response.error);
     const { data: refreshed, error: refreshError } = await supabase.auth.refreshSession();
     const refreshedToken = refreshed.session?.access_token?.trim();
     if (!refreshError && refreshedToken) {
@@ -250,7 +250,7 @@ async function invokeTicketActivation(body: Record<string, unknown>) {
       });
     }
     if (response.error && getFunctionErrorStatus(response.error) === 401) {
-      console.warn('[ticket-activation] 401 on retry, invalidating session');
+      if (import.meta.env.DEV) console.warn('[ticket-activation] 401 on retry, invalidating session');
       await invalidateAuthSession();
     }
   }


### PR DESCRIPTION
Closes #815

## Summary
- Wrapped both `console.warn` calls in `ticket-activation.ts` (lines 243 and 253) with `if (import.meta.env.DEV)`, matching the convention already used at line 235 in the same file
- In production builds these calls are tree-shaken out, preventing auth failure details from leaking to the browser console

## Test plan
- [ ] In dev: 401 retry path still logs to console
- [ ] In production build: no `console.warn` fires during the 401 retry flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)