### PR TITLE
fix(mobile): always use Italian fallback for app info error message

### DIFF
--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -406,7 +406,7 @@ function useAppInfo() {
       }
       const { data, error } = await supabase.functions.invoke('app-version', { body: { limit: 8 } });
       if (!mounted) return;
-      if (error) { setAppInfoStatus('error'); setAppInfoError(error.message || 'Impossibile caricare la versione'); return; }
+      if (error) { setAppInfoStatus('error'); setAppInfoError('Impossibile caricare la versione'); return; }
       setAppInfo({
         version: typeof data?.version === 'string' ? data.version : '0.0.5',
         repo: typeof data?.repo === 'string' ? data.repo : null,


### PR DESCRIPTION
## Summary
- Replaces `error.message || 'Impossibile caricare la versione'` with always `'Impossibile caricare la versione'`
- Prevents raw English Supabase/network error text from leaking to the user when `error.message` is truthy

## Test plan
- [ ] Simulate a Supabase `app-version` function error (e.g., network down or misconfigured URL)
- [ ] Confirm the displayed error is the Italian generic message, not a raw English string

Closes #827