### PR TITLE
fix: remove roleId dep from refreshEventPlanning to prevent redundant fetches

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3150,7 +3150,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         }
       );
     },
-    [authUserId, state.profile.roleId, syncLocalEventPlanning]
+    [authUserId, syncLocalEventPlanning]
   );
 
   const refreshShopCatalog = useCallback(async () => {


### PR DESCRIPTION
Closes #899

`refreshEventPlanning` had `state.profile.roleId` in its `useCallback` dependency array, causing the function to be recreated and triggering redundant RPC fetches on every role change. Removed `state.profile.roleId` from the dependency list since role changes do not warrant a new planning fetch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aws2SepkENkoRJC6NxHbca)_