### PR TITLE
fix: add .catch to loadCatalog and loadRemoteState calls (#886)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3650,7 +3650,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       );
     };
 
-    loadCatalog();
+    loadCatalog().catch((err: unknown) => console.warn('[store] loader rejected', err));
 
     return () => {
       isMounted = false;
@@ -3774,7 +3774,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       );
     };
 
-    loadRemoteState();
+    loadRemoteState().catch((err: unknown) => console.warn('[store] loader rejected', err));
 
     return () => {
       isMounted = false;


### PR DESCRIPTION
## Summary
- Add `.catch((err: unknown) => console.warn('[store] loader rejected', err))` to `loadCatalog()` call site in `GameStateProvider`
- Same fix for `loadRemoteState()` call site
- Both remain intentional fire-and-forget (no `await` added); rejection is now surfaced via `console.warn` instead of silently becoming an unhandled rejection

## Test plan
- [ ] Confirm no unhandled promise rejection warnings when loadCatalog or loadRemoteState encounter errors
- [ ] Confirm app still loads correctly in normal conditions

Closes #886

https://claude.ai/code/session_01ULfFmfFsxxNWevffQEecwf

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULfFmfFsxxNWevffQEecwf)_