### PR TITLE
fix(edge): replace raw error.message with generic message in public-leaderboard

### DIFF
--- a/supabase/functions/public-leaderboard/index.ts
+++ b/supabase/functions/public-leaderboard/index.ts
@@ -95,7 +95,8 @@ serve(async (req) => {
   const { data, error } = await supabase.rpc('get_public_leaderboard', { p_limit: limit });
 
   if (error) {
-    return json({ error: error.message }, 500);
+    console.error('[public-leaderboard] RPC error:', error.message);
+    return json({ error: 'Errore durante il recupero della classifica.' }, 500);
   }
 
   const rows = (data ?? []) as LeaderboardRow[];


### PR DESCRIPTION
## Summary
- `public-leaderboard` returned `error.message` verbatim on RPC failure, potentially exposing Postgres/RLS schema names, column names, or policy details to unauthenticated callers on a public endpoint
- Fix: log the raw error server-side via `console.error` for observability, and return a generic Italian string `'Errore durante il recupero della classifica.'` to the client
- Mirrors the same pattern applied to `cleanup-events`, `mobile-logs`, `import-spazio-rossellini`, and `ticket-activation`

## Test plan
- [ ] Trigger an RPC failure (e.g. drop the function temporarily) — confirm the response body contains the generic Italian message, not raw DB error text
- [ ] Confirm the raw error still appears in Supabase edge function logs

Closes #859