### PR TITLE
fix: race condition in updateProfile — move persistProfile inside setState updater (closes #925)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4068,21 +4068,18 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
   const updateProfile = useCallback(
     (updates: Partial<Pick<PlayerProfile, 'name' | 'email' | 'roleId' | 'profileImage' | 'leaderboardVisible'>>) => {
-      let nextProfile: PlayerProfile | null = null;
       setState((prev: GameState) => {
         const nextRole =
           updates.roleId && catalog.roles.some((role: Role) => role.id === updates.roleId)
             ? updates.roleId
             : prev.profile.roleId;
-        nextProfile = { ...prev.profile, ...updates, roleId: nextRole ?? prev.profile.roleId };
+        const nextProfile: PlayerProfile = { ...prev.profile, ...updates, roleId: nextRole ?? prev.profile.roleId };
+        persistProfile(nextProfile);
         return {
           ...prev,
           profile: nextProfile,
         };
       });
-      if (nextProfile) {
-        persistProfile(nextProfile);
-      }
     },
     [catalog.roles, persistProfile]
   );


### PR DESCRIPTION
## Summary
- `nextProfile` was assigned inside the `setState` updater but read synchronously outside it. In React 18 concurrent mode the updater may be deferred, so `persistProfile` could be called with `null`.
- Moved `persistProfile(nextProfile)` inside the `setState` updater callback so it is guaranteed to execute with the correct value.

## Test plan
- [ ] Update profile (name, role, etc.) and verify remote sync is triggered correctly
- [ ] No regressions in profile update UI flow

Closes #925

https://claude.ai/code/session_0165Sg2EyxLqnFzpMZBjSspa

---
_Generated by [Claude Code](https://claude.ai/code/session_0165Sg2EyxLqnFzpMZBjSspa)_