### PR TITLE
fix: rename duplicate error binding in ticket-activation

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -280,14 +280,14 @@ serve(async (req: Request) => {
       }
 
       // 3. Check current status if update failed
-      const { data: current, error } = await supabase
+      const { data: current, error: fallbackError } = await supabase
         .from('ticket_activations')
         .select('activated_by')
         .eq('hash', targetHash)
         .maybeSingle();
 
-      if (error) {
-        console.error('[ticket-activation] fallback select error:', error);
+      if (fallbackError) {
+        console.error('[ticket-activation] fallback select error:', fallbackError);
         return jsonResponse({ error: 'Activation failed' }, 500);
       }
 


### PR DESCRIPTION
Renames the second `error` destructuring in the same try-block scope to `fallbackError` to resolve TS2300 duplicate identifier error that prevented the edge function from deploying.

Closes #933

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqvhHMsULuseHMhFqhD4RR)_