### PR TITLE
fix: require valid JWT on mobile-logs endpoint

### DIFF
--- a/supabase/functions/mobile-logs/index.ts
+++ b/supabase/functions/mobile-logs/index.ts
@@ -122,6 +122,16 @@ serve(async (req: Request) => {
     return jsonResponse({ error: 'Metodo non consentito' }, 405);
   }
 
+  // Require a valid JWT before processing any log entries
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return jsonResponse({ error: 'Autenticazione richiesta' }, 401);
+  }
+  const requesterUserIdFromAuth = await resolveRequesterUserId(req);
+  if (!requesterUserIdFromAuth) {
+    return jsonResponse({ error: 'Sessione non valida o scaduta' }, 401);
+  }
+
   try {
     const body = await req.json();
     if (!isRecord(body)) {
@@ -148,7 +158,7 @@ serve(async (req: Request) => {
       .map((entry, index) => normalizeLogEntry(entry, index))
       .filter((entry): entry is NormalizedLogEntry => !!entry);
 
-    const requesterUserId = await resolveRequesterUserId(req);
+    const requesterUserId = requesterUserIdFromAuth;
     const duplicateCount = countDuplicateLogIds(normalizedLogs);
 
     console.info('[mobile-logs] ingest request', {


### PR DESCRIPTION
Closes #913

The `mobile-logs` endpoint previously accepted up to 100 log entries per request with no authentication check. Any unauthenticated caller could flood server logs.

**Fix:** Added a JWT validation gate at the top of the request handler (before parsing the body). If no `Authorization: Bearer <token>` header is present or the token does not resolve to a valid Supabase user, the request is rejected with a 401. The resolved user ID is then reused downstream so the existing `resolveRequesterUserId` call is not duplicated.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NH86z7S3PpJXspYMNVkTU)_