### PR TITLE
fix: preserve in-memory turns when remote turns query fails

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3762,7 +3762,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
                 leaderboardVisible: profileRow.leaderboard_visible ?? prev.profile.leaderboardVisible,
               },
               eventPlans: prev.eventPlans,
-              turns: remoteTurns,
+              turns: turnsRes.error ? prev.turns : remoteTurns,
             }));
           }
 


### PR DESCRIPTION
Closes #915

In `loadRemoteState`, when the Supabase `turns` query fails, `turnsRes.data` is `null` so `remoteTurns` was set to `[]`. This empty array was then written into `setState`, silently overwriting the user's existing in-memory turn history with nothing.

**Fix:** Changed `turns: remoteTurns` to `turns: turnsRes.error ? prev.turns : remoteTurns`. On query failure the previous turn state is preserved; on success the remote data is applied as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NH86z7S3PpJXspYMNVkTU)_