### PR TITLE
fix(mobile): prevent double onLogout call on voluntary signOut

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -144,12 +144,17 @@ export function useAuth(
             try {
                 isVoluntaryLogoutRef.current = true;
                 await supabase.auth.signOut();
+                // onLogout() will be called by the SIGNED_OUT listener;
+                // do NOT call it here to avoid the double-fire.
             } catch {
-                // signOut failure must not block local logout
+                // signOut failure must not block local logout.
                 isVoluntaryLogoutRef.current = false;
+                onLogout();
             }
+        } else {
+            // Demo mode / no Supabase: no auth listener fires, call directly.
+            onLogout();
         }
-        onLogout();
     }, [onLogout]);
 
     const profileNameRef = useRef(profile.name);


### PR DESCRIPTION
## Summary
- `handleLogoutAction` was calling `onLogout()` directly after `supabase.auth.signOut()`, AND the `SIGNED_OUT` auth listener was also calling it — resulting in double invocation per logout
- Fix: remove the direct `onLogout()` call after a successful `signOut()`; let the `SIGNED_OUT` listener be the sole caller
- `onLogout()` is still called directly in the catch path (signOut threw) and in demo mode (no Supabase, no listener fires)

## Test plan
- [ ] Trigger voluntary logout — confirm `onLogout` fires exactly once (navigation happens once, no flicker)
- [ ] Simulate `signOut()` throwing — confirm local logout still proceeds via the catch path
- [ ] Confirm involuntary session expiry still shows the "Sessione scaduta" error and logs out

Closes #831