### PR TITLE
fix: enforce minimum 7-day retention in cleanup-events

### DIFF
--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -62,8 +62,9 @@ serve(async (req) => {
     const url = new URL(req.url)
     const rawDays = url.searchParams.get('days') ?? ''
     const parsedDays = parseInt(rawDays, 10)
-    // Validate: must be a positive integer; default to 7 if absent or invalid
-    const daysToKeep = (!rawDays || isNaN(parsedDays) || parsedDays <= 0) ? 7 : parsedDays
+    // Validate: must be an integer >= 7; default to 7 if absent or invalid
+    const MIN_DAYS = 7
+    const daysToKeep = (!rawDays || isNaN(parsedDays) || parsedDays < MIN_DAYS) ? MIN_DAYS : parsedDays
 
     console.log(`🧹 Pulizia eventi più vecchi di ${daysToKeep} giorni...`)
 


### PR DESCRIPTION
Closes #914

The `cleanup-events` function only rejected `days <= 0`, meaning an admin could pass `days=1` and delete nearly all events in the table.

**Fix:** Raised the lower bound to `MIN_DAYS = 7`. Any value below 7 (including 1–6) now falls back to the 7-day default, preventing accidental mass-deletion of recent events.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NH86z7S3PpJXspYMNVkTU)_