### PR TITLE
Fix Maxwell production chat endpoint and watchdog target

### DIFF
--- a/apps/mobile/.env.production
+++ b/apps/mobile/.env.production
@@ -1,0 +1,2 @@
+VITE_AI_SUPPORT_ENDPOINT=https://maxwell-ai-support.onrender.com/api/ai/chat
+VITE_AI_SUPPORT_ISSUE_ENDPOINT=https://maxwell-ai-support.onrender.com/api/ai/issue

--- a/apps/mobile/src/services/ai.ts
+++ b/apps/mobile/src/services/ai.ts
@@ -56,7 +56,7 @@ const SUPPORT_PROMPT =
   "Non citare il marker o il JSON nel testo per l'utente: lascia la spiegazione sopra al marker. " +
   "Non ripetere il saluto iniziale se e' gia' presente nella chat.";
 
-const FALLBACK_PORT = String.fromCharCode(56, 55, 56, 55);
+const FALLBACK_PORT = '8787';
 const DEFAULT_PORT = import.meta.env.VITE_AI_SUPPORT_PORT ?? FALLBACK_PORT;
 const DEFAULT_ENDPOINT =
   import.meta.env.VITE_AI_SUPPORT_ENDPOINT ?? buildDefaultEndpoint('/api/ai/chat');
@@ -81,7 +81,14 @@ function buildDefaultEndpoint(path: string) {
   }
   const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:';
   const host = window.location.hostname || 'localhost';
-  return `${protocol}//${host}:${DEFAULT_PORT}${path}`;
+  // Only append the dev port on loopback hosts. On a deployed origin the
+  // Maxwell server lives on a separate host, and appending :8787 to a
+  // managed-platform domain (e.g. *.onrender.com) makes the request
+  // unreachable. Callers must set VITE_AI_SUPPORT_ENDPOINT in production.
+  if (isLocalHost(host) && DEFAULT_PORT) {
+    return `${protocol}//${host}:${DEFAULT_PORT}${path}`;
+  }
+  return `${protocol}//${host}${path}`;
 }
 
 function normalizeEndpoint(endpoint: string) {

--- a/render.yaml
+++ b/render.yaml
@@ -14,6 +14,10 @@ services:
     sync: false
   - key: VITE_DEV_CONTROL_PLANE_URL
     sync: false
+  - key: VITE_AI_SUPPORT_ENDPOINT
+    value: https://maxwell-ai-support.onrender.com/api/ai/chat
+  - key: VITE_AI_SUPPORT_ISSUE_ENDPOINT
+    value: https://maxwell-ai-support.onrender.com/api/ai/issue
   region: frankfurt
   buildCommand: npm ci && npm run build:mobile
   startCommand: npm --workspace apps/mobile run preview:https -- --host 0.0.0.0 --port $PORT --strictPort --clearScreen false

--- a/tools/maxwell-watchdog.js
+++ b/tools/maxwell-watchdog.js
@@ -8,9 +8,25 @@
 const https = require('https');
 const { spawnSync } = require('child_process');
 
+function resolveWatchdogRepo() {
+  const candidates = [
+    process.env.AI_SUPPORT_GH_REPO,
+    process.env.GITHUB_REPO,
+    process.env.GITHUB_REPO_OWNER && process.env.GITHUB_REPO_NAME
+      ? `${process.env.GITHUB_REPO_OWNER}/${process.env.GITHUB_REPO_NAME}`
+      : null,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  return 'ATCL-Lazio/Turni-di-Palco';
+}
+
 // Configurazione
 const CONFIG = {
-  repo: 'Heartran/Turni-di-Palco',
+  repo: resolveWatchdogRepo(),
   scanInterval: 60 * 60 * 1000, // 1 ora
   maxIssuesPerDay: 5,
   dryRun: process.env.NODE_ENV === 'development',
@@ -39,7 +55,7 @@ function log(level, message, data = null) {
 // GitHub API helper
 class GitHubAPI {
   constructor() {
-    this.token = process.env.GITHUB_TOKEN;
+    this.token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || '';
     this.baseUrl = 'https://api.github.com';
   }
 
@@ -144,8 +160,18 @@ class ProblemDetector {
   async checkRenderPerformance() {
     const problems = [];
     const services = [
-      { name: 'Maxwell-AI-Support', url: 'https://maxwell-ai-support.onrender.com/health' },
-      { name: 'Turni-di-Palco', url: 'https://turni-di-palco-fq85.onrender.com/health' }
+      {
+        name: 'Maxwell-AI-Support',
+        url:
+          process.env.WATCHDOG_SERVICE_MAXWELL_URL ||
+          'https://maxwell-ai-support.onrender.com/health'
+      },
+      {
+        name: 'Turni-di-Palco',
+        url:
+          process.env.WATCHDOG_SERVICE_TURNI_URL ||
+          'https://turni-di-palco-fq85.onrender.com/health'
+      }
     ];
 
     for (const service of services) {


### PR DESCRIPTION
- apps/mobile/src/services/ai.ts: buildDefaultEndpoint no longer appends
  the dev port (8787) to non-loopback hosts. In production the app ran
  on https://<render-host>:8787 which Render never exposes, so chat was
  unreachable whenever VITE_AI_SUPPORT_ENDPOINT was unset. Also replace
  the String.fromCharCode(...) obfuscation with a plain '8787'.
- render.yaml: set VITE_AI_SUPPORT_ENDPOINT and VITE_AI_SUPPORT_ISSUE_ENDPOINT
  on the Turni-di-Palco service so the production build points at the
  Maxwell Render URL.
- tools/maxwell-watchdog.js: stop hardcoding the wrong repo
  (Heartran/Turni-di-Palco) and read AI_SUPPORT_GH_REPO / GITHUB_REPO
  first, falling back to ATCL-Lazio/Turni-di-Palco. Accept GH_TOKEN as
  well as GITHUB_TOKEN. Honour WATCHDOG_SERVICE_{MAXWELL,TURNI}_URL to
  match the env vars already supported by the embedded watchdog.