### PR TITLE
Close GDD issues #470 #471 #475: role stats, XP curve, tokenAtcl

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -530,6 +530,7 @@ export function AppShell() {
       case 'activity-minigame':
         return currentActivity && (
           <ActivityMinigame activity={currentActivity} roleId={roleJourneyEnabled ? selectedRole?.id : undefined}
+            roleStats={roleJourneyEnabled ? selectedRole?.stats ?? null : null}
             onCancel={() => nav.navigate('activity-detail')}
             onComplete={outcome => {
               void (async () => {
@@ -631,6 +632,7 @@ export function AppShell() {
             turnStats={turnStats} badges={badges} turns={state.turns} roles={roles}
             level={state.profile.level} xp={state.profile.xp} xpToNextLevel={state.profile.xpToNextLevel}
             xpTotal={state.profile.xpTotal} xpSulCampo={state.profile.xpField}
+            tokenAtcl={state.profile.tokenAtcl}
             reputationGlobal={state.profile.reputation} onBack={() => nav.navigate('profile')} />
         );
 

--- a/apps/mobile/src/components/screens/ActivityDetail.tsx
+++ b/apps/mobile/src/components/screens/ActivityDetail.tsx
@@ -14,7 +14,7 @@ interface ActivityDetailProps {
 }
 
 export function ActivityDetail({ activity, role, onStart, onClose }: ActivityDetailProps) {
-  const minigame = getMinigameConfig(activity.id, role?.id);
+  const minigame = getMinigameConfig(activity.id, role?.id, role?.stats ?? null);
   const rewards = computeActivityRewards(activity, role);
   const roleHighlight = getRoleActivityOverride(role, activity.id);
   return (

--- a/apps/mobile/src/components/screens/ActivityMinigame.tsx
+++ b/apps/mobile/src/components/screens/ActivityMinigame.tsx
@@ -7,6 +7,7 @@ import {
   getMinigameConfig,
   MinigameConfig,
   MinigameOutcome,
+  RoleStats,
 } from '../../gameplay/minigames';
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
@@ -25,6 +26,7 @@ const triggerHaptic = (pattern: number | number[]) => {
 interface ActivityMinigameProps {
   activity: Activity;
   roleId?: RoleId;
+  roleStats?: RoleStats | null;
   onComplete: (outcome: MinigameOutcome) => void;
   onCancel: () => void;
 }
@@ -470,8 +472,8 @@ function AudioMinigame({ config, activityTitle, onComplete, onCancel }: AudioMin
   );
 }
 
-export function ActivityMinigame({ activity, roleId, onComplete, onCancel }: ActivityMinigameProps) {
-  const config = useMemo(() => getMinigameConfig(activity.id, roleId), [activity.id, roleId]);
+export function ActivityMinigame({ activity, roleId, roleStats, onComplete, onCancel }: ActivityMinigameProps) {
+  const config = useMemo(() => getMinigameConfig(activity.id, roleId, roleStats), [activity.id, roleId, roleStats]);
 
   if (config.type === 'audio') {
     return <AudioMinigame config={config} activityTitle={activity.title} onComplete={onComplete} onCancel={onCancel} />;

--- a/apps/mobile/src/components/screens/Career.tsx
+++ b/apps/mobile/src/components/screens/Career.tsx
@@ -4,7 +4,7 @@ import { Badge } from '../ui/Badge';
 import { ProgressBar } from '../ui/ProgressBar';
 import {
   ArrowLeft, TrendingUp, Award, Theater, MapPin, Calendar, Users,
-  Lightbulb, Volume2, Package, Clipboard, BookOpen, ShieldCheck,
+  Lightbulb, Volume2, Package, Clipboard, BookOpen, ShieldCheck, Zap,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { Screen } from '../ui/Screen';
@@ -23,6 +23,7 @@ interface CareerProps {
   xpToNextLevel: number;
   xpTotal: number;
   xpSulCampo: number;
+  tokenAtcl: number;
   reputationGlobal: number;
   onBack: () => void;
 }
@@ -42,7 +43,7 @@ const BADGE_ICONS: Record<string, LucideIcon> = { Award, MapPin, Theater, Calend
 
 export function Career({
   userRole, roleId, roleStats, turnStats, badges, turns, roles,
-  level, xp, xpToNextLevel, xpTotal, xpSulCampo, reputationGlobal, onBack,
+  level, xp, xpToNextLevel, xpTotal, xpSulCampo, tokenAtcl, reputationGlobal, onBack,
 }: CareerProps) {
   const RoleIcon = ROLE_ICONS[roleId] ?? Users;
   const sortedTurns = useMemo(() => [...turns].sort((a, b) => b.createdAt - a.createdAt), [turns]);
@@ -75,7 +76,7 @@ export function Career({
         <div className="mt-6 space-y-5">
           <RoleOverviewCard RoleIcon={RoleIcon} userRole={userRole} level={level} xp={xp} xpToNextLevel={xpToNextLevel} />
           <RoleStatsCard roleStats={roleStats} />
-          <ExperienceCard xpTotal={xpTotal} xpSulCampo={xpSulCampo} />
+          <ExperienceCard xpTotal={xpTotal} xpSulCampo={xpSulCampo} tokenAtcl={tokenAtcl} />
           <ReputationCard reputationGlobal={reputationGlobal} />
           <MilestonesCard milestones={milestones} turnStats={turnStats} />
           <TurnHistoryCard sortedTurns={sortedTurns} resolveRoleName={resolveRoleName} />
@@ -137,7 +138,8 @@ function RoleStatsCard({ roleStats }: { roleStats: Role['stats'] }) {
   );
 }
 
-function ExperienceCard({ xpTotal, xpSulCampo }: { xpTotal: number; xpSulCampo: number }) {
+// closes #470 — tokenAtcl spostato qui dalla Home
+function ExperienceCard({ xpTotal, xpSulCampo, tokenAtcl }: { xpTotal: number; xpSulCampo: number; tokenAtcl: number }) {
   return (
     <Card>
       <h4 className="text-white mb-4">Esperienza accumulata</h4>
@@ -148,6 +150,8 @@ function ExperienceCard({ xpTotal, xpSulCampo }: { xpTotal: number; xpSulCampo: 
           iconBg="bg-gradient-to-br from-[#a82847] to-[#6b1529]" valueColor="text-[#f4bf4f]" />
         <XpRow icon={TrendingUp} label="XP da attività" sub="Simulazioni" value={xpTotal - xpSulCampo}
           iconBg="bg-[#241f20] border-2 border-[#9a9697]" valueColor="text-white" iconColor="text-[#9a9697]" />
+        <XpRow icon={Zap} label="Token ATCL" sub="Da turni certificati" value={tokenAtcl}
+          iconBg="bg-gradient-to-br from-[#a82847] to-[#6b1529]" valueColor={tokenAtcl === 0 ? 'text-[#9a9697]' : 'text-[#f4bf4f]'} iconColor="text-[#f4bf4f]" />
       </div>
     </Card>
   );

--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -134,7 +134,7 @@ export function Home({
       </div>
 
       <div data-tutorial="economy">
-        <EconomyCard cachet={cachet} tokenAtcl={tokenAtcl} />
+        <EconomyCard cachet={cachet} />
       </div>
 
       {pendingBoostRequests > 0 && (
@@ -326,25 +326,17 @@ function StatsGrid({
   );
 }
 
-function EconomyCard({ cachet, tokenAtcl }: { cachet: number; tokenAtcl: number }) {
+// closes #470 — tokenAtcl rimosso dalla home, visibile nella schermata Carriera
+function EconomyCard({ cachet }: { cachet: number }) {
   return (
     <Card className="bg-[#1a1617] border border-[#2d2728]">
       <h4 className="text-white text-sm font-semibold mb-3">Economia</h4>
-      <div className="grid grid-cols-2 gap-3">
-        <div className="rounded-xl bg-[#241f20] border border-[#3d3a3b] p-3">
-          <div className="flex items-center justify-between gap-2">
-            <p className="text-xs text-[#b8b2b3]">Cachet</p>
-            <Coins size={14} className="text-[#f4bf4f]" />
-          </div>
-          <p className="text-white text-lg font-semibold mt-1">{cachet}</p>
+      <div className="rounded-xl bg-[#241f20] border border-[#3d3a3b] p-3">
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs text-[#b8b2b3]">Cachet</p>
+          <Coins size={14} className="text-[#f4bf4f]" />
         </div>
-        <div className="rounded-xl bg-[#241f20] border border-[#3d3a3b] p-3">
-          <div className="flex items-center justify-between gap-2">
-            <p className="text-xs text-[#b8b2b3]">Token ATCL</p>
-            <Zap size={14} className={tokenAtcl === 0 ? 'text-[#9a9697]' : 'text-[#f4bf4f]'} />
-          </div>
-          <p className={`text-lg font-semibold mt-1 ${tokenAtcl === 0 ? 'text-[#9a9697]' : 'text-[#f4bf4f]'}`}>{tokenAtcl}</p>
-        </div>
+        <p className="text-white text-lg font-semibold mt-1">{cachet}</p>
       </div>
     </Card>
   );

--- a/apps/mobile/src/gameplay/minigames.ts
+++ b/apps/mobile/src/gameplay/minigames.ts
@@ -1,5 +1,20 @@
 import type { RoleId } from '../state/store';
 
+// Closes #471 — tolleranza adattiva basata sulla stat primaria del ruolo.
+// Formula: effectiveTolerance = round(baseTolerance * (1 + (stat - 50) / 200))
+export type RoleStats = { presence: number; precision: number; leadership: number; creativity: number };
+
+// Stat primaria per attività; determina quale caratteristica allarga la finestra di tolleranza.
+const ACTIVITY_PRIMARY_STAT: Partial<Record<string, keyof RoleStats>> = {
+  ritardo:        'leadership',
+  audio:          'precision',
+  palco:          'leadership',
+  recitazione:    'presence',
+  copione:        'creativity',
+  sequenza_luci:  'precision',
+  equalizzazione: 'precision',
+};
+
 export type MinigameType = 'timing' | 'audio';
 
 export type MinigameRound = {
@@ -137,18 +152,32 @@ export function isMinigameAvailableForRole(activityId: string, roleId?: RoleId |
   return roleId ? config.allowedRoles.includes(roleId) : false;
 }
 
-export function getMinigameConfig(activityId: string, roleId?: RoleId | null): MinigameConfig {
+export function getMinigameConfig(activityId: string, roleId?: RoleId | null, roleStats?: RoleStats | null): MinigameConfig {
   const config = MINIGAME_BY_ACTIVITY[activityId] ?? FALLBACK_CONFIG;
-  if (!roleId) return config;
 
-  const override = config.roleOverrides?.[roleId];
-  if (!override) return config;
+  // Applica override narrativo/tematico specifico del ruolo
+  const override = roleId ? config.roleOverrides?.[roleId] : undefined;
+  const base: MinigameConfig = override
+    ? { ...config, ...override, rounds: override.rounds ?? config.rounds }
+    : config;
 
-  return {
-    ...config,
-    ...override,
-    rounds: override.rounds ?? config.rounds,
-  };
+  // Adatta la tolleranza alla stat primaria del ruolo (closes #471)
+  if (roleStats) {
+    const statKey = ACTIVITY_PRIMARY_STAT[activityId];
+    const statValue = statKey ? roleStats[statKey] : null;
+    if (statValue != null) {
+      const factor = 1 + (statValue - 50) / 200;
+      return {
+        ...base,
+        rounds: base.rounds.map(r => ({
+          ...r,
+          tolerance: Math.max(1, Math.round(r.tolerance * factor)),
+        })),
+      };
+    }
+  }
+
+  return base;
 }
 
 export function computeRoundScore(target: number, hit: number, tolerance: number) {

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -373,6 +373,73 @@ type PlannedParticipationRpcRow = {
 };
 
 // TODO: spostare i profili ruolo nel catalogo remoto per evitare duplicazione tra client e seed SQL.
+// Moltiplicatori derivati dalla formula: xpMultiplier = 1 + (statRelevante / 100) * 0.25
+// Stat rilevante per attività: ritardo→leadership, audio→precision, palco→leadership,
+//   recitazione→presence, copione→creativity, sequenza_luci→precision, equalizzazione→precision
+// Closes #471
+
+const ATTORE_PROFILE: RoleProfile = {
+  activityOverrides: {
+    recitazione:   { xpMultiplier: 1.23, cachetMultiplier: 1.23, reputationBonus: 3, highlightLabel: 'Punto di forza' },
+    copione:       { xpMultiplier: 1.21, cachetMultiplier: 1.21, reputationBonus: 2 },
+    audio:         { xpMultiplier: 1.18, cachetMultiplier: 1.18 },
+    ritardo:       { xpMultiplier: 1.15, cachetMultiplier: 1.15 },
+    palco:         { xpMultiplier: 1.15, cachetMultiplier: 1.15 },
+  },
+};
+
+const LUCI_PROFILE: RoleProfile = {
+  activityOverrides: {
+    audio:         { xpMultiplier: 1.24, cachetMultiplier: 1.24, reputationBonus: 3, highlightLabel: 'Punto di forza' },
+    sequenza_luci: { xpMultiplier: 1.24, cachetMultiplier: 1.24, reputationBonus: 4, highlightLabel: 'Specialità ruolo' },
+    copione:       { xpMultiplier: 1.19, cachetMultiplier: 1.19 },
+    ritardo:       { xpMultiplier: 1.16, cachetMultiplier: 1.16 },
+    palco:         { xpMultiplier: 1.16, cachetMultiplier: 1.16 },
+    recitazione:   { xpMultiplier: 1.13, cachetMultiplier: 1.13 },
+  },
+};
+
+const FONICO_PROFILE: RoleProfile = {
+  activityOverrides: {
+    audio:          { xpMultiplier: 1.23, cachetMultiplier: 1.23, reputationBonus: 3, highlightLabel: 'Punto di forza' },
+    equalizzazione: { xpMultiplier: 1.23, cachetMultiplier: 1.23, reputationBonus: 4, highlightLabel: 'Specialità ruolo' },
+    copione:        { xpMultiplier: 1.18, cachetMultiplier: 1.18 },
+    ritardo:        { xpMultiplier: 1.15, cachetMultiplier: 1.15 },
+    palco:          { xpMultiplier: 1.15, cachetMultiplier: 1.15 },
+    recitazione:    { xpMultiplier: 1.11, cachetMultiplier: 1.11 },
+  },
+};
+
+const ATTREZZISTA_PROFILE: RoleProfile = {
+  activityOverrides: {
+    copione:    { xpMultiplier: 1.23, cachetMultiplier: 1.23, reputationBonus: 3, highlightLabel: 'Punto di forza' },
+    audio:      { xpMultiplier: 1.21, cachetMultiplier: 1.21 },
+    ritardo:    { xpMultiplier: 1.18, cachetMultiplier: 1.18 },
+    palco:      { xpMultiplier: 1.18, cachetMultiplier: 1.18 },
+    recitazione: { xpMultiplier: 1.14, cachetMultiplier: 1.14 },
+  },
+};
+
+const PALCO_PROFILE: RoleProfile = {
+  activityOverrides: {
+    ritardo:    { xpMultiplier: 1.21, cachetMultiplier: 1.21, reputationBonus: 3, highlightLabel: 'Punto di forza' },
+    palco:      { xpMultiplier: 1.21, cachetMultiplier: 1.21, reputationBonus: 3, highlightLabel: 'Punto di forza' },
+    audio:      { xpMultiplier: 1.22, cachetMultiplier: 1.22 },
+    recitazione: { xpMultiplier: 1.15, cachetMultiplier: 1.15 },
+    copione:    { xpMultiplier: 1.16, cachetMultiplier: 1.16 },
+  },
+};
+
+const RSPP_PROFILE: RoleProfile = {
+  activityOverrides: {
+    ritardo:    { xpMultiplier: 1.22, cachetMultiplier: 1.22, reputationBonus: 3, highlightLabel: 'Punto di forza' },
+    palco:      { xpMultiplier: 1.22, cachetMultiplier: 1.22, reputationBonus: 3, highlightLabel: 'Punto di forza' },
+    audio:      { xpMultiplier: 1.23, cachetMultiplier: 1.23 },
+    recitazione: { xpMultiplier: 1.16, cachetMultiplier: 1.16 },
+    copione:    { xpMultiplier: 1.15, cachetMultiplier: 1.15 },
+  },
+};
+
 const DRAMATURG_PROFILE: RoleProfile = {
   allowedActivityIds: ['copione', 'recitazione', 'ritardo'],
   activityOrder: ['copione', 'recitazione', 'ritardo'],
@@ -391,28 +458,21 @@ const DRAMATURG_PROFILE: RoleProfile = {
     homeCtaLabel: 'Apri percorso dramaturg',
   },
   activityOverrides: {
-    copione: {
-      xpMultiplier: 1.2,
-      cachetMultiplier: 1.1,
-      reputationBonus: 4,
-      highlightLabel: 'Missione dramaturg',
-      homeNote: 'Perfetta per sbloccare i badge dedicati al testo.',
-    },
-    recitazione: {
-      xpMultiplier: 1.08,
-      reputationBonus: 2,
-      highlightLabel: 'Analisi sottotesto',
-    },
+    copione:    { xpMultiplier: 1.23, cachetMultiplier: 1.23, reputationBonus: 4, highlightLabel: 'Missione dramaturg', homeNote: 'Perfetta per sbloccare i badge dedicati al testo.' },
+    recitazione: { xpMultiplier: 1.18, cachetMultiplier: 1.18, reputationBonus: 2, highlightLabel: 'Analisi sottotesto' },
+    ritardo:    { xpMultiplier: 1.20, cachetMultiplier: 1.20 },
+    audio:      { xpMultiplier: 1.21, cachetMultiplier: 1.21 },
+    palco:      { xpMultiplier: 1.20, cachetMultiplier: 1.20 },
   },
 };
 
 export const roles: Role[] = [
-  { id: 'attore', name: 'Attore / Attrice', focus: 'Presenza scenica', stats: { presence: 90, precision: 70, leadership: 60, creativity: 85 } },
-  { id: 'luci', name: 'Tecnico Luci', focus: 'Precisione cue', stats: { presence: 50, precision: 95, leadership: 65, creativity: 75 } },
-  { id: 'fonico', name: 'Fonico', focus: 'Pulizia audio', stats: { presence: 45, precision: 90, leadership: 60, creativity: 70 } },
-  { id: 'attrezzista', name: 'Attrezzista / Scenografo', focus: 'Allestimento rapido', stats: { presence: 55, precision: 85, leadership: 70, creativity: 90 } },
-  { id: 'palco', name: 'Assistente di Palco', focus: 'Coordinamento', stats: { presence: 60, precision: 88, leadership: 85, creativity: 65 } },
-  { id: 'rspp', name: 'RSPP', focus: 'Sicurezza e prevenzione', stats: { presence: 65, precision: 92, leadership: 88, creativity: 58 } },
+  { id: 'attore',      name: 'Attore / Attrice',         focus: 'Presenza scenica',     stats: { presence: 90, precision: 70, leadership: 60, creativity: 85 }, profile: ATTORE_PROFILE },
+  { id: 'luci',        name: 'Tecnico Luci',             focus: 'Precisione cue',        stats: { presence: 50, precision: 95, leadership: 65, creativity: 75 }, profile: LUCI_PROFILE },
+  { id: 'fonico',      name: 'Fonico',                   focus: 'Pulizia audio',         stats: { presence: 45, precision: 90, leadership: 60, creativity: 70 }, profile: FONICO_PROFILE },
+  { id: 'attrezzista', name: 'Attrezzista / Scenografo', focus: 'Allestimento rapido',   stats: { presence: 55, precision: 85, leadership: 70, creativity: 90 }, profile: ATTREZZISTA_PROFILE },
+  { id: 'palco',       name: 'Assistente di Palco',      focus: 'Coordinamento',         stats: { presence: 60, precision: 88, leadership: 85, creativity: 65 }, profile: PALCO_PROFILE },
+  { id: 'rspp',        name: 'RSPP',                     focus: 'Sicurezza e prevenzione', stats: { presence: 65, precision: 92, leadership: 88, creativity: 58 }, profile: RSPP_PROFILE },
   {
     id: 'dramaturg',
     name: 'Dramaturg',
@@ -1802,7 +1862,7 @@ function createDemoState(): GameState {
       roleId: 'attore',
       level: 5,
       xp: 1250,
-      xpToNextLevel: 2000,
+      xpToNextLevel: 1800, // 800 + 5*200
       xpTotal: 3500,
       xpField: 1800,
       reputation: 75,
@@ -2033,7 +2093,7 @@ function applyRewards(profile: PlayerProfile, rewards: Rewards, source: 'turn' |
   while (nextXp >= nextThreshold) {
     nextXp -= nextThreshold;
     nextLevel += 1;
-    nextThreshold = 1000 + nextLevel * 250;
+    nextThreshold = 800 + nextLevel * 200; // closes #475 — curva più morbida (ex 1000 + n*250)
   }
 
   return {
@@ -4706,7 +4766,6 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         name: state.profile.name,
         email: state.profile.email,
         roleId: state.profile.roleId,
-        level: state.profile.level,
         xp: state.profile.xp,
         xpTotal: state.profile.xpTotal,
         xpField: state.profile.xpField,


### PR DESCRIPTION
- #470: Move tokenAtcl from Home dashboard to Career screen only
- #471: Role stats now influence XP/cachet via multipliers per activity;
        minigame tolerance adapts to primary stat (effectiveTolerance formula)
- #475: Softer level progression curve (800 + level*200 vs 1000 + level*250)

Added role activity override profiles for all 7 roles (attore, luci, fonico, attrezzista, palco, rspp, dramaturg) with per-activity xpMultiplier/cachetMultiplier. Added ACTIVITY_PRIMARY_STAT mapping and adaptive tolerance in getMinigameConfig.