### PR TITLE
fix(mobile): catch watchdog rejection in useSupportStatus effect

### DIFF
--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -546,8 +546,12 @@ function useSupportStatus(showAiSupport: boolean) {
     let mounted = true;
     const check = async () => {
       if (!showAiSupport) { if (mounted) setStatus('unavailable'); return; }
-      const result = await checkAiSupportAvailability();
-      if (mounted) setStatus(result);
+      try {
+        const result = await checkAiSupportAvailability();
+        if (mounted) setStatus(result);
+      } catch {
+        if (mounted) setStatus('unavailable');
+      }
     };
     check();
     return () => { mounted = false; };


### PR DESCRIPTION
Closes #853

## Problem
In `apps/mobile/src/components/screens/AccountSettings.tsx` the `useSupportStatus` effect called `check()` without a `.catch()`. Since `checkAiSupportAvailability` is wrapped in `withMobileWatchdog` (which rejects with `WatchdogTimeoutError` on timeout), any timeout bubbled up as an unhandled promise rejection, tripping `initErrorHandler` and surfacing a false-positive critical-error banner on slow/flaky networks.

## Fix
Wrapped the awaited call in `try/catch` inside `check` and set status to `'unavailable'` on any error (including watchdog timeouts). This matches the graceful fallback expected for the AI-support probe.

## Testing
- On timeout, status now falls back to `'unavailable'` instead of triggering an unhandled rejection.
- Normal success path (resolved result) unchanged.