### PR TITLE
fix(mobile): handle unconfirmed email and duplicate signup in handleSignup

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -124,6 +124,20 @@ export function useAuth(
             return;
         }
 
+        // When email confirmation is required, data.session is null — the user
+        // has not signed in yet. Show a "check your email" message and stop.
+        if (!data.session) {
+            setAuthError('Registrazione quasi completata! Controlla la tua email per confermare l\'account.');
+            return;
+        }
+
+        // Supabase returns identities: [] when the email is already registered
+        // (deliberate enumeration protection). Treat as a generic credentials error.
+        if (!data.user?.identities?.length) {
+            setAuthError(GENERIC_CREDENTIALS_ERROR);
+            return;
+        }
+
         const displayName = resolveDisplayName({
             name: data.user?.user_metadata?.name ?? name,
             metadata: data.user?.user_metadata,


### PR DESCRIPTION
## Summary
- `handleSignup` always called `onAuthChange('welcome')` on a non-error response, even when `data.session` is null (email confirmation required) or `data.user.identities` is empty (already-registered email, Supabase enumeration protection)
- Fix: check `data.session` first — if absent, show an Italian "check your email" message; check `data.user.identities.length` — if empty, show `GENERIC_CREDENTIALS_ERROR`
- Only proceeds to role-selection when a real session and non-empty identities are present

## Test plan
- [ ] Sign up with an email requiring confirmation — confirm the "check your email" message appears, no navigation
- [ ] Sign up with an already-registered email — confirm a generic credentials error appears
- [ ] Normal new signup — confirm navigation to role-selection still works

Closes #840