### PR TITLE
fix: remove redundant in-memory filter in cleanup-events

### DIFF
--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -85,10 +85,7 @@ serve(async (req) => {
       event_date: string;
     }
 
-    const eventsToDelete = (events as Event[] || []).filter((event: Event) => {
-      if (!event?.event_date) return false
-      return event.event_date < cutoffDateStr
-    })
+    const eventsToDelete: Event[] = (events as Event[]) ?? []
 
     if (eventsToDelete.length === 0) {
       return new Response(


### PR DESCRIPTION
Closes #946

The DB query already filters events with `.lt('event_date', cutoffDateStr)`, making the subsequent in-memory `.filter()` always true. Removed the redundant in-memory pass and trusted the database result directly, eliminating the risk of a future logic mismatch if the cutoff condition is updated in only one place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gyto5KkZycpAWCwepKK7YQ)_