### PR TITLE
fix(pwa): replace raw Supabase error with generic message in dev-gate

### DIFF
--- a/apps/pwa/src/services/dev-gate.ts
+++ b/apps/pwa/src/services/dev-gate.ts
@@ -126,7 +126,7 @@ export async function requireDevAccess(): Promise<boolean> {
 
         if (error) {
           setBusy(gate, false);
-          setMessage(gate.message, error.message, "error");
+          setMessage(gate.message, "Credenziali non valide.", "error");
           return;
         }
 


### PR DESCRIPTION
Closes #825

## Summary
- Replaced `error.message` with the fixed Italian string `"Credenziali non valide."` in the PWA dev-gate sign-in error path (`dev-gate.ts:129`)
- Raw English Supabase strings (e.g. "Invalid login credentials") no longer reach the UI; all auth failures collapse to one generic message, preventing account-state enumeration

## Test plan
- [ ] Entering wrong credentials on the PWA dev gate shows "Credenziali non valide." in Italian
- [ ] No raw English error string is displayed to the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)