### PR TITLE
fix(mobile): suppress unhandled rejection from refreshAll in usePermissions

### DIFF
--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -452,7 +452,7 @@ function usePermissions() {
     setPermissionStatuses({ notifications, camera, geolocation });
   }, []);
 
-  useEffect(() => { refreshAll(); }, [refreshAll]);
+  useEffect(() => { void refreshAll().catch(() => {}); }, [refreshAll]);
 
   const handlePermissionRequest = useCallback(async (key: PermissionKey) => {
     setPermissionMessages(p => ({ ...p, [key]: null }));


### PR DESCRIPTION
## Summary
- `useEffect(() => { refreshAll(); }, [refreshAll])` invoked an async function without `void` or `.catch`, so any unexpected rejection produced an unhandled promise rejection that could trigger the global error overlay
- Fix: `void refreshAll().catch(() => {})` — rejections are silently absorbed; the UI already handles unsupported/default states inside `refreshAll` itself

## Test plan
- [ ] Open AccountSettings — confirm no error overlay appears
- [ ] Simulate `navigator.permissions.query` throwing — confirm no unhandled rejection fires

Closes #841