### PR TITLE
fix: return 502 instead of raw GitHub status on API error in app-version

### DIFF
--- a/supabase/functions/app-version/index.ts
+++ b/supabase/functions/app-version/index.ts
@@ -92,7 +92,8 @@ serve(async (req) => {
     return errorResponse('Impossibile caricare il changelog', 502);
   }
   if (!response.ok) {
-    return errorResponse('Impossibile caricare il changelog', response.status);
+    console.error('[app-version] GitHub API error', response.status, response.statusText);
+    return errorResponse('Impossibile caricare il changelog', 502);
   }
 
   let json: any[] = [];


### PR DESCRIPTION
Closes #945

Replaces `response.status` with a fixed `502` when the GitHub API returns a non-2xx response, preventing the upstream HTTP code (e.g. 403, 404) from being forwarded to clients. The original status and status text are now logged server-side via `console.error` for observability.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gyto5KkZycpAWCwepKK7YQ)_