### PR TITLE
fix: remove demo-mode tokenAtcl increment in registerTurn

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4171,7 +4171,6 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
               localBoostRejectionReason = 'insufficient_token_balance';
             }
           }
-          workingToken += 1;
           nextTokenAtcl = workingToken;
           localSyncStatus = boostRequested && !localBoostApplied ? 'failed_boost_fallback' : 'synced';
           localTurnRecord = buildTurnRecordFromPayload(


### PR DESCRIPTION
Closes #896

In demo mode (no Supabase configured), `registerTurn` was unconditionally incrementing `tokenAtcl` by 1 on every turn registration, granting free tokens. Removed the `workingToken += 1` line so demo mode no longer awards real tokens.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aws2SepkENkoRJC6NxHbca)_