### PR TITLE
Add GitHub App configuration for AI support feature

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -33,12 +33,20 @@ services:
     sync: false
   - key: AI_SUPPORT_ALLOWED_ORIGINS
     value: https://turni-di-palco-fq85.onrender.com,https://turni-di-palco-fq85.onrender.com/mobile,https://turni-di-palco.vercel.app
+  - key: AI_SUPPORT_GH_REPO
+    value: ATCL-Lazio/Turni-di-Palco
+  - key: GITHUB_APP_ID
+    sync: false
+  - key: GITHUB_APP_INSTALLATION_ID
+    sync: false
+  - key: GITHUB_APP_PRIVATE_KEY
+    sync: false
   - key: GROQ_API_KEY
     sync: false
   - key: GROQ_MODEL
     value: llama-3.3-70b-versatile
   region: frankfurt
-  buildCommand: npm ci && npm install -g gh
+  buildCommand: npm ci
   startCommand: npm run ai:support
   autoDeployTrigger: commit
   previews:


### PR DESCRIPTION
## Summary
This PR adds GitHub App integration configuration to the AI support service and simplifies the build process by removing the unnecessary global installation of the GitHub CLI.

## Key Changes
- Added `AI_SUPPORT_GH_REPO` environment variable pointing to the GitHub repository (ATCL-Lazio/Turni-di-Palco)
- Added three new GitHub App authentication environment variables:
  - `GITHUB_APP_ID`
  - `GITHUB_APP_INSTALLATION_ID`
  - `GITHUB_APP_PRIVATE_KEY`
  - All marked with `sync: false` to prevent accidental exposure in version control
- Removed `npm install -g gh` from the build command, simplifying the build process to just `npm ci`

## Implementation Details
The GitHub App credentials are configured as environment variables without syncing to version control, ensuring sensitive authentication data remains secure. The removal of the global `gh` CLI installation suggests the application now handles GitHub interactions through the GitHub App API directly rather than relying on the CLI tool.

https://claude.ai/code/session_01WFSHjJTgvC5p4frcM26j77