### PR TITLE
fix(mobile): add default title/message to initErrorHandler critical error reports

### DIFF
--- a/apps/mobile/src/services/error-handler.ts
+++ b/apps/mobile/src/services/error-handler.ts
@@ -57,12 +57,16 @@ export function initErrorHandler() {
 
   window.addEventListener('error', (event) => {
     reportCriticalError({
+      title: 'Errore imprevisto',
+      message: 'L\'app ha rilevato un problema. Ricarica la pagina o riprova più tardi.',
       details: normalizeDetails(event.error ?? event.message),
     });
   });
 
   window.addEventListener('unhandledrejection', (event) => {
     reportCriticalError({
+      title: 'Errore imprevisto',
+      message: 'L\'app ha rilevato un problema. Ricarica la pagina o riprova più tardi.',
       details: normalizeDetails(event.reason),
     });
   });


### PR DESCRIPTION
## Summary
- `initErrorHandler` dispatched `reportCriticalError({ details: ... })` with no `title` or `message`, causing the ErrorOverlay to render a blank header and body for every script error or unhandled rejection
- Fix: add Italian defaults `title: 'Errore imprevisto'` and `message: 'L\'app ha rilevato un problema...'` to both the `error` and `unhandledrejection` listeners

## Test plan
- [ ] Trigger an unhandled rejection (e.g. call a failing async without catch) — confirm the overlay shows the Italian title and message plus the error details
- [ ] Confirm the `details` field still shows the specific error string for debugging

Closes #842