### PR TITLE
fix(mobile): show generic Italian error in ChangePassword reset email handler

### DIFF
--- a/apps/mobile/src/components/screens/ChangePassword.tsx
+++ b/apps/mobile/src/components/screens/ChangePassword.tsx
@@ -46,8 +46,8 @@ export function ChangePassword({
     try {
       await onSendResetEmail();
       setResetEmailStatus('sent');
-    } catch (error) {
-      setResetEmailError(error instanceof Error ? error.message : 'Errore sconosciuto');
+    } catch {
+      setResetEmailError('Impossibile inviare l\'email di reset. Riprova più tardi.');
       setResetEmailStatus('idle');
     }
   };


### PR DESCRIPTION
## Summary
- Replaces `error instanceof Error ? error.message : 'Errore sconosciuto'` in the `handleSendResetEmail` catch block with the fixed Italian string `'Impossibile inviare l\'email di reset. Riprova più tardi.'`
- Removes unused `error` binding from the catch clause
- Prevents raw English Supabase error messages from leaking to the user

## Test plan
- [ ] Trigger a reset-email error (e.g., network failure or Supabase misconfiguration)
- [ ] Confirm the displayed error is the Italian generic message, not the raw English error

Closes #826