### PR TITLE
fix: recheck isMounted before refreshEventPlanning in loadCatalog

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3668,6 +3668,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             events: nextEvents,
             activities: nextActivities,
           });
+          if (!isMounted) return;
           await refreshEventPlanning(nextEvents);
         },
         {


### PR DESCRIPTION
Closes #944

Adds a second `isMounted` guard between `setCatalog` and `await refreshEventPlanning(nextEvents)` in the `loadCatalog` watchdog. This prevents state updates from being dispatched to an unmounted component when the user navigates away while the catalog is still loading.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gyto5KkZycpAWCwepKK7YQ)_