### PR TITLE
fix: guard fallback DB query error in ticket-activation Edge Function (closes #926)

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -280,11 +280,16 @@ serve(async (req: Request) => {
       }
 
       // 3. Check current status if update failed
-      const { data: current } = await supabase
+      const { data: current, error } = await supabase
         .from('ticket_activations')
         .select('activated_by')
         .eq('hash', targetHash)
         .maybeSingle();
+
+      if (error) {
+        console.error('[ticket-activation] fallback select error:', error);
+        return jsonResponse({ error: 'Activation failed' }, 500);
+      }
 
       if (!current) {
         return jsonResponse({ ok: false, error: 'Ticket non trovato.' }, 200);


### PR DESCRIPTION
## Summary
- The fallback `.select('activated_by')` query after a CAS update failure destructured `{ data: current }` but never checked `error`.
- A transient DB failure would leave `current` undefined and return "ticket not found" instead of a 500, creating a TOCTOU window.
- Added `if (error) return jsonResponse({ error: 'Activation failed' }, 500)` guard immediately after the destructure.

## Test plan
- [ ] Simulate a DB failure on the fallback select and verify a 500 is returned
- [ ] Normal double-activation still returns `alreadyActivated: true`
- [ ] Normal first activation still succeeds

Closes #926

https://claude.ai/code/session_0165Sg2EyxLqnFzpMZBjSspa

---
_Generated by [Claude Code](https://claude.ai/code/session_0165Sg2EyxLqnFzpMZBjSspa)_