### PR TITLE
fix: move persistProfile out of setState updater in updateProfile

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4073,20 +4073,18 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
   const updateProfile = useCallback(
     (updates: Partial<Pick<PlayerProfile, 'name' | 'email' | 'roleId' | 'profileImage' | 'leaderboardVisible'>>) => {
-      setState((prev: GameState) => {
-        const nextRole =
-          updates.roleId && catalog.roles.some((role: Role) => role.id === updates.roleId)
-            ? updates.roleId
-            : prev.profile.roleId;
-        const nextProfile: PlayerProfile = { ...prev.profile, ...updates, roleId: nextRole ?? prev.profile.roleId };
-        persistProfile(nextProfile);
-        return {
-          ...prev,
-          profile: nextProfile,
-        };
-      });
+      const nextRole =
+        updates.roleId && catalog.roles.some((role: Role) => role.id === updates.roleId)
+          ? updates.roleId
+          : state.profile.roleId;
+      const nextProfile: PlayerProfile = { ...state.profile, ...updates, roleId: nextRole ?? state.profile.roleId };
+      setState((prev: GameState) => ({
+        ...prev,
+        profile: nextProfile,
+      }));
+      persistProfile(nextProfile);
     },
-    [catalog.roles, persistProfile]
+    [catalog.roles, persistProfile, state.profile]
   );
 
   const registerTurn = useCallback(


### PR DESCRIPTION
Closes #936

`persistProfile` (an async Supabase upsert) was being called inside the `setState` updater callback, violating React's requirement that updaters be pure functions. In React 18 Strict Mode this caused the upsert to fire twice per update.

The fix captures `nextProfile` outside the updater using the current `state.profile` from the closure, calls `setState` with a pure updater, then calls `persistProfile(nextProfile)` once after the state update.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnGsL7S4d75AaTEjy2Web4)_