### PR TITLE
fix(mobile): clear ChangePassword onBack timer on unmount

### DIFF
--- a/apps/mobile/src/components/screens/ChangePassword.tsx
+++ b/apps/mobile/src/components/screens/ChangePassword.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { ArrowLeft } from 'lucide-react';
 import { Screen } from '../ui/Screen';
 
@@ -29,6 +29,16 @@ export function ChangePassword({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [resetEmailStatus, setResetEmailStatus] = useState<'idle' | 'sending' | 'sent'>('idle');
   const [resetEmailError, setResetEmailError] = useState<string | null>(null);
+  const backTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (backTimerRef.current !== null) {
+        clearTimeout(backTimerRef.current);
+        backTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const handleSendResetEmail = async () => {
     setResetEmailError(null);
@@ -66,7 +76,11 @@ export function ChangePassword({
       setConfirmPassword('');
       setSuccessMessage('Password aggiornata con successo.');
       setIsSubmitting(false);
-      setTimeout(() => {
+      if (backTimerRef.current !== null) {
+        clearTimeout(backTimerRef.current);
+      }
+      backTimerRef.current = setTimeout(() => {
+        backTimerRef.current = null;
         onBack();
       }, 1500);
       return;


### PR DESCRIPTION
Closes #821

Track the 1.5s post-success setTimeout in a ref and clear it in a useEffect cleanup, preventing the delayed `onBack()` from firing (and causing stale navigation / state-update-on-unmounted warnings) if the component unmounts during the window.

Also defensively clears any pending timer before scheduling a new one inside handleSubmit.

Matches the fix pattern used in closed issues #633 (EventConfirmation) and #678 (ProgressBar).