### PR TITLE
fix(mobile): replace raw error.message with Italian fallback in ChangePassword submit

### DIFF
--- a/apps/mobile/src/components/screens/ChangePassword.tsx
+++ b/apps/mobile/src/components/screens/ChangePassword.tsx
@@ -84,8 +84,8 @@ export function ChangePassword({
         onBack();
       }, 1500);
       return;
-    } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : 'Errore sconosciuto');
+    } catch {
+      setErrorMessage('Impossibile aggiornare la password. Riprova più tardi.');
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
## Summary
- The submit handler catch block in `ChangePassword.tsx` displayed `error.message` verbatim, leaking English Supabase strings (e.g. "New password should be different from the old password") to Italian-language users
- Fix: replace with a fixed Italian string `'Impossibile aggiornare la password. Riprova più tardi.'` and drop the unused `error` binding, consistent with the `translateAuthError` policy used in login/signup/reset flows

## Test plan
- [ ] Trigger a password update failure (e.g. same password as current, or session missing) — confirm the Italian message appears instead of raw English text
- [ ] Successful password change — confirm no regression in the success/back flow

Closes #849