### PR TITLE
fix: prevent stale session writes in SupportChat save effect

### DIFF
--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -82,9 +82,13 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
 
   useEffect(() => {
     if (!hasLoadedRef.current || !activeSessionId) return;
-    const next = updateSessionList(chatSessions, activeSessionId, messages);
-    setChatSessions(next);
-    saveChatHistory(displayName, next, userId);
+    const capturedSessionId = activeSessionId;
+    const next = updateSessionList(chatSessions, capturedSessionId, messages);
+    setChatSessions((prev) => {
+      if (prev.find(s => s.id === capturedSessionId) === undefined) return prev;
+      saveChatHistory(displayName, next, userId);
+      return next;
+    });
   }, [messages, activeSessionId, chatSessions, historyId, displayName, userId]);
 
   const hasInput = input.trim().length > 0;


### PR DESCRIPTION
Closes #902

The `SupportChat` save effect could write a stale session list to localStorage when sessions switched concurrently. The fix captures `activeSessionId` at effect-start and uses the functional setter form of `setChatSessions` to confirm the captured session still exists before writing to localStorage.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aws2SepkENkoRJC6NxHbca)_