### PR TITLE
fix: ATCLTurns event sort with Italian-format dates (#885)

### DIFF
--- a/apps/mobile/src/components/screens/ATCLTurns.tsx
+++ b/apps/mobile/src/components/screens/ATCLTurns.tsx
@@ -3,7 +3,7 @@ import { Card } from '../ui/Card';
 import { Button } from '../ui/Button';
 import { ScanQRCard } from '../ScanQRCard';
 import { QrCode, MapPin, Calendar, TrendingUp, Theater, Map as MapIcon, Award, Pencil, X } from 'lucide-react';
-import { EventPlanning, GameEvent, Role } from '../../state/store';
+import { EventPlanning, GameEvent, parseEventScheduleTimestamp, Role } from '../../state/store';
 import { AtclPromoBanner } from '../AtclPromoBanner';
 import { useAtclPromotion } from '../../hooks/useAtclPromotion';
 import { AtclNewsTicker } from '../AtclNewsTicker';
@@ -49,20 +49,16 @@ export function ATCLTurns({
   }, [events]);
 
   const sortedEvents = useMemo(() => {
-    const now = new Date();
+    const now = Date.now();
     return [...events].sort((a, b) => {
-      const dateA = new Date(`${a.date} ${a.time}`);
-      const dateB = new Date(`${b.date} ${b.time}`);
+      const tsA = parseEventScheduleTimestamp(a);
+      const tsB = parseEventScheduleTimestamp(b);
+      const aFuture = tsA >= now;
+      const bFuture = tsB >= now;
 
-      if (dateA >= now && dateB >= now) {
-        return dateA.getTime() - dateB.getTime();
-      }
-
-      if (dateA < now && dateB < now) {
-        return dateB.getTime() - dateA.getTime();
-      }
-
-      return dateA >= now ? -1 : 1;
+      if (aFuture !== bFuture) return aFuture ? -1 : 1;
+      if (aFuture && bFuture) return tsA - tsB;
+      return tsB - tsA;
     });
   }, [events]);
 

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -1030,7 +1030,7 @@ const ITALIAN_MONTHS: Record<string, string> = {
   lug: '07', ago: '08', set: '09', ott: '10', nov: '11', dic: '12',
 };
 
-function parseEventScheduleTimestamp(event: Pick<GameEvent, 'date' | 'time'>) {
+export function parseEventScheduleTimestamp(event: Pick<GameEvent, 'date' | 'time'>) {
   const parts = event.date.trim().split(/\s+/);
   if (parts.length === 3) {
     const [day, monthStr, year] = parts;


### PR DESCRIPTION
## Summary
- Export `parseEventScheduleTimestamp` from `store.tsx` (it already handles Italian month abbreviations like `Dic`, `Gen`, etc.)
- Replace `new Date(a.date + ' ' + a.time)` in `ATCLTurns.tsx` sort comparator with the exported helper to fix `Invalid Date` for Italian-locale month names

## Test plan
- [ ] Verify events with Italian month dates (e.g. `'15 Dic 2025'`) sort correctly in ATCLTurns screen
- [ ] Confirm future events appear before past events
- [ ] Confirm future events are sorted ascending, past events descending

Closes #885

https://claude.ai/code/session_01ULfFmfFsxxNWevffQEecwf

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULfFmfFsxxNWevffQEecwf)_