### PR TITLE
fix(mobile): catch WatchdogTimeoutError in useSupportStatus check()

### DIFF
--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -546,10 +546,14 @@ function useSupportStatus(showAiSupport: boolean) {
     let mounted = true;
     const check = async () => {
       if (!showAiSupport) { if (mounted) setStatus('unavailable'); return; }
-      const result = await checkAiSupportAvailability();
-      if (mounted) setStatus(result);
+      try {
+        const result = await checkAiSupportAvailability();
+        if (mounted) setStatus(result);
+      } catch {
+        if (mounted) setStatus('unavailable');
+      }
     };
-    check();
+    void check();
     return () => { mounted = false; };
   }, [showAiSupport]);
 


### PR DESCRIPTION
## Summary
- `check()` in `useSupportStatus` was called without `void` or `.catch`; a `WatchdogTimeoutError` (or any rejection from `checkAiSupportAvailability`) became an unhandled promise rejection, tripping `initErrorHandler` and showing a false-positive critical-error banner on flaky/offline networks
- Fix: wrap the `await checkAiSupportAvailability()` call in `try/catch`, falling back to `setStatus('unavailable')` on any error; also add `void` to the `check()` invocation

## Test plan
- [ ] Simulate a slow/timed-out network when opening AccountSettings — confirm no critical-error banner appears and status falls back to unavailable
- [ ] Normal online scenario — confirm support status still resolves correctly

Closes #853