### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -17,7 +17,6 @@ import {
   X,
   Bell,
   Coins,
-  Zap,
 } from 'lucide-react';
 import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover';
 import { GameEvent, TurnSyncFeedback } from '../../state/store';


### PR DESCRIPTION
To fix this safely, remove `Zap` from the `lucide-react` named import list in `apps/mobile/src/components/screens/Home.tsx`.

Best single fix (no behavior change):
- Edit only the icon import block (lines 9–21 region).
- Delete `Zap,` from the list.
- Keep all other imports untouched.

No new methods, definitions, or external packages are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._