### PR TITLE
fix: add .catch to restoreSession so authReady is always set on failure

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -2984,7 +2984,10 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       );
     };
 
-    restoreSession();
+    restoreSession().catch((err) => {
+      console.error('[restoreSession] unexpected error', err);
+      if (isMounted) setAuthReady(true);
+    });
 
     const { data: authListener } = supabase!.auth.onAuthStateChange((_event, session) => {
       persistStoredSession(session ?? null);


### PR DESCRIPTION
Closes #901

`restoreSession()` was called without `.catch`, so if the watchdog or an unexpected error fired, `authReady` would never be set to `true`, permanently blocking the app. Added a `.catch` handler that logs the error and ensures `authReady` is set to `true` even on failure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aws2SepkENkoRJC6NxHbca)_