### PR TITLE
fix: move saveChatHistory out of setState updater in SupportChat (#888)

### DIFF
--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -82,12 +82,10 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
 
   useEffect(() => {
     if (!hasLoadedRef.current || !activeSessionId) return;
-    setChatSessions(prev => {
-      const next = updateSessionList(prev, activeSessionId, messages);
-      saveChatHistory(displayName, next, userId);
-      return next;
-    });
-  }, [messages, activeSessionId, historyId, displayName, userId]);
+    const next = updateSessionList(chatSessions, activeSessionId, messages);
+    setChatSessions(next);
+    saveChatHistory(displayName, next, userId);
+  }, [messages, activeSessionId, chatSessions, historyId, displayName, userId]);
 
   const hasInput = input.trim().length > 0;
   const activeSession = useMemo(


### PR DESCRIPTION
## Summary
- Refactor the `useEffect` in `SupportChat` that persisted chat history
- Previously, `saveChatHistory` (a `localStorage` write) was called inside the `setChatSessions` updater callback — a side effect inside a pure updater, which violates React's rules
- Fix: compute `next` using `chatSessions` from closure, call `setChatSessions(next)` with a plain value, then call `saveChatHistory(displayName, next, userId)` as a separate statement
- Add `chatSessions` to the effect dependency array since it is now read directly

## Test plan
- [ ] Verify chat sessions are still persisted correctly to localStorage after sending messages
- [ ] Verify chat history loads correctly on re-open
- [ ] Confirm no React strict-mode double-invocation issues with localStorage writes

Closes #888

https://claude.ai/code/session_01ULfFmfFsxxNWevffQEecwf

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULfFmfFsxxNWevffQEecwf)_