### PR TITLE
fix: require JWT auth in event-links to block unauthenticated DB queries

### DIFF
--- a/supabase/functions/event-links/index.ts
+++ b/supabase/functions/event-links/index.ts
@@ -102,11 +102,20 @@ serve(async (req) => {
   }
 
   const authHeader = req.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return json({ error: 'Autenticazione richiesta' }, 401);
+  }
+
   const supabase = createClient(supabaseUrl, anonKey, {
     global: {
-      headers: authHeader ? { Authorization: authHeader } : undefined,
+      headers: { Authorization: authHeader },
     },
   });
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return json({ error: 'Autenticazione richiesta' }, 401);
+  }
 
   let body: Record<string, unknown>;
   try {


### PR DESCRIPTION
Closes #903

The `event-links` edge function allowed unauthenticated DB queries for all three actions (`validate_qr`, `create_deep_link`, `resolve_deep_link`) with no rate limiting. Added an Authorization check before processing any action: verifies a valid JWT via `supabase.auth.getUser()` and returns 401 if missing or invalid.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aws2SepkENkoRJC6NxHbca)_