### PR TITLE
fix: verify JWT with anon-key client in mobile-logs

### DIFF
--- a/supabase/functions/mobile-logs/index.ts
+++ b/supabase/functions/mobile-logs/index.ts
@@ -86,16 +86,17 @@ async function resolveRequesterUserId(req: Request): Promise<string | null> {
   if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
 
   const supabaseUrl = Deno.env.get('SUPABASE_URL');
-  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
-  if (!supabaseUrl || !serviceKey) return null;
+  const anonKey = Deno.env.get('SUPABASE_ANON_KEY');
+  if (!supabaseUrl || !anonKey) return null;
 
   try {
-    const authClient = createClient(supabaseUrl, serviceKey);
-    const token = authHeader.slice('Bearer '.length).trim();
-    if (!token) return null;
-    const { data, error } = await authClient.auth.getUser(token);
-    if (error || !data.user) return null;
-    return data.user.id;
+    const authClient = createClient(supabaseUrl, anonKey, {
+      global: { headers: { Authorization: authHeader } },
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const { data: { user }, error } = await authClient.auth.getUser();
+    if (error || !user) return null;
+    return user.id;
   } catch {
     return null;
   }


### PR DESCRIPTION
Closes #949

`resolveRequesterUserId` was creating a Supabase client with the service role key and calling `getUser(token)` directly, which is an anti-pattern that bypasses RLS and uses superuser privileges for a low-privilege JWT verification step. Replaced it with an anon-key client that forwards the `Authorization` header and calls `getUser()` without arguments, matching the pattern used consistently across all other functions in the codebase (e.g. `cleanup-events`, `import-spazio-rossellini`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gyto5KkZycpAWCwepKK7YQ)_