### PR TITLE
fix: remove spurious state.eventPlans dep from refreshEventPlanning (#889)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -2262,6 +2262,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   const [turnSyncFeedback, setTurnSyncFeedback] = useState<TurnSyncFeedback | null>(null);
   const offlineSyncInFlightRef = useRef(false);
   const offlineServerLogSyncInFlightRef = useRef(false);
+  const eventPlansRef = useRef(state.eventPlans);
+  useEffect(() => { eventPlansRef.current = state.eventPlans; }, [state.eventPlans]);
 
   const syncLocalEventPlanning = useCallback(
     (plans: EventPlanning[]) => {
@@ -3080,7 +3082,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       if (!isSupabaseConfigured || !supabase || !authUserId) {
         setEventPlansLoading(false);
         setFollowedEventsLoading(false);
-        syncLocalEventPlanning(state.eventPlans);
+        syncLocalEventPlanning(eventPlansRef.current);
         return;
       }
       await withMobileWatchdog(
@@ -3148,7 +3150,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         }
       );
     },
-    [authUserId, state.eventPlans, state.profile.roleId, syncLocalEventPlanning]
+    [authUserId, state.profile.roleId, syncLocalEventPlanning]
   );
 
   const refreshShopCatalog = useCallback(async () => {


### PR DESCRIPTION
## Summary
- `refreshEventPlanning` had `state.eventPlans` in its `useCallback` dependency array, causing unnecessary re-creation of the callback whenever event plans changed
- `state.eventPlans` is only needed in the `!supabase || !authUserId` offline path via `syncLocalEventPlanning(state.eventPlans)`
- Fix: introduce `eventPlansRef` (a ref that tracks the latest `state.eventPlans` via a `useEffect`) and use `eventPlansRef.current` inside `refreshEventPlanning` instead of `state.eventPlans`
- Remove `state.eventPlans` from the `useCallback` dependency array

## Test plan
- [ ] Verify event planning still loads correctly when online (Supabase path)
- [ ] Verify event planning falls back to local plans when offline / unauthenticated
- [ ] Confirm `refreshEventPlanning` is not recreated on every `eventPlans` state update

Closes #889

https://claude.ai/code/session_01ULfFmfFsxxNWevffQEecwf

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULfFmfFsxxNWevffQEecwf)_