### PR TITLE
fix: build nextProfile inside setState updater to avoid stale closure

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4096,18 +4096,17 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
   const updateProfile = useCallback(
     (updates: Partial<Pick<PlayerProfile, 'name' | 'email' | 'roleId' | 'profileImage' | 'leaderboardVisible'>>) => {
-      const nextRole =
-        updates.roleId && catalog.roles.some((role: Role) => role.id === updates.roleId)
-          ? updates.roleId
-          : state.profile.roleId;
-      const nextProfile: PlayerProfile = { ...state.profile, ...updates, roleId: nextRole ?? state.profile.roleId };
-      setState((prev: GameState) => ({
-        ...prev,
-        profile: nextProfile,
-      }));
-      persistProfile(nextProfile);
+      setState((prev: GameState) => {
+        const nextRole =
+          updates.roleId && catalog.roles.some((role: Role) => role.id === updates.roleId)
+            ? updates.roleId
+            : prev.profile.roleId;
+        const nextProfile: PlayerProfile = { ...prev.profile, ...updates, roleId: nextRole ?? prev.profile.roleId };
+        persistProfile(nextProfile);
+        return { ...prev, profile: nextProfile };
+      });
     },
-    [catalog.roles, persistProfile, state.profile]
+    [catalog.roles, persistProfile]
   );
 
   const registerTurn = useCallback(


### PR DESCRIPTION
Closes #947

`updateProfile` was constructing `nextProfile` from the captured `state.profile` snapshot and then passing it into the `setState` functional updater, bypassing `prev`. Moved the entire `nextProfile` construction inside the updater so it always layers on top of the most recent committed state, preventing data loss when rapid updates are batched. Also removed `state.profile` from the dependency array since it is no longer needed at the outer scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gyto5KkZycpAWCwepKK7YQ)_