### PR TITLE
fix: guard loadRemoteState INSERT against transient profileRes.error

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3702,6 +3702,16 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             return;
           }
 
+          // If the profile SELECT itself errored (e.g. transient DB/network
+          // blip), profileRes.data is also null — but the profile likely exists.
+          // Attempting an INSERT in this case would trigger a PK conflict and
+          // surface a misleading "unable to create profile" critical error.
+          // Propagate the fetch error and bail out early instead.
+          if (profileRes.error) {
+            console.warn('[loadRemoteState] profile fetch error, aborting:', profileRes.error);
+            return;
+          }
+
           let profileRow: DbProfileRow | null = profileRes.data as DbProfileRow | null;
 
           if (!profileRow && userRes.data?.user?.email) {


### PR DESCRIPTION
Closes #938

When the profiles SELECT returned an error (e.g. transient DB/network blip), `profileRes.data` was also `null`. The existing `!profileRow` guard did not distinguish between "profile genuinely not found" and "profile fetch failed", so the code would proceed to INSERT a new profile — hitting a primary-key conflict and surfacing a misleading "unable to create profile" critical error to the user.

The fix adds an explicit `if (profileRes.error)` early-return before the INSERT guard. When the SELECT errors, we log a warning and return without attempting the INSERT, preventing the spurious critical error. The actual DB error is still captured by the existing `notifyCriticalError` call earlier in the function.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnGsL7S4d75AaTEjy2Web4)_