### PR TITLE
feat(a11y): WCAG 2.2 AA baseline

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -681,6 +681,7 @@ export function AppShell() {
 
   return (
     <div className="min-h-screen app-gradient app-shell">
+      <a href="#main-content" className="skip-link">Salta al contenuto principale</a>
       {!isOnline && (
         <div className="fixed top-0 left-0 right-0 z-[998] bg-[#2a1f14] border-b border-[#f4bf4f]/30 px-4 py-2 text-center text-sm text-[#f4bf4f]">
           Sei offline — le modifiche saranno sincronizzate al ritorno della connessione
@@ -696,7 +697,7 @@ export function AppShell() {
           className="fixed bottom-[calc(env(safe-area-inset-bottom,0px)+72px)] left-4 right-4 z-[999] flex items-center justify-between gap-3 rounded-xl bg-[#2a1f14] border border-[#f4bf4f]/30 px-4 py-3 shadow-lg text-sm text-[#f4bf4f]">
           <span>{infoToast}</span>
           <button type="button" onClick={() => setInfoToast(null)}
-            className="shrink-0 text-[#b8b2b3] hover:text-white text-lg leading-none" aria-label="Chiudi">✕</button>
+            className="shrink-0 inline-flex items-center justify-center size-6 text-[#b8b2b3] hover:text-white text-lg leading-none" aria-label="Chiudi">✕</button>
         </div>
       )}
       <ScreenTransition animationClass={screenAnimation} animationKey={screenAnimationKey}>
@@ -706,7 +707,7 @@ export function AppShell() {
             {renderScreen()}
           </MainLayout>
         ) : (
-          <div className="app-frame">{renderScreen()}</div>
+          <div id="main-content" tabIndex={-1} className="app-frame">{renderScreen()}</div>
         )}
         </Suspense>
       </ScreenTransition>

--- a/apps/mobile/src/components/BottomNav.tsx
+++ b/apps/mobile/src/components/BottomNav.tsx
@@ -33,7 +33,7 @@ export function BottomNav({ activeTab, onTabChange, enabledTabs }: BottomNavProp
   } : undefined;
 
   return (
-    <nav data-tutorial="bottom-nav" role="tablist" className="fixed bottom-0 left-0 right-0 w-full z-50 bg-[#0f0d0e]/90 backdrop-blur-2xl border-t border-white/[0.05]">
+    <nav data-tutorial="bottom-nav" role="tablist" aria-label="Navigazione principale" className="fixed bottom-0 left-0 right-0 w-full z-50 bg-[#0f0d0e]/90 backdrop-blur-2xl border-t border-white/[0.05]">
       <div className="relative app-content flex items-stretch justify-around px-2 pt-1 min-h-[54px]" style={{ paddingBottom: 'calc(4px + env(safe-area-inset-bottom, 0px))' }}>
 
           {indicatorStyle && (

--- a/apps/mobile/src/layouts/MainLayout.tsx
+++ b/apps/mobile/src/layouts/MainLayout.tsx
@@ -12,7 +12,7 @@ interface MainLayoutProps {
 export function MainLayout({ children, activeTab, enabledTabs, onTabChange }: MainLayoutProps) {
   return (
     <>
-      <div className="app-frame">{children}</div>
+      <div id="main-content" tabIndex={-1} className="app-frame">{children}</div>
       <BottomNav activeTab={activeTab} onTabChange={onTabChange} enabledTabs={enabledTabs} />
     </>
   );

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -71,6 +71,9 @@
   html {
     -webkit-text-size-adjust: 100%;
     text-size-adjust: 100%;
+    /* WCAG 2.2 — 2.4.11 Focus Not Obscured (Minimum): keep focused elements
+       clear of the fixed bottom navigation (54px base + safe-area inset). */
+    scroll-padding-bottom: calc(72px + env(safe-area-inset-bottom, 0px));
   }
 
   body {
@@ -176,6 +179,31 @@
   }
 
   :focus-visible {
+    outline: 2px solid var(--color-gold-400);
+    outline-offset: 2px;
+  }
+
+  /* WCAG 2.1 — 2.4.1 Bypass Blocks: skip-link visible only on focus. */
+  .skip-link {
+    position: fixed;
+    top: calc(env(safe-area-inset-top, 0px) + 8px);
+    left: 50%;
+    transform: translate(-50%, -150%);
+    z-index: 1000;
+    padding: 10px 16px;
+    background: var(--color-bg-surface-elevated);
+    color: var(--color-gold-400);
+    border: 2px solid var(--color-gold-400);
+    border-radius: var(--radius-md);
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 150ms ease-out;
+  }
+
+  .skip-link:focus,
+  .skip-link:focus-visible {
+    transform: translate(-50%, 0);
     outline: 2px solid var(--color-gold-400);
     outline-offset: 2px;
   }


### PR DESCRIPTION
## Summary

Reimplementazione pulita dell'accessibilità a partire da `main` dopo la chiusura di #736. Scope stretto: **solo criteri WCAG 2.2 Level AA**, nessun redesign del tema chiaro e nessun rework del toggle "modalità accessibile" (come da discussione con @Heartran).

Refs #476. Supersedes #736 (chiusa, commit preservato via `refs/pull/736/head` @ `a92f3e8` e tag locale `backup/a11y-wcag-v1`).

## Cosa cambia

4 file, +33 / −4:

| WCAG 2.2 | Intervento | File |
|---|---|---|
| **2.4.11 Focus Not Obscured Minimum** (AA, nuovo in 2.2) | `scroll-padding-bottom: calc(72px + env(safe-area-inset-bottom))` su `<html>` → il focus non finisce mai sotto la BottomNav fissa | `shared/styles/main.css` |
| **2.5.8 Target Size Minimum** (AA, nuovo in 2.2) | Close button del info-toast globale portato a 24×24 (`size-6` + `inline-flex`) | `AppShell.tsx` |
| **2.4.1 Bypass Blocks** (A) | Skip-link "Salta al contenuto principale" come primo elemento focusabile; stili off-screen → visibile on focus | `AppShell.tsx`, `main.css` |
| **1.3.1 Info and Relationships** / **4.1.2 Name, Role, Value** (A) | `id="main-content" tabIndex={-1}` sul wrapper screen (sia MainLayout che fallback auth); `aria-label="Navigazione principale"` sul `<nav>` BottomNav | `AppShell.tsx`, `MainLayout.tsx`, `BottomNav.tsx` |

## Criteri 2.2 AA verificati già conformi (nessuna modifica)

- **2.5.7 Dragging Movements** — l'unico componente drag (`Carousel` Embla in `ui/carousel.tsx`) è dead code, 0 usage nel tree `apps/mobile/src`. Nessuna funzionalità live basata su drag (BottomNav = tap, QR = scan camera, form = keyboard).
- **3.2.6 Consistent Help** — il criterio si attiva solo se un help mechanism appare su più pagine. `SupportChat` è raggiungibile unicamente via `Profile → Impostazioni → Supporto AI`: posizione unica, trivially met.
- **3.3.7 Redundant Entry** — tutti i form sono single-step (Login, Signup, ChangePassword). `RoleSelection` è selezione + conferma, non re-entry. `confirmPassword` su Signup è una verifica parallela, non una ri-digitazione del valore.
- **3.3.8 Accessible Authentication Minimum** — niente CAPTCHA, niente puzzle, password rule = solo lunghezza ≥8 (non memorization). `autoComplete="username" / "current-password" / "new-password" / "email" / "name"` già presenti su Login/Signup → il browser può autofillare senza che l'utente debba ricordare.

## Base WCAG 2.1 AA già presente pre-esistente

- `html[lang="it"]` in `apps/mobile/index.html` ✓
- `:focus-visible` con outline gold 2px + offset in `main.css` ✓
- Radix UI (Dialog/Sheet/AlertDialog) gestisce focus trap nativamente ✓
- Tag/Badge sono `<span>` presentazionali, non interattivi → 2.5.8 non applicabile

## Esplicitamente fuori scope

Come concordato, **non** è incluso in questa PR:

- Redesign del tema chiaro (feedback "bright theme not so well-designed")
- Rework del default "accessibility forced on" → vero opt-in
- Refactor componenti custom su pattern ARIA APG (Grid, Combobox, Treegrid)
- Riscrittura ampia sezione a11y secondo guida direttive UE (Legge Stanca / EAA / dichiarazione AgID / RTD / Obiettivi di accessibilità)

Questi sono follow-up naturali per PR dedicate.

## Test

- [x] TypeScript: nessun errore **nuovo** introdotto dal branch (gli errori presenti in `typecheck` sono pre-esistenti: `@types/node` mancante su `vite.config.ts`, implicit `any` in `state/store.tsx`, vitest types mancanti — tutti su `main` prima di questa PR)
- [x] Diff confinato a 4 file, modifiche chirurgiche
- [x] Skip-link testabile manualmente con Tab dal primo focus
- [x] `scroll-padding-bottom` verificabile con Tab dentro liste lunghe (es. Leaderboard, Activities)
- [ ] Verifica manuale con screen reader (NVDA / VoiceOver) — richiesta al maintainer prima del merge
- [ ] Verifica visiva skip-link su deploy preview Vercel

## Storia

Questa PR sostituisce #736, chiusa per:
- `mergeable_state: dirty` dopo accumulo conflitti su main
- feedback maintainer su tema chiaro e "accessibility forced on"
- decisione di allinearsi a WCAG 2.2 (vs 2.1 della PR precedente) in vista di EN 301 549 v4.1.1

Il lavoro originale di #736 resta consultabile al SHA `a92f3e8` (tag locale `backup/a11y-wcag-v1`; il push del tag al remote è stato rifiutato dal repo con 403, ma il commit resta vivo via `refs/pull/736/head`).