### PR TITLE
fix(mobile): catch unhandled promise rejections in ticker and promotion hooks

### DIFF
--- a/apps/mobile/src/hooks/useAtclNewsTicker.ts
+++ b/apps/mobile/src/hooks/useAtclNewsTicker.ts
@@ -15,6 +15,8 @@ export function useAtclNewsTicker(limit = 20) {
     void getAtclNewsTickerItemsSmart(normalizedLimit).then((nextItems) => {
       if (!active) return;
       setItems(nextItems);
+    }).catch((err) => {
+      if (import.meta.env.DEV) console.warn('[useAtclNewsTicker] fetch error:', err);
     });
 
     return () => {

--- a/apps/mobile/src/hooks/useAtclPromotion.ts
+++ b/apps/mobile/src/hooks/useAtclPromotion.ts
@@ -15,6 +15,8 @@ export function useAtclPromotion(slot: AtclPromotionSlot) {
     void getAtclPromotionBySlotSmart(slot).then((value) => {
       if (!active) return;
       setPromotion(value);
+    }).catch((err) => {
+      if (import.meta.env.DEV) console.warn('[useAtclPromotion] fetch error:', err);
     });
 
     return () => {


### PR DESCRIPTION
## Summary
- Both `useAtclNewsTicker` and `useAtclPromotion` fired `void promise.then(...)` with no `.catch`, causing unhandled rejections on network errors or Supabase failures
- Added `.catch((err) => { if (import.meta.env.DEV) console.warn(...) })` to each chain
- The UI already falls back to local data on mount, so no user-visible change; rejections are now silently absorbed and logged only in dev mode

## Test plan
- [ ] Simulate a network failure while the ticker/promotion hooks are active
- [ ] Confirm no `Uncaught (in promise)` error appears in the console (production) or dev overlay
- [ ] In dev mode, confirm the `console.warn` message appears with the error details

Closes #832