### PR TITLE
fix(mobile): reject activation when remote response omits event_id

### DIFF
--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -506,15 +506,21 @@ export async function activateTicketHash(
 
     if (remote?.ok) {
       const currentRecord = localActivationStore.get(normalizedHash);
+      const resolvedEventId = remote.eventId || currentRecord?.eventId || null;
+      if (!resolvedEventId) {
+        // Server confirmed activation but omitted event_id — storing an empty
+        // eventId would create un-reconcilable ghost records downstream.
+        return { ok: false, error: 'Risposta server incompleta: evento non identificato.' };
+      }
       localActivationStore.set(normalizedHash, {
         hash: normalizedHash,
-        eventId: remote.eventId ?? currentRecord?.eventId ?? '',
+        eventId: resolvedEventId,
         ticketNumber: currentRecord?.ticketNumber ?? 'N/A',
         status: 'activated',
         activatedBy: normalizedUserId,
         activatedAtIso: new Date().toISOString(),
       });
-      return { ok: true, eventId: remote.eventId, event: remote.event };
+      return { ok: true, eventId: resolvedEventId, event: remote.event };
     }
 
     if (remote?.alreadyActivated) {


### PR DESCRIPTION
## Summary
- When the remote activation endpoint returned `ok` without an `event_id`, the code fell back to `eventId: ''` in the local store and passed it to `registerTurn`, creating ghost rows with no real event
- Fix: resolve `eventId` from remote first, then local cache; if both are absent/falsy, return `{ ok: false, error: '...' }` instead of storing the empty string
- Return value's `eventId` is now the resolved non-empty value instead of the raw `remote.eventId` which could be undefined

## Test plan
- [ ] Simulate remote response `{ ok: true }` with no `event_id` — confirm activation returns an error and nothing is stored in local cache
- [ ] Normal activation with valid `event_id` — confirm nothing changes in the happy path

Closes #843