### PR TITLE
fix: suppress SIGNED_IN navigation during changePassword verification

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { supabase, isSupabaseConfigured } from '../lib/supabase';
 import { resolveDisplayName } from '../lib/profile-utils';
-import { PlayerProfile } from '../state/store';
+import { PlayerProfile, suppressSignedInNavigation } from '../state/store';
 
 const getEmailPrefix = (value?: string) => value?.split('@')[0]?.trim() ?? '';
 
@@ -257,7 +257,13 @@ export function useAuth(
                 // Only navigate on an explicit sign-in transition.
                 // TOKEN_REFRESHED / USER_UPDATED / INITIAL_SESSION refresh
                 // the profile without interrupting the current screen.
-                const navigateTo = event === 'SIGNED_IN' ? 'home' : undefined;
+                // Skip navigation when the SIGNED_IN event comes from a
+                // credential-verification sign-in inside changePassword (flag
+                // set in store.tsx) to prevent spurious redirect to 'home'.
+                const navigateTo =
+                    event === 'SIGNED_IN' && !suppressSignedInNavigation
+                        ? 'home'
+                        : undefined;
                 applyUserProfileRef.current(session.user, {
                     navigateTo,
                 });

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -24,6 +24,18 @@ import {
   readEnvFeatureFlagOverrides,
 } from '../services/feature-flags';
 
+/**
+ * Set to `true` before a `signInWithPassword` call used only for credential
+ * verification (e.g. in `changePassword`). The `onAuthStateChange` listener
+ * in `useAuth.ts` checks this flag and skips the SIGNED_IN navigation while
+ * it is set, preventing the user from being redirected away mid-flow.
+ * Must be reset to `false` immediately after the verification attempt completes.
+ */
+export let suppressSignedInNavigation = false;
+export const setSuppressSignedInNavigation = (value: boolean) => {
+  suppressSignedInNavigation = value;
+};
+
 export const ROLE_IDS = ['attore', 'luci', 'fonico', 'attrezzista', 'palco', 'rspp', 'dramaturg'] as const;
 export type RoleId = (typeof ROLE_IDS)[number];
 export type Rewards = { xp: number; reputation: number; cachet: number };
@@ -4718,13 +4730,22 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             if (!email) {
               throw new Error('Email mancante');
             }
-            const { error: signInError } = await supabase.auth.signInWithPassword({
-              email,
-              password: currentPassword,
-            });
-            if (signInError) {
-              throw new Error('Password attuale non valida');
+            // Suppress the SIGNED_IN auth-state event that signInWithPassword
+            // emits: it would otherwise trigger navigation to 'home' via
+            // useAuth's onAuthStateChange listener before the password update
+            // even runs.
+            setSuppressSignedInNavigation(true);
+            let signInError: Error | null = null;
+            try {
+              const { error } = await supabase.auth.signInWithPassword({
+                email,
+                password: currentPassword,
+              });
+              if (error) signInError = new Error('Password attuale non valida');
+            } finally {
+              setSuppressSignedInNavigation(false);
             }
+            if (signInError) throw signInError;
           }
 
           const { error } = await supabase.auth.updateUser({ password: newPassword });


### PR DESCRIPTION
Closes #937

`changePassword` calls `signInWithPassword` to verify the current password. This emits a `SIGNED_IN` auth state change event, which the listener in `useAuth.ts` handles by navigating to `'home'` — aborting the password change flow before `updateUser` runs.

The fix adds a module-level `suppressSignedInNavigation` flag (exported from `store.tsx`). It is set to `true` immediately before the verification `signInWithPassword` call and cleared in a `finally` block. The `onAuthStateChange` handler in `useAuth.ts` now checks this flag and skips the navigation when it is set, allowing the change-password flow to complete normally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnGsL7S4d75AaTEjy2Web4)_