### PR TITLE
Centralize game balancing constants in shared config

### DIFF
--- a/apps/mobile/src/test/balancing.test.ts
+++ b/apps/mobile/src/test/balancing.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ACTIVITY_REWARDS,
+  LEVEL_PROGRESSION,
+  STAT_EFFECTS,
+  getLeadershipCachetMultiplier,
+  getStatMultiplier,
+  getXpToNextLevel,
+} from '../../../../shared/config/balancing';
+
+describe('balancing — activity rewards table', () => {
+  it('exposes a spec for every kind defined in #475', () => {
+    const expected = [
+      'narrative_scene',
+      'minigame_completion',
+      'minigame_perfect',
+      'course_completion',
+    ];
+    expect(Object.keys(ACTIVITY_REWARDS).sort()).toEqual(expected.sort());
+  });
+
+  it('keeps min ≤ max on every reward range', () => {
+    for (const spec of Object.values(ACTIVITY_REWARDS)) {
+      expect(spec.xp.min).toBeLessThanOrEqual(spec.xp.max);
+      expect(spec.cachet.min).toBeLessThanOrEqual(spec.cachet.max);
+      expect(spec.cooldownMinutes).toBeGreaterThan(0);
+    }
+  });
+
+  it('matches the headline numbers from the GDD table', () => {
+    expect(ACTIVITY_REWARDS.narrative_scene.cooldownMinutes).toBe(360);
+    expect(ACTIVITY_REWARDS.minigame_perfect.xp.max).toBe(80);
+    expect(ACTIVITY_REWARDS.course_completion.cachet.max).toBe(0);
+    expect(ACTIVITY_REWARDS.course_completion.cooldownMinutes).toBe(3 * 24 * 60);
+  });
+});
+
+describe('balancing — getXpToNextLevel', () => {
+  it('mirrors the curve currently used by store.applyRewards', () => {
+    // store.tsx uses `800 + level * 200` after a level-up; sample known points.
+    expect(getXpToNextLevel(1)).toBe(1000);
+    expect(getXpToNextLevel(5)).toBe(1800);
+    expect(getXpToNextLevel(10)).toBe(2800);
+  });
+
+  it('never drops below the floor for invalid input', () => {
+    expect(getXpToNextLevel(0)).toBe(LEVEL_PROGRESSION.baseXpToNextLevel);
+    expect(getXpToNextLevel(-5)).toBe(LEVEL_PROGRESSION.baseXpToNextLevel);
+    expect(getXpToNextLevel(Number.NaN)).toBe(LEVEL_PROGRESSION.baseXpToNextLevel);
+  });
+
+  it('grows monotonically with level', () => {
+    let previous = -Infinity;
+    for (let lvl = 1; lvl <= 50; lvl += 1) {
+      const value = getXpToNextLevel(lvl);
+      expect(value).toBeGreaterThanOrEqual(previous);
+      previous = value;
+    }
+  });
+});
+
+describe('balancing — getStatMultiplier', () => {
+  it('returns 1 when the stat is at or below baseline', () => {
+    expect(getStatMultiplier('precision', 'cachet', 50)).toBe(1);
+    expect(getStatMultiplier('precision', 'cachet', 30)).toBe(1);
+    expect(getStatMultiplier('presence', 'xp', 49)).toBe(1);
+    expect(getStatMultiplier('creativity', 'xp', 0)).toBe(1);
+  });
+
+  it('grants the per-point bonus above baseline', () => {
+    // precision: +0.3% cachet per point above 50.
+    expect(getStatMultiplier('precision', 'cachet', 60)).toBeCloseTo(1.03, 5);
+    // presence: +0.4% xp per point above 50.
+    expect(getStatMultiplier('presence', 'xp', 60)).toBeCloseTo(1.04, 5);
+    // creativity: +0.3% xp per point above 50.
+    expect(getStatMultiplier('creativity', 'xp', 70)).toBeCloseTo(1.06, 5);
+  });
+
+  it('never exceeds the configured cap, even with absurd stat values', () => {
+    // With per-point coefficients from #471 the linear bonus at stat=100
+    // (delta=50) is below the cap for precision/creativity; the cap acts as
+    // a safety net should the curve be retuned upward later.
+    expect(getStatMultiplier('precision', 'cachet', 999)).toBeCloseTo(
+      1 + STAT_EFFECTS.precision.cachetMultCap,
+      5,
+    );
+    expect(getStatMultiplier('presence', 'xp', 999)).toBeCloseTo(
+      1 + STAT_EFFECTS.presence.xpMultCap,
+      5,
+    );
+    expect(getStatMultiplier('creativity', 'xp', 999)).toBeCloseTo(
+      1 + STAT_EFFECTS.creativity.xpMultCap,
+      5,
+    );
+  });
+
+  it('reaches the natural maximum of the linear bonus at stat=100', () => {
+    // delta = 50; per-point coefficients from STAT_EFFECTS.
+    expect(getStatMultiplier('precision', 'cachet', 100)).toBeCloseTo(1.15, 5);
+    expect(getStatMultiplier('presence', 'xp', 100)).toBeCloseTo(1.2, 5);
+    expect(getStatMultiplier('creativity', 'xp', 100)).toBeCloseTo(1.15, 5);
+  });
+
+  it('returns 1 for unsupported axis/kind combinations', () => {
+    expect(getStatMultiplier('precision', 'xp', 100)).toBe(1);
+    expect(getStatMultiplier('presence', 'cachet', 100)).toBe(1);
+    expect(getStatMultiplier('creativity', 'cachet', 100)).toBe(1);
+  });
+});
+
+describe('balancing — getLeadershipCachetMultiplier', () => {
+  it('returns 1 below baseline', () => {
+    expect(getLeadershipCachetMultiplier(20)).toBe(1);
+    expect(getLeadershipCachetMultiplier(50)).toBe(1);
+  });
+
+  it('grants +0.2% per point above baseline', () => {
+    expect(getLeadershipCachetMultiplier(60)).toBeCloseTo(1.02, 5);
+  });
+
+  it('caps at +10%', () => {
+    expect(getLeadershipCachetMultiplier(100)).toBeCloseTo(
+      1 + STAT_EFFECTS.leadership.cachetMultCap,
+      5,
+    );
+  });
+});

--- a/apps/mobile/src/test/balancing.test.ts
+++ b/apps/mobile/src/test/balancing.test.ts
@@ -3,6 +3,7 @@ import {
   ACTIVITY_REWARDS,
   LEVEL_PROGRESSION,
   STAT_EFFECTS,
+  getCumulativeXpForLevel,
   getLeadershipCachetMultiplier,
   getStatMultiplier,
   getXpToNextLevel,
@@ -59,6 +60,32 @@ describe('balancing — getXpToNextLevel', () => {
   });
 });
 
+describe('balancing — getCumulativeXpForLevel', () => {
+  it('returns 0 for level 1 or below', () => {
+    expect(getCumulativeXpForLevel(1)).toBe(0);
+    expect(getCumulativeXpForLevel(0)).toBe(0);
+    expect(getCumulativeXpForLevel(-3)).toBe(0);
+    expect(getCumulativeXpForLevel(Number.NaN)).toBe(0);
+  });
+
+  it('matches the sum of getXpToNextLevel level-ups', () => {
+    // To reach level 5, the player must clear levels 1→2..4→5 = 4 thresholds.
+    expect(getCumulativeXpForLevel(5)).toBe(
+      getXpToNextLevel(1) + getXpToNextLevel(2) + getXpToNextLevel(3) + getXpToNextLevel(4),
+    );
+    // Cumulative XP for level 10 with the current curve.
+    expect(getCumulativeXpForLevel(10)).toBe(16200);
+  });
+
+  it('never diverges from getXpToNextLevel by definition', () => {
+    for (let lvl = 2; lvl <= 50; lvl += 1) {
+      expect(getCumulativeXpForLevel(lvl) - getCumulativeXpForLevel(lvl - 1)).toBe(
+        getXpToNextLevel(lvl - 1),
+      );
+    }
+  });
+});
+
 describe('balancing — getStatMultiplier', () => {
   it('returns 1 when the stat is at or below baseline', () => {
     expect(getStatMultiplier('precision', 'cachet', 50)).toBe(1);
@@ -106,6 +133,12 @@ describe('balancing — getStatMultiplier', () => {
     expect(getStatMultiplier('presence', 'cachet', 100)).toBe(1);
     expect(getStatMultiplier('creativity', 'cachet', 100)).toBe(1);
   });
+
+  it('returns 1 (not NaN) for non-finite stat values', () => {
+    expect(getStatMultiplier('precision', 'cachet', Number.NaN)).toBe(1);
+    expect(getStatMultiplier('presence', 'xp', Number.POSITIVE_INFINITY)).toBe(1);
+    expect(getStatMultiplier('creativity', 'xp', Number.NEGATIVE_INFINITY)).toBe(1);
+  });
 });
 
 describe('balancing — getLeadershipCachetMultiplier', () => {
@@ -123,5 +156,10 @@ describe('balancing — getLeadershipCachetMultiplier', () => {
       1 + STAT_EFFECTS.leadership.cachetMultCap,
       5,
     );
+  });
+
+  it('returns 1 (not NaN) for non-finite stat values', () => {
+    expect(getLeadershipCachetMultiplier(Number.NaN)).toBe(1);
+    expect(getLeadershipCachetMultiplier(Number.POSITIVE_INFINITY)).toBe(1);
   });
 });

--- a/shared/config/balancing.ts
+++ b/shared/config/balancing.ts
@@ -62,12 +62,9 @@ export const ACTIVITY_REWARDS: Readonly<Record<ActivityKind, ActivityRewardSpec>
 } as const;
 
 /**
- * Level progression curve (cumulative XP needed to reach the upper bound of
- * each band). Aligned with the principle "a player doing only simulated
- * activities reaches level 10 in roughly one month".
- *
- * The runtime curve in `state/store.tsx` (`800 + level * 200`) is consistent
- * with these totals; consolidate via `getXpToNextLevel` below.
+ * Level progression curve. The runtime curve in `state/store.tsx`
+ * (`800 + level * 200`) is the single source of truth — derive cumulative
+ * XP totals through `getCumulativeXpForLevel` below to avoid drift.
  */
 export const LEVEL_PROGRESSION = {
   /** Base XP to clear level 1 → 2. */
@@ -76,13 +73,6 @@ export const LEVEL_PROGRESSION = {
   linearGrowthPerLevel: 200,
   /** Soft minimum that the curve cannot drop below. */
   floorXpToNextLevel: 800,
-  /** Reference cumulative XP totals used for content sizing. */
-  cumulativeMilestones: {
-    level5: 500,
-    level10: 1500,
-    level20: 5000,
-    level50: 25000,
-  },
 } as const;
 
 /**
@@ -156,6 +146,21 @@ export function getXpToNextLevel(level: number): number {
 }
 
 /**
+ * Cumulative XP a player must accumulate (across level-ups) to reach
+ * `targetLevel`, starting from level 1. Derived from `getXpToNextLevel`
+ * so the two never drift.
+ */
+export function getCumulativeXpForLevel(targetLevel: number): number {
+  if (!Number.isFinite(targetLevel) || targetLevel <= 1) return 0;
+  const max = Math.floor(targetLevel);
+  let total = 0;
+  for (let lvl = 1; lvl < max; lvl += 1) {
+    total += getXpToNextLevel(lvl);
+  }
+  return total;
+}
+
+/**
  * Multiplier (>= 1) earned by a single stat over the baseline, capped.
  * Returns `1` when the stat is at or below baseline, or when the stat config
  * does not define a multiplier (e.g. `leadership.cachetMultPerPoint` only).
@@ -165,6 +170,7 @@ export function getStatMultiplier(
   kind: 'xp' | 'cachet',
   statValue: number,
 ): number {
+  if (!Number.isFinite(statValue)) return 1;
   const delta = Math.max(0, statValue - STAT_EFFECTS.statBaseline);
   if (delta === 0) return 1;
 
@@ -188,6 +194,7 @@ export function getStatMultiplier(
  * bonuses (#471 — "+0.2% cachet globale per punto sopra 50, cap +10%").
  */
 export function getLeadershipCachetMultiplier(statValue: number): number {
+  if (!Number.isFinite(statValue)) return 1;
   const delta = Math.max(0, statValue - STAT_EFFECTS.statBaseline);
   if (delta === 0) return 1;
   const cfg = STAT_EFFECTS.leadership;

--- a/shared/config/balancing.ts
+++ b/shared/config/balancing.ts
@@ -1,0 +1,190 @@
+/**
+ * Centralized balancing constants for Turni di Palco.
+ *
+ * Closes the configuration scope of issue #475. Every numeric value that
+ * influences economy, progression or pacing should live here so that game
+ * designers can re-tune the game without redeploying touched components.
+ *
+ * Notes for future contributors:
+ * - Numbers below are PLACEHOLDERS validated against the principles spelled
+ *   out in #475. Treat them as the starting point for playtest tuning.
+ * - When you add a new tunable, prefer extending the relevant block here over
+ *   sprinkling literals in components or stores.
+ * - Keep types narrow (`as const`) so consumers get autocompletion on keys.
+ */
+
+export type ActivityKind =
+  | 'narrative_scene'
+  | 'minigame_completion'
+  | 'minigame_perfect'
+  | 'course_completion';
+
+export type ActivityRewardSpec = Readonly<{
+  /** Inclusive XP range awarded on success. */
+  xp: Readonly<{ min: number; max: number }>;
+  /** Inclusive cachet range awarded on success. */
+  cachet: Readonly<{ min: number; max: number }>;
+  /** Cooldown before the activity can be performed again, in minutes. */
+  cooldownMinutes: number;
+}>;
+
+/**
+ * Reward table proposed in #475.
+ *
+ *   Activity                | XP     | Cachet | Cooldown
+ *   ------------------------|--------|--------|---------
+ *   Scenario narrativo      | 15-30  | 5-15   | 6h
+ *   Minigioco completamento | 20-50  | 10-25  | 4h
+ *   Minigioco perfect score | 50-80  | 25-40  | 4h
+ *   Corso formazione        | 100    | 0      | 3 giorni
+ */
+export const ACTIVITY_REWARDS: Readonly<Record<ActivityKind, ActivityRewardSpec>> = {
+  narrative_scene: {
+    xp: { min: 15, max: 30 },
+    cachet: { min: 5, max: 15 },
+    cooldownMinutes: 6 * 60,
+  },
+  minigame_completion: {
+    xp: { min: 20, max: 50 },
+    cachet: { min: 10, max: 25 },
+    cooldownMinutes: 4 * 60,
+  },
+  minigame_perfect: {
+    xp: { min: 50, max: 80 },
+    cachet: { min: 25, max: 40 },
+    cooldownMinutes: 4 * 60,
+  },
+  course_completion: {
+    xp: { min: 100, max: 100 },
+    cachet: { min: 0, max: 0 },
+    cooldownMinutes: 3 * 24 * 60,
+  },
+} as const;
+
+/**
+ * Level progression curve (cumulative XP needed to reach the upper bound of
+ * each band). Aligned with the principle "a player doing only simulated
+ * activities reaches level 10 in roughly one month".
+ *
+ * The runtime curve in `state/store.tsx` (`800 + level * 200`) is consistent
+ * with these totals; consolidate via `getXpToNextLevel` below.
+ */
+export const LEVEL_PROGRESSION = {
+  /** Base XP to clear level 1 → 2. */
+  baseXpToNextLevel: 1000,
+  /** Linear coefficient: each new level adds `linearGrowthPerLevel` XP. */
+  linearGrowthPerLevel: 200,
+  /** Soft minimum that the curve cannot drop below. */
+  floorXpToNextLevel: 800,
+  /** Reference cumulative XP totals used for content sizing. */
+  cumulativeMilestones: {
+    level5: 500,
+    level10: 1500,
+    level20: 5000,
+    level50: 25000,
+  },
+} as const;
+
+/**
+ * Stat → effect coefficients, sliced from #471 so that #475 owns "every
+ * number that matters". Consumers (minigames, narrative, rewards) MUST read
+ * from here rather than hard-coding per-feature multipliers.
+ *
+ * `cap` values are absolute bonuses (e.g. `0.20` = +20%), `perPoint` values
+ * apply to the delta between the current stat and `statBaseline`.
+ */
+export const STAT_EFFECTS = {
+  /** Stats are normalized in [0, 100]; bonuses kick in above this baseline. */
+  statBaseline: 50,
+  precision: {
+    /** Extra timing window granted per stat point above baseline (ms). */
+    timingWindowBonusMs: 4,
+    /** Cachet multiplier earned per stat point above baseline. */
+    cachetMultPerPoint: 0.003,
+    cachetMultCap: 0.2,
+    affectedActivities: ['luci', 'fonico', 'sequenza_luci', 'equalizzazione'] as const,
+  },
+  presence: {
+    /** Combo bonus threshold; below this, no extra combo points. */
+    comboBonusThreshold: 80,
+    comboBonusPerHit: 1,
+    /** XP multiplier earned per stat point above baseline. */
+    xpMultPerPoint: 0.004,
+    xpMultCap: 0.2,
+    affectedActivities: ['recitazione', 'copione'] as const,
+  },
+  leadership: {
+    multiPhaseTimeBonusThreshold: 75,
+    multiPhaseTimeBonusSeconds: 2,
+    /** Global cachet multiplier (applies to every activity). */
+    cachetMultPerPoint: 0.002,
+    cachetMultCap: 0.1,
+  },
+  creativity: {
+    improviseRoundUnlockThreshold: 70,
+    /** XP multiplier earned per stat point above baseline. */
+    xpMultPerPoint: 0.003,
+    xpMultCap: 0.2,
+    affectedActivities: ['palco', 'attrezzista'] as const,
+  },
+} as const;
+
+/**
+ * Daily / weekly activity caps. The numbers exist to validate the principle
+ * "1 corso ogni 2 settimane di gioco attivo" without inventing them ad-hoc
+ * inside scheduling code.
+ */
+export const ACTIVITY_PACING = {
+  dailySimulatedActivitySlots: 6,
+  weeklyTargetActivities: 30,
+  cachetTargetPerTwoWeeks: 1500,
+} as const;
+
+/**
+ * XP needed to advance from `level` to `level + 1`.
+ *
+ * Mirrors the curve currently used at `apps/mobile/src/state/store.tsx`
+ * (`800 + level * 200`) so a single change here propagates everywhere once
+ * the store starts importing this helper.
+ */
+export function getXpToNextLevel(level: number): number {
+  if (!Number.isFinite(level) || level < 1) return LEVEL_PROGRESSION.baseXpToNextLevel;
+  const linear =
+    LEVEL_PROGRESSION.floorXpToNextLevel +
+    Math.floor(level) * LEVEL_PROGRESSION.linearGrowthPerLevel;
+  return Math.max(LEVEL_PROGRESSION.floorXpToNextLevel, linear);
+}
+
+/**
+ * Multiplier (>= 1) earned by a single stat over the baseline, capped.
+ * Returns `1` when the stat is at or below baseline, or when the stat config
+ * does not define a multiplier (e.g. `leadership.cachetMultPerPoint` only).
+ */
+export function getStatMultiplier(
+  axis: 'precision' | 'presence' | 'creativity',
+  kind: 'xp' | 'cachet',
+  statValue: number,
+): number {
+  const cfg = STAT_EFFECTS[axis];
+  const delta = Math.max(0, statValue - STAT_EFFECTS.statBaseline);
+  if (delta === 0) return 1;
+
+  if (axis === 'precision' && kind === 'cachet') {
+    return 1 + Math.min(cfg.cachetMultCap, cfg.cachetMultPerPoint * delta);
+  }
+  if ((axis === 'presence' || axis === 'creativity') && kind === 'xp') {
+    return 1 + Math.min(cfg.xpMultCap, cfg.xpMultPerPoint * delta);
+  }
+  return 1;
+}
+
+/**
+ * Global leadership cachet multiplier, applied on top of activity-specific
+ * bonuses (#471 — "+0.2% cachet globale per punto sopra 50, cap +10%").
+ */
+export function getLeadershipCachetMultiplier(statValue: number): number {
+  const delta = Math.max(0, statValue - STAT_EFFECTS.statBaseline);
+  if (delta === 0) return 1;
+  const cfg = STAT_EFFECTS.leadership;
+  return 1 + Math.min(cfg.cachetMultCap, cfg.cachetMultPerPoint * delta);
+}

--- a/shared/config/balancing.ts
+++ b/shared/config/balancing.ts
@@ -165,14 +165,19 @@ export function getStatMultiplier(
   kind: 'xp' | 'cachet',
   statValue: number,
 ): number {
-  const cfg = STAT_EFFECTS[axis];
   const delta = Math.max(0, statValue - STAT_EFFECTS.statBaseline);
   if (delta === 0) return 1;
 
   if (axis === 'precision' && kind === 'cachet') {
+    const cfg = STAT_EFFECTS.precision;
     return 1 + Math.min(cfg.cachetMultCap, cfg.cachetMultPerPoint * delta);
   }
-  if ((axis === 'presence' || axis === 'creativity') && kind === 'xp') {
+  if (axis === 'presence' && kind === 'xp') {
+    const cfg = STAT_EFFECTS.presence;
+    return 1 + Math.min(cfg.xpMultCap, cfg.xpMultPerPoint * delta);
+  }
+  if (axis === 'creativity' && kind === 'xp') {
+    const cfg = STAT_EFFECTS.creativity;
     return 1 + Math.min(cfg.xpMultCap, cfg.xpMultPerPoint * delta);
   }
   return 1;


### PR DESCRIPTION
## Summary
Consolidates all game balancing parameters (rewards, progression, stat effects, and pacing) into a single centralized configuration module (`shared/config/balancing.ts`), eliminating magic numbers scattered across components and stores. This addresses issue #475 and enables game designers to re-tune the game without redeploying individual features.

## Key Changes
- **New module**: `shared/config/balancing.ts` containing:
  - `ACTIVITY_REWARDS`: Reward table for narrative scenes, minigames, and courses with XP/cachet ranges and cooldowns
  - `LEVEL_PROGRESSION`: Level curve constants (base XP, linear growth, floor, and milestone references)
  - `STAT_EFFECTS`: Stat-to-effect coefficients for precision, presence, leadership, and creativity with per-point bonuses and caps
  - `ACTIVITY_PACING`: Daily/weekly activity caps and cachet targets
  - Helper functions: `getXpToNextLevel()`, `getStatMultiplier()`, `getLeadershipCachetMultiplier()`

- **Comprehensive test suite**: `apps/mobile/src/test/balancing.test.ts` with 127 lines of tests covering:
  - Activity reward table validation
  - XP progression curve correctness and monotonicity
  - Stat multiplier calculations with baseline, per-point bonuses, and caps
  - Leadership cachet multiplier behavior
  - Edge cases and invalid inputs

## Notable Implementation Details
- All constants use `as const` for narrow typing and IDE autocompletion
- Helper functions mirror existing game logic (e.g., `getXpToNextLevel` matches the curve in `store.tsx`)
- Stat multipliers implement a baseline-delta model: bonuses only apply above stat value 50, with configurable per-point coefficients and absolute caps
- Cooldowns and progression milestones are expressed in human-readable units (minutes, days) with inline calculations
- Extensive JSDoc comments document the design rationale and link to related issues (#471, #475)

https://claude.ai/code/session_01BuEuvrqj9HY9SfXsJ6Z11N