### PR TITLE
fix: guard null hash after ticket lookup in activate flows

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -208,6 +208,10 @@ serve(async (req: Request) => {
           return jsonResponse({ ok: false, error: 'Ticket non trovato.' }, 200);
         }
         targetHash = ticket.hash;
+
+        if (targetHash == null) {
+          return jsonResponse({ ok: false, error: 'Ticket non attivabile: hash mancante.' }, 200);
+        }
       } else if (action === 'activate_by_ticket_number') {
         let query = supabase
           .from('ticket_activations')
@@ -240,6 +244,10 @@ serve(async (req: Request) => {
         }
 
         targetHash = tickets[0].hash;
+
+        if (targetHash == null) {
+          return jsonResponse({ ok: false, error: 'Ticket non attivabile: hash mancante.' }, 200);
+        }
       }
 
       // 2. Atomic activation update


### PR DESCRIPTION
Closes #912

When a `ticket_activations` row has a `NULL` hash column, the previous code assigned `targetHash = null` and then called `.eq('hash', null)` on PostgREST, which matches nothing. The activation silently failed with a misleading "Ticket non trovato" error even though the ticket exists.

**Fix:** After assigning `targetHash` from a DB lookup (both `activate_by_details` and `activate_by_ticket_number` paths), check for `null`/`undefined` and return a clear error response before attempting the atomic update.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NH86z7S3PpJXspYMNVkTU)_