### PR TITLE
fix: add refreshLeaderboard to useEffect deps and catch rejection

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3583,8 +3583,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     refreshTurnStats();
     refreshTheatreReputation();
     refreshBadges();
-    refreshLeaderboard();
-  }, [authUserId, refreshBadges, refreshTheatreReputation, refreshTurnStats]);
+    refreshLeaderboard().catch(console.error);
+  }, [authUserId, refreshBadges, refreshLeaderboard, refreshTheatreReputation, refreshTurnStats]);
 
   useEffect(() => {
     if (isSupabaseConfigured && supabase && authUserId) return;


### PR DESCRIPTION
Closes #943

Adds `refreshLeaderboard` to the `useEffect` dependency array so the effect re-runs when the callback reference changes, preventing stale-closure bugs. Also attaches `.catch(console.error)` to handle any promise rejection from the underlying fetch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gyto5KkZycpAWCwepKK7YQ)_