### PR TITLE
fix: restrict resolve_hash to admin/staff roles

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -141,6 +141,11 @@ serve(async (req: Request) => {
     }
 
     if (action === 'resolve_hash') {
+      const resolveRole = authenticatedUser?.app_metadata?.role as string | undefined;
+      if (resolveRole !== 'admin' && resolveRole !== 'staff') {
+        return jsonResponse({ error: 'Accesso negato: ruolo admin o staff richiesto' }, 403);
+      }
+
       if (!hash || typeof hash !== 'string') {
         return jsonResponse({ error: 'Missing hash' }, 400);
       }


### PR DESCRIPTION
Closes #916

The `resolve_hash` action was authenticated (required a valid JWT) but had no role check, so any authenticated user could call it with arbitrary hashes to probe ticket existence and retrieve full event metadata.

**Fix:** Added a role check immediately inside the `resolve_hash` block. Only users whose `app_metadata.role` is `admin` or `staff` are allowed through; all others receive a 403.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NH86z7S3PpJXspYMNVkTU)_