### PR TITLE
fix: early return on auth error in loadRemoteState to prevent ghost profile inserts (closes #927)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3697,6 +3697,11 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             ]);
           }
 
+          if (userRes.error) {
+            console.warn('[loadRemoteState] auth error, aborting profile load:', userRes.error);
+            return;
+          }
+
           let profileRow: DbProfileRow | null = profileRes.data as DbProfileRow | null;
 
           if (!profileRow && userRes.data?.user?.email) {


### PR DESCRIPTION
## Summary
- Errors from `Promise.all([userRes, profileRes, turnsRes])` were only logged via `notifyCriticalError`, but execution continued.
- The guard `if (!profileRow && userRes.data?.user?.email)` ignored `userRes.error`, so a profile insert could be attempted on an expired/invalid session, producing ghost rows.
- Added `if (userRes.error) { console.warn(...); return; }` immediately after the error notification block.

## Test plan
- [ ] Simulate expired auth session and verify no profile insert is attempted
- [ ] Normal login flow still inserts profile when missing
- [ ] Existing profile row still loaded correctly

Closes #927

https://claude.ai/code/session_0165Sg2EyxLqnFzpMZBjSspa

---
_Generated by [Claude Code](https://claude.ai/code/session_0165Sg2EyxLqnFzpMZBjSspa)_