### PR TITLE
fix: openEventsMap uses window.open for PWA safety

### DIFF
--- a/apps/mobile/src/lib/navigation-utils.ts
+++ b/apps/mobile/src/lib/navigation-utils.ts
@@ -23,5 +23,5 @@ export function openEventsMap(theatres: string[]) {
     // Omit origin so Google Maps defaults to the device's current location.
     // Passing 'My Location' as a literal string causes geocoding failures.
     const url = `https://www.google.com/maps/dir/?api=1&destination=${destination}${waypoints ? `&waypoints=${waypoints}` : ''}`;
-    window.location.href = url;
+    window.open(url, '_blank', 'noopener');
 }


### PR DESCRIPTION
Closes #858

Switches openEventsMap from 'window.location.href =' to window.open(url, '_blank', 'noopener'), matching the sibling openInMaps helper. Prevents the installed PWA from being replaced by Google Maps when users tap 'Mappa' in ATCLTurns, preserving session/UI state.