### PR TITLE
fix: wrap req.json() in try/catch to return 400 on malformed body in ticket-activation

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -51,8 +51,16 @@ serve(async (req: Request) => {
 
   const supabase = createClient(supabaseUrl, serviceKey);
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let body: Record<string, any>;
   try {
-    const { action, hash, payload, userId: requestedUserId } = await req.json();
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: 'Invalid request body' }, 400);
+  }
+
+  try {
+    const { action, hash, payload, userId: requestedUserId } = body;
 
     const activationActions = ['activate_hash', 'activate_by_details', 'activate_by_ticket_number'];
     const authRequiredActions = [...activationActions, 'reserve_hash', 'resolve_hash'];


### PR DESCRIPTION
Closes #962

The `ticket-activation` Edge Function was calling `await req.json()` inside a general outer try/catch that caught all unexpected errors and returned a generic 500 response. When the request body is malformed JSON (e.g. empty body, invalid JSON syntax), this produced an opaque 500 instead of an informative client error. This fix adds a dedicated inner try/catch specifically around the `req.json()` call that returns a proper JSON 400 response with `{ error: "Invalid request body" }`, allowing the outer try/catch to remain focused on actual server-side failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TG9aGVViuFncBi2iQmgCZe)_