### PR TITLE
fix: add state.profile.roleId to refreshEventPlanning deps (#967)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3177,7 +3177,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         }
       );
     },
-    [authUserId, syncLocalEventPlanning]
+    [authUserId, syncLocalEventPlanning, state.profile.roleId]
   );
 
   const refreshShopCatalog = useCallback(async () => {


### PR DESCRIPTION
## Summary

- `refreshEventPlanning` useCallback reads `state.profile.roleId` inside the callback but was missing it from the dependency array `[authUserId, syncLocalEventPlanning]`.
- After a role change, the callback held a stale closure and operated with the old roleId.
- Fix: added `state.profile.roleId` to the dependency array.

## Test plan
- [ ] Verify that after a role change, `refreshEventPlanning` correctly uses the updated roleId when called.
- [ ] Confirm no regressions in event planning sync behaviour.

Closes #967

https://claude.ai/code/session_01WddUSng66C8jkJCFHmymY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01WddUSng66C8jkJCFHmymY3)_