### PR TITLE
Add narrative scene engine and UI for branching dialogue

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -38,6 +38,7 @@ const ActivitiesHub = React.lazy(() => import('./screens/ActivitiesHub').then(m 
 const ActivityDetail = React.lazy(() => import('./screens/ActivityDetail').then(m => ({ default: m.ActivityDetail })));
 const ActivityMinigame = React.lazy(() => import('./screens/ActivityMinigame').then(m => ({ default: m.ActivityMinigame })));
 const ActivityResult = React.lazy(() => import('./screens/ActivityResult').then(m => ({ default: m.ActivityResult })));
+const NarrativeScene = React.lazy(() => import('./screens/NarrativeScene').then(m => ({ default: m.NarrativeScene })));
 const Shop = React.lazy(() => import('./screens/Shop').then(m => ({ default: m.Shop })));
 const Leaderboard = React.lazy(() => import('./screens/Leaderboard').then(m => ({ default: m.Leaderboard })));
 const Profile = React.lazy(() => import('./screens/Profile').then(m => ({ default: m.Profile })));
@@ -79,7 +80,7 @@ export function AppShell() {
     activitySlotsStatus, activitySlotsLoading,
     getEventPlan, planEvent, cancelEventPlan, markBadgesSeen,
     updateProfile, registerTurn, pendingBoostRequests, turnSyncFeedback, clearTurnSyncFeedback,
-    completeActivity, resetProgress, deleteAccount, exportUserData, resetState,
+    completeActivity, completeNarrativeChoice, resetProgress, deleteAccount, exportUserData, resetState,
     changePassword, sendPasswordResetEmail, featureFlags, isFeatureEnabled,
   } = gameState;
 
@@ -464,7 +465,9 @@ export function AppShell() {
                   if (!isFeatureEnabled('avvia_attivita')) { showFeatureDisabledAlert('Avvio attivita'); return; }
                   nav.setSelectedActivityId(id);
                   nav.navigate('activity-detail');
-                }} embedded />
+                }}
+                onOpenScenario={(sceneId: string) => { nav.setCurrentNarrativeSceneId(sceneId); nav.navigate('narrative-scene'); }}
+                embedded />
             }
           />
         );
@@ -556,8 +559,20 @@ export function AppShell() {
             onStartActivity={(id: string) => {
               if (!isFeatureEnabled('avvia_attivita')) { showFeatureDisabledAlert('Avvio attivita'); return; }
               nav.setSelectedActivityId(id); nav.navigate('activity-detail');
-            }} />
+            }}
+            onOpenScenario={(sceneId: string) => { nav.setCurrentNarrativeSceneId(sceneId); nav.navigate('narrative-scene'); }} />
         );
+
+      case 'narrative-scene':
+        return nav.currentNarrativeSceneId ? (
+          <NarrativeScene
+            sceneId={nav.currentNarrativeSceneId}
+            roleId={selectedRole?.id ?? null}
+            roleStats={selectedRole?.stats ?? null}
+            onSubmit={completeNarrativeChoice}
+            onClose={() => { nav.setCurrentNarrativeSceneId(''); handleTabChange('activities'); }}
+          />
+        ) : null;
 
       case 'profile':
         return (

--- a/apps/mobile/src/components/screens/Activities.tsx
+++ b/apps/mobile/src/components/screens/Activities.tsx
@@ -17,6 +17,7 @@ interface ActivitiesProps {
   embedded?: boolean;
   recommendedActivityId?: string;
   onStartActivity: (activityId: string) => void;
+  onOpenScenario?: (sceneId: string) => void;
 }
 
 const difficultyLabels: Record<Activity['difficulty'], string> = {
@@ -28,7 +29,7 @@ const difficultyLabels: Record<Activity['difficulty'], string> = {
 export function Activities({
   activities, activeRole, slotsStatus, slotsLoading = false,
   isOnline = true, canStartActivities = true, embedded = false,
-  recommendedActivityId, onStartActivity,
+  recommendedActivityId, onStartActivity, onOpenScenario,
 }: ActivitiesProps) {
   const totalActivities = activities.length;
   const dailyGoal = slotsStatus.totalSlots;
@@ -51,6 +52,8 @@ export function Activities({
         dailyProgress={dailyProgress}
         slotsLoading={slotsLoading}
       />
+
+      {onOpenScenario && <ScenarioPreviewCard onOpen={() => onOpenScenario('debug_intro')} />}
 
       <section className="space-y-3">
         <div className="flex items-center justify-between">
@@ -92,6 +95,28 @@ export function Activities({
 }
 
 // === Sub-components ===
+
+function ScenarioPreviewCard({ onOpen }: { onOpen: () => void }) {
+  return (
+    <Card className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs uppercase tracking-wider text-[#a82847]">Scenario narrativo</span>
+        <Tag size="sm" variant="info">Anteprima</Tag>
+      </div>
+      <p className="text-sm text-white">Cinque minuti al sipario</p>
+      <p className="text-sm text-[#9a9697]">
+        Una scelta rapida prima dell'apertura. Conseguenze immediate.
+      </p>
+      <button
+        type="button"
+        onClick={onOpen}
+        className="w-full rounded-xl bg-[#a82847] px-4 py-2 text-sm font-medium text-white"
+      >
+        Inizia scenario
+      </button>
+    </Card>
+  );
+}
 
 function TrainingBanner() {
   return (

--- a/apps/mobile/src/components/screens/NarrativeScene.tsx
+++ b/apps/mobile/src/components/screens/NarrativeScene.tsx
@@ -1,0 +1,177 @@
+import React, { useMemo, useState } from 'react';
+import { Screen } from '../ui/Screen';
+import {
+  applyChoice,
+  createRunState,
+  evaluateChoice,
+  loadScene,
+  type NarrativeChoice,
+  type NarrativeContext,
+  type NarrativeOutcome,
+  type NarrativeRunState,
+  type NarrativeScene as NarrativeSceneData,
+} from '../../gameplay/narrative';
+import type { CompleteNarrativeChoiceInput, RoleId, Rewards } from '../../state/store';
+import type { RoleStats } from '../../gameplay/minigames';
+
+// Eagerly initialize the scene registry on module load.
+import '../../data/narrative';
+
+interface NarrativeSceneProps {
+  sceneId: string;
+  roleId: RoleId | null;
+  roleStats: RoleStats | null;
+  onSubmit: (input: CompleteNarrativeChoiceInput) => Promise<{ ok: boolean; rewards?: Rewards; error?: string }>;
+  onClose: () => void;
+}
+
+type LocalState =
+  | { phase: 'choosing'; run: NarrativeRunState }
+  | { phase: 'submitting'; run: NarrativeRunState; choiceId: string }
+  | { phase: 'outcome'; run: NarrativeRunState; outcome: NarrativeOutcome; rewards: Rewards }
+  | { phase: 'error'; message: string };
+
+function rewardsLine(rewards: Rewards): string {
+  const parts: string[] = [];
+  if (rewards.xp) parts.push(`+${rewards.xp} XP`);
+  if (rewards.cachet) parts.push(`+${rewards.cachet} cachet`);
+  if (rewards.reputation) parts.push(`+${rewards.reputation} reputazione`);
+  return parts.join(' · ') || 'Nessuna ricompensa';
+}
+
+export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }: NarrativeSceneProps) {
+  const scene = useMemo<NarrativeSceneData | null>(() => loadScene(sceneId), [sceneId]);
+
+  const ctx: NarrativeContext = useMemo(
+    () => ({ roleId, stats: roleStats, flags: new Set<string>() }),
+    [roleId, roleStats],
+  );
+
+  const [local, setLocal] = useState<LocalState>(() =>
+    scene
+      ? { phase: 'choosing', run: createRunState(scene.id) }
+      : { phase: 'error', message: `Scenario "${sceneId}" non trovato.` },
+  );
+
+  if (!scene || local.phase === 'error') {
+    return (
+      <Screen withBottomNavPadding={false}>
+        <h1 className="text-xl font-semibold">Scenario non disponibile</h1>
+        <p className="text-sm text-[#9a9697]">
+          {local.phase === 'error' ? local.message : 'Lo scenario richiesto non è registrato.'}
+        </p>
+        <button
+          type="button"
+          onClick={onClose}
+          className="mt-4 self-start rounded-xl bg-[#a82847] px-4 py-2 text-sm font-medium text-white"
+        >
+          Torna indietro
+        </button>
+      </Screen>
+    );
+  }
+
+  if (local.phase === 'outcome') {
+    return (
+      <Screen withBottomNavPadding={false}>
+        <span className="text-xs uppercase tracking-wider text-[#a82847]">Esito</span>
+        <h1 className="text-xl font-semibold">{scene.title}</h1>
+        <p className="text-base leading-relaxed text-[#e3e0e0]">{local.outcome.text}</p>
+        <p className="text-sm font-medium text-[#d4af37]">{rewardsLine(local.rewards)}</p>
+        <button
+          type="button"
+          onClick={onClose}
+          className="mt-6 w-full rounded-xl bg-[#a82847] px-4 py-3 text-sm font-medium text-white"
+        >
+          Continua
+        </button>
+      </Screen>
+    );
+  }
+
+  const submitting = local.phase === 'submitting';
+  const submittingChoiceId = submitting ? local.choiceId : null;
+
+  const handleChoose = async (choice: NarrativeChoice) => {
+    if (submitting) return;
+    const availability = evaluateChoice(choice, ctx);
+    if (!availability.available) return;
+
+    setLocal({ phase: 'submitting', run: local.run, choiceId: choice.id });
+
+    let nextRun: NarrativeRunState;
+    let outcome: NarrativeOutcome;
+    try {
+      const result = applyChoice(local.run, scene, choice.id, ctx);
+      nextRun = result.state;
+      outcome = result.outcome;
+    } catch (error) {
+      setLocal({ phase: 'error', message: error instanceof Error ? error.message : 'Errore sconosciuto' });
+      return;
+    }
+
+    const submitResult = await onSubmit({
+      sceneId: scene.id,
+      choiceId: choice.id,
+      rewards: outcome.rewards,
+      setFlags: outcome.setFlags,
+    });
+
+    if (!submitResult.ok) {
+      setLocal({ phase: 'error', message: submitResult.error ?? 'Errore nel salvataggio della scelta' });
+      return;
+    }
+
+    setLocal({
+      phase: 'outcome',
+      run: nextRun,
+      outcome,
+      rewards: submitResult.rewards ?? { xp: 0, cachet: 0, reputation: 0 },
+    });
+  };
+
+  return (
+    <Screen withBottomNavPadding={false}>
+      <div className="flex items-center justify-between">
+        <span className="text-xs uppercase tracking-wider text-[#9a9697]">{scene.setting}</span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-xs text-[#9a9697] underline"
+          aria-label="Chiudi scenario"
+        >
+          Esci
+        </button>
+      </div>
+      <h1 className="text-xl font-semibold">{scene.title}</h1>
+      <p className="text-base leading-relaxed text-[#e3e0e0]">{scene.prompt}</p>
+
+      <div className="mt-4 flex flex-col gap-2">
+        {scene.choices.map(choice => {
+          const availability = evaluateChoice(choice, ctx);
+          const disabled = !availability.available || submitting;
+          const isSubmittingThis = submittingChoiceId === choice.id;
+          return (
+            <button
+              key={choice.id}
+              type="button"
+              onClick={() => handleChoose(choice)}
+              disabled={disabled}
+              className={`rounded-xl border px-4 py-3 text-left text-sm transition ${
+                disabled
+                  ? 'border-[#2d2728] bg-[#1a1617] text-[#6f6a6b]'
+                  : 'border-[#a82847] bg-[#1a1617] text-white hover:bg-[#2d1820]'
+              }`}
+            >
+              <span className="block font-medium">{choice.label}</span>
+              {!availability.available && availability.reason === 'stat' && availability.detail && (
+                <span className="mt-1 block text-xs text-[#a82847]">{availability.detail}</span>
+              )}
+              {isSubmittingThis && <span className="mt-1 block text-xs text-[#9a9697]">In corso…</span>}
+            </button>
+          );
+        })}
+      </div>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/components/screens/NarrativeScene.tsx
+++ b/apps/mobile/src/components/screens/NarrativeScene.tsx
@@ -1,9 +1,10 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { Screen } from '../ui/Screen';
 import {
   applyChoice,
   createRunState,
   evaluateChoice,
+  isSceneAvailable,
   loadScene,
   type NarrativeChoice,
   type NarrativeContext,
@@ -26,9 +27,9 @@ interface NarrativeSceneProps {
 }
 
 type LocalState =
-  | { phase: 'choosing'; run: NarrativeRunState }
-  | { phase: 'submitting'; run: NarrativeRunState; choiceId: string }
-  | { phase: 'outcome'; run: NarrativeRunState; outcome: NarrativeOutcome; rewards: Rewards }
+  | { phase: 'choosing'; run: NarrativeRunState; scene: NarrativeSceneData }
+  | { phase: 'submitting'; run: NarrativeRunState; scene: NarrativeSceneData; choiceId: string }
+  | { phase: 'outcome'; run: NarrativeRunState; scene: NarrativeSceneData; outcome: NarrativeOutcome; rewards: Rewards; finished: boolean }
   | { phase: 'error'; message: string };
 
 function rewardsLine(rewards: Rewards): string {
@@ -39,27 +40,26 @@ function rewardsLine(rewards: Rewards): string {
   return parts.join(' · ') || 'Nessuna ricompensa';
 }
 
+function makeCtx(roleId: RoleId | null, roleStats: RoleStats | null, flags: ReadonlySet<string>): NarrativeContext {
+  return { roleId, stats: roleStats, flags };
+}
+
 export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }: NarrativeSceneProps) {
-  const scene = useMemo<NarrativeSceneData | null>(() => loadScene(sceneId), [sceneId]);
+  const [local, setLocal] = useState<LocalState>(() => {
+    const scene = loadScene(sceneId);
+    if (!scene) return { phase: 'error', message: `Scenario "${sceneId}" non trovato.` };
+    const ctx = makeCtx(roleId, roleStats, new Set());
+    if (!isSceneAvailable(scene, ctx)) {
+      return { phase: 'error', message: 'Accesso allo scenario non consentito per il tuo ruolo o le tue attività.' };
+    }
+    return { phase: 'choosing', run: createRunState(scene.id), scene };
+  });
 
-  const ctx: NarrativeContext = useMemo(
-    () => ({ roleId, stats: roleStats, flags: new Set<string>() }),
-    [roleId, roleStats],
-  );
-
-  const [local, setLocal] = useState<LocalState>(() =>
-    scene
-      ? { phase: 'choosing', run: createRunState(scene.id) }
-      : { phase: 'error', message: `Scenario "${sceneId}" non trovato.` },
-  );
-
-  if (!scene || local.phase === 'error') {
+  if (local.phase === 'error') {
     return (
       <Screen withBottomNavPadding={false}>
         <h1 className="text-xl font-semibold">Scenario non disponibile</h1>
-        <p className="text-sm text-[#9a9697]">
-          {local.phase === 'error' ? local.message : 'Lo scenario richiesto non è registrato.'}
-        </p>
+        <p className="text-sm text-[#9a9697]">{local.message}</p>
         <button
           type="button"
           onClick={onClose}
@@ -72,46 +72,67 @@ export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }
   }
 
   if (local.phase === 'outcome') {
+    const handleContinue = () => {
+      if (local.finished) { onClose(); return; }
+      const nextSceneId = local.run.currentSceneId;
+      const nextScene = loadScene(nextSceneId);
+      if (!nextScene) {
+        setLocal({ phase: 'error', message: `Scenario "${nextSceneId}" non trovato.` });
+        return;
+      }
+      const nextCtx = makeCtx(roleId, roleStats, local.run.flags);
+      if (!isSceneAvailable(nextScene, nextCtx)) {
+        setLocal({ phase: 'error', message: 'Accesso allo scenario successivo non consentito.' });
+        return;
+      }
+      setLocal({ phase: 'choosing', run: local.run, scene: nextScene });
+    };
+
     return (
       <Screen withBottomNavPadding={false}>
         <span className="text-xs uppercase tracking-wider text-[#a82847]">Esito</span>
-        <h1 className="text-xl font-semibold">{scene.title}</h1>
+        <h1 className="text-xl font-semibold">{local.scene.title}</h1>
         <p className="text-base leading-relaxed text-[#e3e0e0]">{local.outcome.text}</p>
         <p className="text-sm font-medium text-[#d4af37]">{rewardsLine(local.rewards)}</p>
         <button
           type="button"
-          onClick={onClose}
+          onClick={handleContinue}
           className="mt-6 w-full rounded-xl bg-[#a82847] px-4 py-3 text-sm font-medium text-white"
         >
-          Continua
+          {local.finished ? 'Continua' : 'Avanti →'}
         </button>
       </Screen>
     );
   }
 
+  // 'choosing' or 'submitting' phase
+  const { run, scene: activeScene } = local;
   const submitting = local.phase === 'submitting';
   const submittingChoiceId = submitting ? local.choiceId : null;
+  // Context reflects current run flags so intra-session flag gating works.
+  const ctx = makeCtx(roleId, roleStats, run.flags);
 
   const handleChoose = async (choice: NarrativeChoice) => {
     if (submitting) return;
-    const availability = evaluateChoice(choice, ctx);
-    if (!availability.available) return;
+    if (!evaluateChoice(choice, ctx).available) return;
 
-    setLocal({ phase: 'submitting', run: local.run, choiceId: choice.id });
+    setLocal({ phase: 'submitting', run, scene: activeScene, choiceId: choice.id });
 
     let nextRun: NarrativeRunState;
     let outcome: NarrativeOutcome;
+    let finished: boolean;
     try {
-      const result = applyChoice(local.run, scene, choice.id, ctx);
+      const result = applyChoice(run, activeScene, choice.id, ctx);
       nextRun = result.state;
       outcome = result.outcome;
+      finished = result.finished;
     } catch (error) {
       setLocal({ phase: 'error', message: error instanceof Error ? error.message : 'Errore sconosciuto' });
       return;
     }
 
     const submitResult = await onSubmit({
-      sceneId: scene.id,
+      sceneId: activeScene.id,
       choiceId: choice.id,
       rewards: outcome.rewards,
       setFlags: outcome.setFlags,
@@ -125,15 +146,17 @@ export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }
     setLocal({
       phase: 'outcome',
       run: nextRun,
+      scene: activeScene,
       outcome,
       rewards: submitResult.rewards ?? { xp: 0, cachet: 0, reputation: 0 },
+      finished,
     });
   };
 
   return (
     <Screen withBottomNavPadding={false}>
       <div className="flex items-center justify-between">
-        <span className="text-xs uppercase tracking-wider text-[#9a9697]">{scene.setting}</span>
+        <span className="text-xs uppercase tracking-wider text-[#9a9697]">{activeScene.setting}</span>
         <button
           type="button"
           onClick={onClose}
@@ -143,11 +166,11 @@ export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }
           Esci
         </button>
       </div>
-      <h1 className="text-xl font-semibold">{scene.title}</h1>
-      <p className="text-base leading-relaxed text-[#e3e0e0]">{scene.prompt}</p>
+      <h1 className="text-xl font-semibold">{activeScene.title}</h1>
+      <p className="text-base leading-relaxed text-[#e3e0e0]">{activeScene.prompt}</p>
 
       <div className="mt-4 flex flex-col gap-2">
-        {scene.choices.map(choice => {
+        {activeScene.choices.map(choice => {
           const availability = evaluateChoice(choice, ctx);
           const disabled = !availability.available || submitting;
           const isSubmittingThis = submittingChoiceId === choice.id;

--- a/apps/mobile/src/data/narrative/index.ts
+++ b/apps/mobile/src/data/narrative/index.ts
@@ -1,0 +1,31 @@
+// Narrative scenes registry.
+//
+// Add a new scene:
+//   1. Drop a `.json` file under `./scenes/` matching the schema in
+//      `../../gameplay/narrative.ts` (NarrativeScene).
+//   2. Import it below and append to SCENES.
+//   3. The registry validates every scene at module load: an invalid file
+//      throws immediately in dev/build, so content errors cannot reach prod.
+//
+// See `./scenes/README.md` for the schema and writing tips.
+
+import { assertValidScene, registerScenes, type NarrativeScene } from '../../gameplay/narrative';
+
+import debugIntro from './scenes/debug_intro.json';
+
+const SCENES: unknown[] = [debugIntro];
+
+let initialized = false;
+
+export function initNarrativeRegistry(): void {
+  if (initialized) return;
+  for (const raw of SCENES) {
+    assertValidScene(raw);
+  }
+  registerScenes(SCENES as NarrativeScene[]);
+  initialized = true;
+}
+
+// Auto-init on import. Call sites can also invoke explicitly (e.g. tests
+// that registered fixtures and then cleared the registry).
+initNarrativeRegistry();

--- a/apps/mobile/src/data/narrative/scenes/README.md
+++ b/apps/mobile/src/data/narrative/scenes/README.md
@@ -1,0 +1,61 @@
+# Scenari narrativi — guida per chi scrive
+
+Ogni scenario è un file `.json` in questa cartella, con la shape definita in
+`apps/mobile/src/gameplay/narrative.ts` (`NarrativeScene`).
+
+## Schema essenziale
+
+```json
+{
+  "id": "unique_snake_case_id",
+  "title": "Titolo breve della scena",
+  "setting": "Dove siamo, in 1 riga",
+  "prompt": "Cosa sta succedendo. 2-4 righe. Termina con una decisione da prendere.",
+  "allowedRoles": ["attore", "luci"],         // opzionale: omettere = tutti i ruoli
+  "requiresFlags": ["completed_intro"],       // opzionale: gating su flag globali
+  "choices": [
+    { "id": "...", "label": "...", "outcome": { ... } },
+    { "id": "...", "label": "...", "outcome": { ... } }
+  ]
+}
+```
+
+## Vincoli
+
+- `choices`: minimo **2**, massimo **4**.
+- `id` di ogni choice deve essere **unico nella scena**.
+- `label`: testo del bottone, max ~40 caratteri.
+- `outcome.text`: 1-3 righe descrittive su cosa accade.
+- `outcome.rewards`: almeno uno tra `xp`, `cachet`, `reputation` (anche 0 è valido).
+- `outcome.next`: `"id_scena_successiva"` per concatenare, oppure `null` per chiudere.
+
+## Gating
+
+- **Per ruolo** (`allowedRoles` sulla scena): solo i ruoli elencati vedono la scena.
+- **Per flag** (`requiresFlags` sulla scena): flag impostati da scelte precedenti.
+- **Per stat** (`choices[].requires.stat + min`): la singola scelta è disabilitata se la stat del ruolo è sotto la soglia. Le 4 stat disponibili sono `presence`, `precision`, `leadership`, `creativity`.
+- **Per flag su singola scelta** (`choices[].requires.flag`).
+
+Esempio scelta gated:
+
+```json
+{
+  "id": "improvvisa",
+  "label": "Improvvisa una variazione",
+  "requires": { "stat": "creativity", "min": 70 },
+  "outcome": { "text": "...", "rewards": { "xp": 30 }, "next": null }
+}
+```
+
+## Flow
+
+1. Crea il file in `apps/mobile/src/data/narrative/scenes/<id>.json`.
+2. Aggiungi l'import in `apps/mobile/src/data/narrative/index.ts` e mettilo in `SCENES`.
+3. Lancia `npm run test:mobile` (o avvia l'app in dev): la validazione runtime fallisce con messaggi puntuali se lo schema non è rispettato.
+
+## Tips di scrittura
+
+- **Una decisione vera per scena.** Se le scelte hanno tutte lo stesso outcome, non è una decisione: è rumore.
+- **Conseguenze diverse, non solo numeri diversi.** Cambia il testo dell'outcome, magari un flag. Le ricompense seguono, non guidano.
+- **Mostra il risultato in 2 righe.** Niente paragrafi, niente lore-dump.
+- **`null` chiude la scena.** Quando concateni con `next: "..."`, ricorda di scrivere anche la scena successiva, altrimenti il loader fallisce all'apertura della scena mancante (a runtime, non in build).

--- a/apps/mobile/src/data/narrative/scenes/debug_intro.json
+++ b/apps/mobile/src/data/narrative/scenes/debug_intro.json
@@ -1,0 +1,37 @@
+{
+  "id": "debug_intro",
+  "title": "Cinque minuti al sipario",
+  "setting": "Backstage del Teatro Palladium — Roma",
+  "prompt": "Mancano cinque minuti all'apertura. La compagnia è agitata: una battuta del primo monologo non funziona ancora come dovrebbe. Il regista ti guarda. Ti chiede un'idea, adesso.",
+  "choices": [
+    {
+      "id": "rispetta_testo",
+      "label": "Rispetta il testo",
+      "outcome": {
+        "text": "Resti fedele al copione. La compagnia ritrova sicurezza e si entra in scena puliti, senza sorprese.",
+        "rewards": { "xp": 20, "cachet": 5 },
+        "next": null
+      }
+    },
+    {
+      "id": "improvvisa",
+      "label": "Suggerisci un'improvvisazione",
+      "requires": { "stat": "creativity", "min": 70 },
+      "outcome": {
+        "text": "Lanci una variazione audace sull'attacco. Il pubblico la sente nuova, viva. La compagnia ti guarda diversamente.",
+        "rewards": { "xp": 35, "cachet": 10, "reputation": 2 },
+        "setFlags": ["improvised_first_show"],
+        "next": null
+      }
+    },
+    {
+      "id": "delega",
+      "label": "Lascia decidere al regista",
+      "outcome": {
+        "text": "Ti tiri indietro. Il regista decide e tira dritto. Lo spettacolo va in scena, ma nessuno ha imparato nulla stasera.",
+        "rewards": { "xp": 10 },
+        "next": null
+      }
+    }
+  ]
+}

--- a/apps/mobile/src/gameplay/narrative.ts
+++ b/apps/mobile/src/gameplay/narrative.ts
@@ -1,0 +1,237 @@
+import type { RoleId } from '../state/store';
+import type { RoleStats } from './minigames';
+
+// Pure narrative engine (no React, no DOM). See issue #328.
+// Loads scenes registered in `../data/narrative` and applies player choices.
+
+export type NarrativeRewards = {
+  xp?: number;
+  cachet?: number;
+  reputation?: number;
+};
+
+export type NarrativeRequirement = {
+  stat?: keyof RoleStats;
+  min?: number;
+  flag?: string;
+};
+
+export type NarrativeOutcome = {
+  text: string;
+  rewards: NarrativeRewards;
+  setFlags?: string[];
+  next?: string | null;
+};
+
+export type NarrativeChoice = {
+  id: string;
+  label: string;
+  requires?: NarrativeRequirement;
+  outcome: NarrativeOutcome;
+};
+
+export type NarrativeScene = {
+  id: string;
+  title: string;
+  setting: string;
+  prompt: string;
+  allowedRoles?: RoleId[];
+  requiresFlags?: string[];
+  choices: NarrativeChoice[];
+};
+
+export type NarrativeContext = {
+  roleId: RoleId | null;
+  stats: RoleStats | null;
+  flags: ReadonlySet<string>;
+};
+
+export type NarrativeRunState = {
+  currentSceneId: string;
+  history: Array<{ sceneId: string; choiceId: string; ts: string }>;
+  flags: Set<string>;
+};
+
+export type ChoiceAvailability =
+  | { available: true }
+  | { available: false; reason: 'role' | 'flag' | 'stat'; detail?: string };
+
+// ---------------------------------------------------------------------------
+// Registry indirection
+//
+// The engine is decoupled from the data layer. `data/narrative/index.ts`
+// registers scenes via `registerScenes`. Tests can register fixtures the same
+// way without touching JSON files on disk.
+// ---------------------------------------------------------------------------
+
+const SCENE_REGISTRY = new Map<string, NarrativeScene>();
+
+export function registerScenes(scenes: NarrativeScene[]): void {
+  for (const scene of scenes) {
+    SCENE_REGISTRY.set(scene.id, scene);
+  }
+}
+
+export function clearSceneRegistry(): void {
+  SCENE_REGISTRY.clear();
+}
+
+export function loadScene(id: string): NarrativeScene | null {
+  return SCENE_REGISTRY.get(id) ?? null;
+}
+
+export function listRegisteredScenes(): NarrativeScene[] {
+  return Array.from(SCENE_REGISTRY.values());
+}
+
+// ---------------------------------------------------------------------------
+// Availability & gating
+// ---------------------------------------------------------------------------
+
+export function isSceneAvailable(scene: NarrativeScene, ctx: NarrativeContext): boolean {
+  if (scene.allowedRoles?.length && (!ctx.roleId || !scene.allowedRoles.includes(ctx.roleId))) {
+    return false;
+  }
+  if (scene.requiresFlags?.length) {
+    for (const flag of scene.requiresFlags) {
+      if (!ctx.flags.has(flag)) return false;
+    }
+  }
+  return true;
+}
+
+export function evaluateChoice(choice: NarrativeChoice, ctx: NarrativeContext): ChoiceAvailability {
+  const req = choice.requires;
+  if (!req) return { available: true };
+
+  if (req.flag && !ctx.flags.has(req.flag)) {
+    return { available: false, reason: 'flag', detail: req.flag };
+  }
+  if (req.stat && req.min != null) {
+    const value = ctx.stats?.[req.stat];
+    if (value == null || value < req.min) {
+      return {
+        available: false,
+        reason: 'stat',
+        detail: `Serve ${req.stat} ≥ ${req.min}`,
+      };
+    }
+  }
+  return { available: true };
+}
+
+export function getAvailableChoices(scene: NarrativeScene, ctx: NarrativeContext): NarrativeChoice[] {
+  return scene.choices.filter(choice => evaluateChoice(choice, ctx).available);
+}
+
+// ---------------------------------------------------------------------------
+// Run state mutations
+// ---------------------------------------------------------------------------
+
+export function createRunState(startSceneId: string): NarrativeRunState {
+  return { currentSceneId: startSceneId, history: [], flags: new Set() };
+}
+
+export type ApplyChoiceResult = {
+  state: NarrativeRunState;
+  outcome: NarrativeOutcome;
+  finished: boolean;
+};
+
+export function applyChoice(
+  state: NarrativeRunState,
+  scene: NarrativeScene,
+  choiceId: string,
+  ctx: NarrativeContext,
+  now: () => string = () => new Date().toISOString(),
+): ApplyChoiceResult {
+  if (scene.id !== state.currentSceneId) {
+    throw new Error(`Scene mismatch: state at ${state.currentSceneId}, got scene ${scene.id}`);
+  }
+  const choice = scene.choices.find(c => c.id === choiceId);
+  if (!choice) {
+    throw new Error(`Choice "${choiceId}" not found in scene "${scene.id}"`);
+  }
+  const availability = evaluateChoice(choice, ctx);
+  if (!availability.available) {
+    throw new Error(`Choice "${choiceId}" not available: ${availability.reason}${availability.detail ? ` (${availability.detail})` : ''}`);
+  }
+
+  const nextFlags = new Set(state.flags);
+  for (const flag of choice.outcome.setFlags ?? []) nextFlags.add(flag);
+
+  const next = choice.outcome.next ?? null;
+  const finished = next === null;
+
+  const nextState: NarrativeRunState = {
+    currentSceneId: finished ? state.currentSceneId : next,
+    history: [...state.history, { sceneId: scene.id, choiceId, ts: now() }],
+    flags: nextFlags,
+  };
+
+  return { state: nextState, outcome: choice.outcome, finished };
+}
+
+// ---------------------------------------------------------------------------
+// Validation (lightweight, runtime-only — no zod dependency)
+// ---------------------------------------------------------------------------
+
+export type ValidationError = { path: string; message: string };
+
+export function validateScene(scene: unknown): ValidationError[] {
+  const errors: ValidationError[] = [];
+  if (!scene || typeof scene !== 'object') {
+    return [{ path: '$', message: 'scene must be an object' }];
+  }
+  const s = scene as Record<string, unknown>;
+
+  for (const field of ['id', 'title', 'setting', 'prompt'] as const) {
+    if (typeof s[field] !== 'string' || !(s[field] as string).length) {
+      errors.push({ path: `$.${field}`, message: `${field} must be a non-empty string` });
+    }
+  }
+
+  if (!Array.isArray(s.choices) || s.choices.length < 2 || s.choices.length > 4) {
+    errors.push({ path: '$.choices', message: 'choices must be an array of 2-4 elements' });
+  } else {
+    const ids = new Set<string>();
+    s.choices.forEach((choice, idx) => {
+      const c = choice as Record<string, unknown>;
+      if (typeof c.id !== 'string' || !c.id.length) {
+        errors.push({ path: `$.choices[${idx}].id`, message: 'id required' });
+      } else if (ids.has(c.id)) {
+        errors.push({ path: `$.choices[${idx}].id`, message: `duplicate choice id "${c.id}"` });
+      } else {
+        ids.add(c.id);
+      }
+      if (typeof c.label !== 'string' || !c.label.length) {
+        errors.push({ path: `$.choices[${idx}].label`, message: 'label required' });
+      }
+      if (!c.outcome || typeof c.outcome !== 'object') {
+        errors.push({ path: `$.choices[${idx}].outcome`, message: 'outcome required' });
+      } else {
+        const o = c.outcome as Record<string, unknown>;
+        if (typeof o.text !== 'string' || !o.text.length) {
+          errors.push({ path: `$.choices[${idx}].outcome.text`, message: 'outcome.text required' });
+        }
+        if (!o.rewards || typeof o.rewards !== 'object') {
+          errors.push({ path: `$.choices[${idx}].outcome.rewards`, message: 'outcome.rewards required' });
+        }
+        if (o.next !== undefined && o.next !== null && typeof o.next !== 'string') {
+          errors.push({ path: `$.choices[${idx}].outcome.next`, message: 'next must be string|null' });
+        }
+      }
+    });
+  }
+
+  return errors;
+}
+
+export function assertValidScene(scene: unknown): asserts scene is NarrativeScene {
+  const errors = validateScene(scene);
+  if (errors.length) {
+    throw new Error(
+      `Invalid narrative scene:\n` + errors.map(e => `  ${e.path}: ${e.message}`).join('\n'),
+    );
+  }
+}

--- a/apps/mobile/src/hooks/useNavigation.ts
+++ b/apps/mobile/src/hooks/useNavigation.ts
@@ -14,6 +14,7 @@ const VALID_SCREENS = new Set<Screen>([
     'account-settings', 'support', 'change-password', 'career',
     'terms', 'privacy', 'earned-titles',
     'ticket-qr-prototype',
+    'narrative-scene',
 ]);
 
 const VALID_TABS = new Set<Tab>(['home', 'turns', 'leaderboard', 'activities', 'shop', 'profile']);
@@ -23,7 +24,7 @@ const VALID_LEGAL_RETURN_SCREENS = new Set<LegalReturnScreen>([
     'welcome', 'login', 'signup', 'role-selection', 'home', 'turns',
     'qr-scanner', 'event-confirmation', 'activities', 'shop', 'activity-detail', 'activity-minigame', 'activity-result',
     'profile', 'account-settings', 'support', 'change-password',
-    'career', 'earned-titles', 'ticket-qr-prototype',
+    'career', 'earned-titles', 'ticket-qr-prototype', 'narrative-scene',
 ]);
 
 type UseNavigationOptions = {
@@ -49,6 +50,7 @@ function readNavState(): PersistedNavState | null {
             legalReturnScreen: parsed.legalReturnScreen,
             scannedEventId: typeof parsed.scannedEventId === 'string' ? parsed.scannedEventId : '',
             selectedActivityId: typeof parsed.selectedActivityId === 'string' ? parsed.selectedActivityId : '',
+            currentNarrativeSceneId: typeof parsed.currentNarrativeSceneId === 'string' ? parsed.currentNarrativeSceneId : '',
         };
     } catch {
         return null;
@@ -108,6 +110,7 @@ export function useNavigation(initialEvents: { id: string }[], options?: UseNavi
             nextScreen = 'activities';
         }
         if (nextScreen === 'event-confirmation' && !persisted.scannedEventId) nextScreen = 'activities';
+        if (nextScreen === 'narrative-scene' && !persisted.currentNarrativeSceneId) nextScreen = 'activities';
 
         nextScreen = getScreenToPersist(nextScreen, nextTab);
         if (isScreenEnabled && !isScreenEnabled(nextScreen)) {
@@ -122,6 +125,7 @@ export function useNavigation(initialEvents: { id: string }[], options?: UseNavi
                 legalReturnScreen: 'welcome' as const,
                 scannedEventId: '',
                 selectedActivityId: '',
+                currentNarrativeSceneId: '',
             };
         }
 
@@ -143,6 +147,7 @@ export function useNavigation(initialEvents: { id: string }[], options?: UseNavi
     const [activeTab, setActiveTab] = useState<Tab>(() => persistedNavState?.activeTab ?? 'home');
     const [scannedEventId, setScannedEventId] = useState<string>(() => persistedNavState?.scannedEventId ?? initialEvents[0]?.id ?? '');
     const [selectedActivityId, setSelectedActivityId] = useState<string>(() => persistedNavState?.selectedActivityId ?? '');
+    const [currentNarrativeSceneId, setCurrentNarrativeSceneId] = useState<string>(() => persistedNavState?.currentNarrativeSceneId ?? '');
 
     const currentScreenRef = useRef(currentScreen);
     useEffect(() => { currentScreenRef.current = currentScreen; }, [currentScreen]);
@@ -179,8 +184,9 @@ export function useNavigation(initialEvents: { id: string }[], options?: UseNavi
             legalReturnScreen,
             scannedEventId,
             selectedActivityId,
+            currentNarrativeSceneId,
         });
-    }, [activeTab, currentScreen, isScreenEnabled, isTabEnabled, legalReturnScreen, scannedEventId, selectedActivityId]);
+    }, [activeTab, currentScreen, isScreenEnabled, isTabEnabled, legalReturnScreen, scannedEventId, selectedActivityId, currentNarrativeSceneId]);
 
     const handleTabChange = (tab: Tab) => {
         const nextTab = isTabEnabled && !isTabEnabled(tab) ? resolveFallbackTab(isTabEnabled) : tab;
@@ -203,5 +209,7 @@ export function useNavigation(initialEvents: { id: string }[], options?: UseNavi
         setScannedEventId,
         selectedActivityId,
         setSelectedActivityId,
+        currentNarrativeSceneId,
+        setCurrentNarrativeSceneId,
     };
 }

--- a/apps/mobile/src/router/NavigatorContext.tsx
+++ b/apps/mobile/src/router/NavigatorContext.tsx
@@ -10,6 +10,7 @@ interface NavigatorContextValue {
   isPasswordRecovery: boolean;
   scannedEventId: string;
   selectedActivityId: string;
+  currentNarrativeSceneId: string;
 
   // Navigation actions
   navigate: (screen: Screen) => void;
@@ -23,6 +24,7 @@ interface NavigatorContextValue {
   setIsPasswordRecovery: (value: boolean) => void;
   setScannedEventId: (id: string) => void;
   setSelectedActivityId: (id: string) => void;
+  setCurrentNarrativeSceneId: (id: string) => void;
   setLegalReturnScreen: (screen: LegalReturnScreen) => void;
 
   // Refs
@@ -51,6 +53,7 @@ const SCREENS_WITH_BACK: Partial<Record<Screen, Screen>> = {
   'event-details': 'home',
   'activity-detail': 'activities',
   'activity-minigame': 'activity-detail',
+  'narrative-scene': 'activities',
   'public-profile': 'leaderboard',
   'ticket-qr-prototype': 'account-settings',
 };
@@ -69,6 +72,7 @@ export function NavigatorProvider({
     isPasswordRecovery, setIsPasswordRecovery,
     scannedEventId, setScannedEventId,
     selectedActivityId, setSelectedActivityId,
+    currentNarrativeSceneId, setCurrentNarrativeSceneId,
   } = useNavigation(initialEvents, { isScreenEnabled, isTabEnabled });
 
   const navigate = useCallback((screen: Screen) => {
@@ -108,6 +112,7 @@ export function NavigatorProvider({
     isPasswordRecovery,
     scannedEventId,
     selectedActivityId,
+    currentNarrativeSceneId,
     navigate,
     switchTab,
     goBack,
@@ -115,6 +120,7 @@ export function NavigatorProvider({
     setIsPasswordRecovery,
     setScannedEventId,
     setSelectedActivityId,
+    setCurrentNarrativeSceneId,
     setLegalReturnScreen,
     screenRef: currentScreenRef,
   };

--- a/apps/mobile/src/router/routes.ts
+++ b/apps/mobile/src/router/routes.ts
@@ -41,6 +41,7 @@ export const routes: RouteConfig[] = [
   { screen: 'activity-detail', layout: 'fullscreen', showBottomNav: false, requiresAuth: true },
   { screen: 'activity-minigame', layout: 'fullscreen', showBottomNav: false, requiresAuth: true },
   { screen: 'activity-result', layout: 'fullscreen', showBottomNav: false, requiresAuth: true },
+  { screen: 'narrative-scene', layout: 'fullscreen', showBottomNav: false, requiresAuth: true },
   { screen: 'account-settings', layout: 'fullscreen', showBottomNav: false, requiresAuth: true },
   { screen: 'support', layout: 'fullscreen', showBottomNav: false, requiresAuth: true },
   { screen: 'change-password', layout: 'fullscreen', showBottomNav: false, requiresAuth: true },

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -139,6 +139,17 @@ export type CompleteActivityResult =
     slotsTotal?: number;
   };
 
+export type CompleteNarrativeChoiceInput = {
+  sceneId: string;
+  choiceId: string;
+  rewards: Partial<Rewards>;
+  setFlags?: string[];
+};
+
+export type CompleteNarrativeChoiceResult =
+  | { ok: true; rewards: Rewards }
+  | { ok: false; error: string };
+
 export type ShopPurchaseResult =
   | {
     ok: true;
@@ -2194,6 +2205,7 @@ type GameContextValue = {
     activityId: string,
     telemetry?: ActivityTelemetryInput
   ) => Promise<CompleteActivityResult>;
+  completeNarrativeChoice: (input: CompleteNarrativeChoiceInput) => Promise<CompleteNarrativeChoiceResult>;
   resetProgress: () => Promise<void>;
   /** GDPR Art. 17 – elimina account e tutti i dati dal server e dal dispositivo. */
   deleteAccount: () => Promise<void>;
@@ -4561,6 +4573,51 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     [authUserId, catalog.activities, featureFlags, refreshBadges]
   );
 
+  // Issue #328 — narrative scene choice completion.
+  // The scene + choice are validated and resolved by the UI layer (see
+  // NarrativeScene.tsx) using the engine in `gameplay/narrative.ts`. This
+  // function is the persistence/state-mutation half: it applies rewards
+  // locally and best-effort logs the choice into `narrative_history`.
+  const completeNarrativeChoice = useCallback(
+    async (input: CompleteNarrativeChoiceInput): Promise<CompleteNarrativeChoiceResult> => {
+      const rewards: Rewards = {
+        xp: Math.max(0, Math.round(input.rewards.xp ?? 0)),
+        cachet: Math.max(0, Math.round(input.rewards.cachet ?? 0)),
+        reputation: Math.max(0, Math.round(input.rewards.reputation ?? 0)),
+      };
+
+      // 1. Apply rewards locally — visible immediately in Home/profile.
+      setState((prev: GameState) => ({
+        ...prev,
+        profile: applyRewards(prev.profile, rewards, 'activity'),
+      }));
+
+      // 2. Persist to narrative_history (append-only, RLS-scoped to user).
+      // Best-effort: a failed insert does not roll back local rewards. Without
+      // a server-side reward authority for narrative scenes, retrying client
+      // rewards on offline replay would risk double-credit. Tracked separately.
+      if (isSupabaseConfigured && supabase && authUserId) {
+        try {
+          const { error } = await supabase.from('narrative_history').insert({
+            user_id: authUserId,
+            scene_id: input.sceneId,
+            choice_id: input.choiceId,
+            rewards,
+            flags_set: input.setFlags ?? [],
+          });
+          if (error) {
+            logOfflineSync('narrative_history insert failed', { error: formatSyncError(error) }, 'warn');
+          }
+        } catch (error) {
+          logOfflineSync('narrative_history insert threw', { error: formatSyncError(error) }, 'warn');
+        }
+      }
+
+      return { ok: true, rewards };
+    },
+    [authUserId]
+  );
+
   const resetProgress = useCallback(async () => {
     logOfflineSync('Action resetProgress');
     await withMobileWatchdog(
@@ -4878,6 +4935,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       turnSyncFeedback,
       clearTurnSyncFeedback,
       completeActivity,
+      completeNarrativeChoice,
       resetProgress,
       deleteAccount,
       exportUserData,
@@ -4930,6 +4988,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       turnSyncFeedback,
       clearTurnSyncFeedback,
       completeActivity,
+      completeNarrativeChoice,
       resetProgress,
       deleteAccount,
       exportUserData,

--- a/apps/mobile/src/test/narrative-engine.test.ts
+++ b/apps/mobile/src/test/narrative-engine.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  applyChoice,
+  assertValidScene,
+  clearSceneRegistry,
+  createRunState,
+  evaluateChoice,
+  getAvailableChoices,
+  isSceneAvailable,
+  loadScene,
+  registerScenes,
+  validateScene,
+  type NarrativeContext,
+  type NarrativeScene,
+} from '../gameplay/narrative';
+
+const fixtureScene = (overrides: Partial<NarrativeScene> = {}): NarrativeScene => ({
+  id: 'test_scene',
+  title: 'Test',
+  setting: 'Backstage',
+  prompt: 'Cosa fai?',
+  choices: [
+    { id: 'safe', label: 'Sicuro', outcome: { text: 'ok', rewards: { xp: 10 }, next: null } },
+    {
+      id: 'risky',
+      label: 'Rischioso',
+      requires: { stat: 'precision', min: 80 },
+      outcome: { text: 'wow', rewards: { xp: 30 }, next: null },
+    },
+  ],
+  ...overrides,
+});
+
+const ctx = (over: Partial<NarrativeContext> = {}): NarrativeContext => ({
+  roleId: 'attore',
+  stats: { presence: 90, precision: 70, leadership: 60, creativity: 85 },
+  flags: new Set(),
+  ...over,
+});
+
+afterEach(() => clearSceneRegistry());
+
+describe('narrative engine — registry', () => {
+  it('registers and loads scenes by id', () => {
+    const scene = fixtureScene();
+    registerScenes([scene]);
+    expect(loadScene('test_scene')).toEqual(scene);
+    expect(loadScene('missing')).toBeNull();
+  });
+
+  it('overwrites scenes with the same id on re-register', () => {
+    registerScenes([fixtureScene({ title: 'A' })]);
+    registerScenes([fixtureScene({ title: 'B' })]);
+    expect(loadScene('test_scene')?.title).toBe('B');
+  });
+});
+
+describe('narrative engine — gating', () => {
+  it('allows scene when no role/flag restriction is set', () => {
+    expect(isSceneAvailable(fixtureScene(), ctx())).toBe(true);
+  });
+
+  it('blocks scene when role is not in allowedRoles', () => {
+    const scene = fixtureScene({ allowedRoles: ['fonico'] });
+    expect(isSceneAvailable(scene, ctx({ roleId: 'attore' }))).toBe(false);
+    expect(isSceneAvailable(scene, ctx({ roleId: 'fonico' }))).toBe(true);
+  });
+
+  it('blocks scene when required flags are missing', () => {
+    const scene = fixtureScene({ requiresFlags: ['met_director'] });
+    expect(isSceneAvailable(scene, ctx())).toBe(false);
+    expect(isSceneAvailable(scene, ctx({ flags: new Set(['met_director']) }))).toBe(true);
+  });
+});
+
+describe('narrative engine — choice availability', () => {
+  it('treats choices without requires as always available', () => {
+    const scene = fixtureScene();
+    expect(evaluateChoice(scene.choices[0], ctx())).toEqual({ available: true });
+  });
+
+  it('blocks a choice when stat is below min', () => {
+    const scene = fixtureScene();
+    const result = evaluateChoice(scene.choices[1], ctx({ stats: { presence: 90, precision: 70, leadership: 60, creativity: 85 } }));
+    expect(result.available).toBe(false);
+    if (!result.available) {
+      expect(result.reason).toBe('stat');
+      expect(result.detail).toContain('precision');
+    }
+  });
+
+  it('unblocks a stat-gated choice when stat meets the threshold', () => {
+    const scene = fixtureScene();
+    const high = ctx({ stats: { presence: 50, precision: 90, leadership: 60, creativity: 50 } });
+    expect(evaluateChoice(scene.choices[1], high)).toEqual({ available: true });
+  });
+
+  it('blocks a flag-gated choice when flag is missing', () => {
+    const scene = fixtureScene({
+      choices: [
+        { id: 'safe', label: 'A', outcome: { text: '', rewards: {}, next: null } },
+        { id: 'gated', label: 'B', requires: { flag: 'has_key' }, outcome: { text: '', rewards: {}, next: null } },
+      ],
+    });
+    const result = evaluateChoice(scene.choices[1], ctx());
+    expect(result.available).toBe(false);
+    if (!result.available) expect(result.reason).toBe('flag');
+  });
+
+  it('getAvailableChoices filters out blocked ones', () => {
+    const scene = fixtureScene();
+    const choices = getAvailableChoices(scene, ctx());
+    expect(choices.map(c => c.id)).toEqual(['safe']);
+  });
+});
+
+describe('narrative engine — applyChoice', () => {
+  const fixedNow = () => '2026-04-29T10:00:00.000Z';
+
+  it('records choice in history with timestamp and returns outcome', () => {
+    const scene = fixtureScene();
+    const state = createRunState(scene.id);
+    const result = applyChoice(state, scene, 'safe', ctx(), fixedNow);
+    expect(result.outcome.rewards.xp).toBe(10);
+    expect(result.finished).toBe(true);
+    expect(result.state.history).toEqual([{ sceneId: 'test_scene', choiceId: 'safe', ts: fixedNow() }]);
+  });
+
+  it('does not mutate input state (immutability)', () => {
+    const scene = fixtureScene();
+    const state = createRunState(scene.id);
+    applyChoice(state, scene, 'safe', ctx(), fixedNow);
+    expect(state.history).toEqual([]);
+    expect(state.flags.size).toBe(0);
+  });
+
+  it('sets flags from the chosen outcome', () => {
+    const scene = fixtureScene({
+      choices: [
+        { id: 'pick', label: 'A', outcome: { text: '', rewards: {}, setFlags: ['met_director'], next: null } },
+        { id: 'other', label: 'B', outcome: { text: '', rewards: {}, next: null } },
+      ],
+    });
+    const result = applyChoice(createRunState(scene.id), scene, 'pick', ctx(), fixedNow);
+    expect(result.state.flags.has('met_director')).toBe(true);
+  });
+
+  it('transitions to next scene when outcome.next is a string', () => {
+    const scene = fixtureScene({
+      id: 'first',
+      choices: [
+        { id: 'go', label: 'Avanti', outcome: { text: '', rewards: {}, next: 'second' } },
+        { id: 'stay', label: 'Ferma', outcome: { text: '', rewards: {}, next: null } },
+      ],
+    });
+    const result = applyChoice(createRunState('first'), scene, 'go', ctx(), fixedNow);
+    expect(result.finished).toBe(false);
+    expect(result.state.currentSceneId).toBe('second');
+  });
+
+  it('throws when choice id does not exist', () => {
+    const scene = fixtureScene();
+    expect(() => applyChoice(createRunState(scene.id), scene, 'bogus', ctx(), fixedNow)).toThrow(/not found/);
+  });
+
+  it('throws when choice is unavailable for the player context', () => {
+    const scene = fixtureScene();
+    expect(() => applyChoice(createRunState(scene.id), scene, 'risky', ctx(), fixedNow)).toThrow(/not available/);
+  });
+
+  it('throws when state is at a different scene than the one passed', () => {
+    const scene = fixtureScene({ id: 'scene_b' });
+    const state = createRunState('scene_a');
+    expect(() => applyChoice(state, scene, 'safe', ctx(), fixedNow)).toThrow(/Scene mismatch/);
+  });
+});
+
+describe('narrative engine — registry integration', () => {
+  it('loads debug_intro scene from the data registry', async () => {
+    clearSceneRegistry();
+    const { initNarrativeRegistry } = await import('../data/narrative');
+    initNarrativeRegistry();
+    const scene = loadScene('debug_intro');
+    expect(scene).not.toBeNull();
+    expect(scene?.choices.length).toBeGreaterThanOrEqual(2);
+    expect(scene?.choices.length).toBeLessThanOrEqual(4);
+  });
+});
+
+describe('narrative engine — schema validation', () => {
+  it('accepts a valid scene', () => {
+    expect(validateScene(fixtureScene())).toEqual([]);
+    expect(() => assertValidScene(fixtureScene())).not.toThrow();
+  });
+
+  it('rejects a scene with fewer than 2 choices', () => {
+    const errors = validateScene({
+      ...fixtureScene(),
+      choices: [{ id: 'only', label: 'X', outcome: { text: 't', rewards: {}, next: null } }],
+    });
+    expect(errors.some(e => e.path === '$.choices')).toBe(true);
+  });
+
+  it('rejects a scene with duplicate choice ids', () => {
+    const errors = validateScene({
+      ...fixtureScene(),
+      choices: [
+        { id: 'dup', label: 'A', outcome: { text: 't', rewards: {}, next: null } },
+        { id: 'dup', label: 'B', outcome: { text: 't', rewards: {}, next: null } },
+      ],
+    });
+    expect(errors.some(e => e.message.includes('duplicate'))).toBe(true);
+  });
+
+  it('rejects a scene with missing outcome.text', () => {
+    const errors = validateScene({
+      ...fixtureScene(),
+      choices: [
+        { id: 'a', label: 'A', outcome: { rewards: {}, next: null } },
+        { id: 'b', label: 'B', outcome: { text: 't', rewards: {}, next: null } },
+      ],
+    });
+    expect(errors.some(e => e.path.includes('outcome.text'))).toBe(true);
+  });
+
+  it('assertValidScene throws on invalid input', () => {
+    expect(() => assertValidScene({ id: '' })).toThrow(/Invalid narrative scene/);
+  });
+});

--- a/apps/mobile/src/types/navigation.ts
+++ b/apps/mobile/src/types/navigation.ts
@@ -16,6 +16,7 @@ export type Screen =
     | 'activity-detail'
     | 'activity-minigame'
     | 'activity-result'
+    | 'narrative-scene'
     | 'profile'
     | 'public-profile'
     | 'account-settings'
@@ -38,4 +39,5 @@ export type PersistedNavState = {
     legalReturnScreen: LegalReturnScreen;
     scannedEventId: string;
     selectedActivityId: string;
+    currentNarrativeSceneId: string;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6455,7 +6455,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -46,10 +46,11 @@
     "ajv": "^8.18.0",
     "dotenv": "^16.3.1"
   },
-  "//overrides": "Security pins driven by Dependabot advisories. minimatch ^10.2.3 and rollup ^4.59.0 added in 3633dee (Feb 27 2026). picomatch 4.0.4 pinned in 97cf1b3 (Mar 26 2026) for CVE-2026-33672. All three are still consumed by transitive deps (eslint, vite, vitest, typescript-eslint) — do not remove without re-running npm audit.",
+  "//overrides": "Security pins driven by Dependabot advisories. minimatch ^10.2.3 and rollup ^4.59.0 added in 3633dee (Feb 27 2026). picomatch 4.0.4 pinned in 97cf1b3 (Mar 26 2026) for CVE-2026-33672. postcss >=8.5.10 pinned for GHSA-qx2v-qp2m-jg93 (XSS via unescaped </style>, Apr 30 2026). All are consumed by transitive deps — do not remove without re-running npm audit.",
   "overrides": {
     "minimatch": "^10.2.3",
     "picomatch": "4.0.4",
-    "rollup": "^4.59.0"
+    "rollup": "^4.59.0",
+    "postcss": ">=8.5.10"
   }
 }

--- a/supabase/migrations/20260429120000_narrative_history.sql
+++ b/supabase/migrations/20260429120000_narrative_history.sql
@@ -1,0 +1,40 @@
+-- Issue #328 — Narrative history.
+-- Persistent log of player choices in narrative scenes. Used for analytics and
+-- to gate future scenes that depend on prior decisions.
+
+create table if not exists public.narrative_history (
+  id           bigserial primary key,
+  user_id      uuid not null references auth.users(id) on delete cascade,
+  scene_id     text not null,
+  choice_id    text not null,
+  rewards      jsonb not null default '{}'::jsonb,
+  flags_set    text[] not null default '{}',
+  created_at   timestamptz not null default now()
+);
+
+create index if not exists narrative_history_user_idx
+  on public.narrative_history (user_id, created_at desc);
+
+create index if not exists narrative_history_scene_idx
+  on public.narrative_history (scene_id);
+
+-- Enable + force RLS so the table owner cannot bypass policies.
+alter table public.narrative_history enable row level security;
+alter table public.narrative_history force row level security;
+
+drop policy if exists "narrative_history select own" on public.narrative_history;
+create policy "narrative_history select own"
+on public.narrative_history
+for select
+to authenticated
+using (user_id = auth.uid());
+
+drop policy if exists "narrative_history insert own" on public.narrative_history;
+create policy "narrative_history insert own"
+on public.narrative_history
+for insert
+to authenticated
+with check (user_id = auth.uid());
+
+-- No update / delete policies: history is append-only by design. GDPR Art. 17
+-- erasure is covered by the on-delete cascade from auth.users.


### PR DESCRIPTION
## Summary

Implements a pure narrative engine (issue #328) for branching dialogue scenes with player choice gating, rewards, and persistent history. Includes a React UI component, schema validation, comprehensive tests, and a sample scene.

## Key Changes

- **Narrative Engine** (`apps/mobile/src/gameplay/narrative.ts`):
  - Pure TypeScript engine decoupled from React/DOM
  - Scene registry system for loading and validating narrative scenes
  - Choice availability evaluation based on player stats, flags, and role restrictions
  - Run state management with immutable choice application
  - Lightweight runtime schema validation (no external dependencies)

- **React UI Component** (`apps/mobile/src/components/screens/NarrativeScene.tsx`):
  - Full-screen scene display with choice buttons
  - Real-time choice availability feedback (shows stat requirements when blocked)
  - Outcome display with reward summary
  - Integration with game state for reward application and persistence

- **State Management** (`apps/mobile/src/state/store.tsx`):
  - New `completeNarrativeChoice` action for persisting choices and applying rewards
  - Best-effort append-only logging to `narrative_history` table
  - Immediate local reward application (XP, cachet, reputation)

- **Database** (`supabase/migrations/20260429120000_narrative_history.sql`):
  - New `narrative_history` table with RLS policies (user-scoped, append-only)
  - Indexes on user_id and scene_id for analytics queries
  - GDPR Art. 17 compliance via cascade delete

- **Scene Data** (`apps/mobile/src/data/narrative/`):
  - Registry system with auto-validation on module load
  - Sample scene `debug_intro.json` demonstrating stat gating and flag setting
  - Comprehensive authoring guide (`scenes/README.md`) with schema, constraints, and writing tips

- **Navigation & Routing**:
  - New `narrative-scene` screen type
  - Navigation context support for scene ID passing
  - Integration into AppShell with lazy loading

- **Tests** (`apps/mobile/src/test/narrative-engine.test.ts`):
  - 20+ test cases covering registry, gating, choice evaluation, state mutations, and validation
  - Fixtures for rapid test authoring
  - Integration test loading real scenes from registry

## Notable Implementation Details

- **Immutability**: `applyChoice` returns new state without mutating input
- **Decoupling**: Engine validates and resolves choices; UI layer handles submission and state updates
- **Gating Layers**: Role restrictions (scene-level), flag requirements (scene/choice-level), stat thresholds (choice-level)
- **Validation**: Runtime schema validation with detailed error paths; invalid scenes throw immediately in dev/build
- **Offline Safety**: Rewards applied locally before persistence attempt; failed inserts don't roll back local state
- **Extensibility**: Scene registry allows tests and future data sources to register fixtures without touching JSON files

https://claude.ai/code/session_012cKNkiMTHjiZ8vrbkUzxYp