### PR TITLE
fix: add .catch to realtime subscription refresh callbacks

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3903,37 +3903,37 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             }));
           }
 
-          refreshTurnStats();
-          refreshTheatreReputation();
-          refreshBadges();
+          refreshTurnStats().catch(console.error);
+          refreshTheatreReputation().catch(console.error);
+          refreshBadges().catch(console.error);
         }
       )
       .on(
         'postgres_changes',
         { event: '*', schema: 'public', table: 'user_badges', filter: `user_id=eq.${authUserId}` },
         () => {
-          refreshBadges();
+          refreshBadges().catch(console.error);
         }
       )
       .on(
         'postgres_changes',
         { event: '*', schema: 'public', table: 'planned_participations', filter: `user_id=eq.${authUserId}` },
         () => {
-          refreshEventPlanning(catalog.events);
+          refreshEventPlanning(catalog.events).catch(console.error);
         }
       )
       .on(
         'postgres_changes',
         { event: '*', schema: 'public', table: 'activity_completions', filter: `user_id=eq.${authUserId}` },
         () => {
-          refreshActivitySlotsStatus();
+          refreshActivitySlotsStatus().catch(console.error);
         }
       )
       .on(
         'postgres_changes',
         { event: '*', schema: 'public', table: 'shop_catalog' },
         () => {
-          refreshShopCatalog();
+          refreshShopCatalog().catch(console.error);
         }
       )
       .on(


### PR DESCRIPTION
Closes #897

Realtime subscription callbacks were calling async refresh functions (`refreshTurnStats`, `refreshTheatreReputation`, `refreshBadges`, `refreshEventPlanning`, `refreshActivitySlotsStatus`, `refreshShopCatalog`) without `.catch`, causing unhandled promise rejections and potential stale UI. Added `.catch(console.error)` to each call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aws2SepkENkoRJC6NxHbca)_