### PR TITLE
fix: handle getSession rejection in useAuth

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -230,7 +230,7 @@ export function useAuth(
                     navigateTo: 'home',
                 });
             }
-        });
+        }).catch(() => undefined);
 
         const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
             if (!mounted) return;


### PR DESCRIPTION
Closes #857

Adds a .catch(() => undefined) to supabase.auth.getSession() in useAuth so promise rejections (network failures, corrupted storage, aborted token refresh) no longer surface as 'Errore imprevisto' critical-error overlays on app mount. Mirrors the defensive behavior of the sibling onAuthStateChange handler.