### PR TITLE
fix: stop infinite re-render loop in SupportChat causing empty page

### DIFF
--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -83,13 +83,13 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
   useEffect(() => {
     if (!hasLoadedRef.current || !activeSessionId) return;
     const capturedSessionId = activeSessionId;
-    const next = updateSessionList(chatSessions, capturedSessionId, messages);
     setChatSessions((prev) => {
       if (prev.find(s => s.id === capturedSessionId) === undefined) return prev;
+      const next = updateSessionList(prev, capturedSessionId, messages);
       saveChatHistory(displayName, next, userId);
       return next;
     });
-  }, [messages, activeSessionId, chatSessions, historyId, displayName, userId]);
+  }, [messages, activeSessionId, displayName, userId]);
 
   const hasInput = input.trim().length > 0;
   const activeSession = useMemo(


### PR DESCRIPTION
Closes #965

## What was fixed

`SupportChat.tsx` had a `useEffect` that listed `chatSessions` in its dependency array and then called `setChatSessions` inside its body. This created an infinite update cycle:

1. `chatSessions` changes → effect runs
2. Effect calls `setChatSessions(...)` → `chatSessions` changes again
3. → effect runs again → infinite loop → React error #185 → blank page

**Fix:** moved the `updateSessionList(...)` call inside the `setChatSessions` functional-update callback so it reads from `prev` (the snapshot passed by React) instead of the stale closure value. This makes `chatSessions` unnecessary as a dependency, breaking the cycle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WddUSng66C8jkJCFHmymY3)_