### PR TITLE
fix(mobile): catch synchronous throws from supabase.functions.invoke in useAppInfo

### DIFF
--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -404,17 +404,25 @@ function useAppInfo() {
         setAppInfoStatus('idle');
         return;
       }
-      const { data, error } = await supabase.functions.invoke('app-version', { body: { limit: 8 } });
-      if (!mounted) return;
-      if (error) { setAppInfoStatus('error'); setAppInfoError('Impossibile caricare la versione'); return; }
-      setAppInfo({
-        version: typeof data?.version === 'string' ? data.version : '0.0.5',
-        repo: typeof data?.repo === 'string' ? data.repo : null,
-        changelog: Array.isArray(data?.changelog) ? data.changelog : [],
-      });
-      setAppInfoStatus('idle');
+      try {
+        const { data, error } = await supabase.functions.invoke('app-version', { body: { limit: 8 } });
+        if (!mounted) return;
+        if (error) { setAppInfoStatus('error'); setAppInfoError('Impossibile caricare la versione'); return; }
+        setAppInfo({
+          version: typeof data?.version === 'string' ? data.version : '0.0.5',
+          repo: typeof data?.repo === 'string' ? data.repo : null,
+          changelog: Array.isArray(data?.changelog) ? data.changelog : [],
+        });
+        setAppInfoStatus('idle');
+      } catch {
+        if (!mounted) return;
+        setAppInfoStatus('error');
+        setAppInfoError('Impossibile caricare la versione');
+      }
     };
-    load();
+    load().catch(() => {
+      if (mounted) { setAppInfoStatus('error'); setAppInfoError('Impossibile caricare la versione'); }
+    });
     return () => { mounted = false; };
   }, []);
 


### PR DESCRIPTION
## Summary
- `supabase.functions.invoke` can throw synchronously (DNS error, offline, CORS preflight rejection) even though it normally returns `{data, error}`
- Such throws rejected the fire-and-forgotten `load()` promise, leaving `appInfoStatus` stuck at `'loading'` forever with an infinite spinner
- Fix: wrap the `invoke` call in `try/catch` inside `load()` so all error paths set `appInfoStatus='error'` and the Italian fallback message
- Added defence-in-depth `.catch()` on the `load()` call to handle any future escape paths

## Test plan
- [ ] Disable network and open AccountSettings — confirm the spinner stops and the Italian error message appears
- [ ] Restore network — confirm the version loads normally

Closes #834