### PR TITLE
fix(mobile): guard against null session/user in handleLogin

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -90,6 +90,12 @@ export function useAuth(
             return;
         }
 
+        if (!data.session || !data.user) {
+            // No session returned — email confirmation may still be pending.
+            setAuthError('Controlla la tua email per confermare l\'account prima di accedere.');
+            return;
+        }
+
         const displayName = resolveDisplayName({
             name: data.user?.user_metadata?.name,
             metadata: data.user?.user_metadata,


### PR DESCRIPTION
## Summary
- `handleLogin` called `onAuthChange('home')` unconditionally after a non-error `signInWithPassword` response, even when `data.session` / `data.user` is null (e.g. email confirmation still pending)
- Fix: check `data.session && data.user` before navigating; show an Italian message to check email if either is absent

## Test plan
- [ ] Sign in with an unconfirmed email — confirm the error message appears and no navigation occurs
- [ ] Sign in normally — confirm navigation to home still works

Closes #839