### PR TITLE
fix(edge): return empty string when no event ID pattern matches in event-links

### DIFF
--- a/supabase/functions/event-links/index.ts
+++ b/supabase/functions/event-links/index.ts
@@ -49,7 +49,7 @@ function extractEventId(payload: string | null | undefined) {
   }
 
   const textMatch = raw.match(EVENT_ID_PATTERN)?.[1];
-  return normalizeEventId(textMatch ?? raw);
+  return textMatch ? normalizeEventId(textMatch) : '';
 }
 
 const ALLOWED_HOSTS = [


### PR DESCRIPTION
Closes #816

## Summary
- Changed `extractEventId` in `supabase/functions/event-links/index.ts` (line 52) to return `''` instead of `normalizeEventId(raw)` when no `EVENT_ID_PATTERN` match is found
- Mirrors the client-side fix applied in #760: callers already treat an empty string as "no event ID found" and produce a proper 400/not-found response instead of building a deeplink with a garbage value

## Test plan
- [ ] Valid event ID payload (e.g. `AT-12345`) resolves correctly
- [ ] Unrecognised payload (e.g. arbitrary text, non-matching URL) now returns empty string, causing the caller to return a 400/not-found rather than a bogus deeplink

🤖 Generated with [Claude Code](https://claude.com/claude-code)