### PR TITLE
fix: await refreshEventPlanning inside loadCatalog watchdog task (#887)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3639,7 +3639,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             events: nextEvents,
             activities: nextActivities,
           });
-          refreshEventPlanning(nextEvents);
+          await refreshEventPlanning(nextEvents);
         },
         {
           operation: 'loadCatalog',


### PR DESCRIPTION
## Summary
- Add `await` before `refreshEventPlanning(nextEvents)` inside the `loadCatalog` watchdog task
- The call is within an `async` function, so `await` is safe and correct
- The outer `withMobileWatchdog` already handles errors from the task, so no additional `.catch` is needed

## Test plan
- [ ] Confirm event planning refreshes correctly after catalog loads
- [ ] Confirm no unhandled promise warnings related to `refreshEventPlanning`

Closes #887

https://claude.ai/code/session_01ULfFmfFsxxNWevffQEecwf

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULfFmfFsxxNWevffQEecwf)_