### PR TITLE
fix: guard non-string payload.circuit/eventID in ticket-activation

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -204,10 +204,16 @@ serve(async (req: Request) => {
           .select('hash, event_id, ticket_number')
           .eq('ticket_number', payload.ticketNumber);
 
-        if (payload.circuit) {
+        if (payload.circuit !== undefined && payload.circuit !== null && payload.circuit !== '') {
+          if (typeof payload.circuit !== 'string') {
+            return jsonResponse({ error: 'Parametro circuit non valido.' }, 400);
+          }
           query = query.ilike('circuit', payload.circuit.trim());
         }
-        if (payload.eventID) {
+        if (payload.eventID !== undefined && payload.eventID !== null && payload.eventID !== '') {
+          if (typeof payload.eventID !== 'string') {
+            return jsonResponse({ error: 'Parametro eventID non valido.' }, 400);
+          }
           query = query.eq('event_id', payload.eventID.trim());
         }
 


### PR DESCRIPTION
Closes #852

## Problem
In `supabase/functions/ticket-activation/index.ts` (action `activate_by_ticket_number`), `payload.circuit` and `payload.eventID` were accessed without type guards. A non-string truthy value (number, boolean, object) would cause `.trim()` to throw, which the outer try/catch masked as a generic 500 `Activation failed`.

## Fix
Added `typeof === 'string'` guards before calling `.trim()`. Non-string values now return a clean 400 with a descriptive error instead of a misleading 500.

## Testing
- Posting `{ action: 'activate_by_ticket_number', payload: { ticketNumber: '123', circuit: 42 } }` now returns 400 with `Parametro circuit non valido.`
- String payloads continue to work as before.