### PR TITLE
fix: add .catch(console.error) to fire-and-forget async calls in auth useEffect

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3580,9 +3580,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       setRemoteTheatreReputation([]);
       return;
     }
-    refreshTurnStats();
-    refreshTheatreReputation();
-    refreshBadges();
+    refreshTurnStats().catch(console.error);
+    refreshTheatreReputation().catch(console.error);
+    refreshBadges().catch(console.error);
     refreshLeaderboard().catch(console.error);
   }, [authUserId, refreshBadges, refreshLeaderboard, refreshTheatreReputation, refreshTurnStats]);
 


### PR DESCRIPTION
Closes #961

The `onAuthStateChange` useEffect was calling `refreshTurnStats()`, `refreshTheatreReputation()`, and `refreshBadges()` as fire-and-forget without any error handling. If any of these promises rejected, it would result in an unhandled promise rejection that could crash the app or silently pollute logs. This fix adds `.catch(console.error)` to each of the three calls, consistent with the existing pattern already applied to `refreshLeaderboard()`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TG9aGVViuFncBi2iQmgCZe)_