### PR TITLE
fix: separate profile and turns error banners in loadRemoteState (#969)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3702,12 +3702,15 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
           if (!isMounted) return;
 
-          if (userRes.error || profileRes.error || turnsRes.error) {
+          if (userRes.error || profileRes.error) {
             notifyCriticalError('Non riusciamo a caricare il profilo dal database.', [
               userRes.error,
               profileRes.error,
-              turnsRes.error,
             ]);
+          }
+
+          if (turnsRes.error) {
+            notifyCriticalError('Non riusciamo a caricare i turni dal database.', [turnsRes.error]);
           }
 
           if (userRes.error) {


### PR DESCRIPTION
## Summary

- The combined `if (userRes.error || profileRes.error || turnsRes.error)` condition triggered the misleading "Non riusciamo a caricare il profilo dal database." banner even when only the turns query failed and the profile loaded successfully.
- Fix: separated the error checks into two independent blocks:
  - User/profile errors → fire the existing "profile" critical error banner.
  - Turns errors → fire a dedicated "Non riusciamo a caricare i turni dal database." banner.

## Test plan
- [ ] Simulate a turns query failure while user/profile loads succeed — confirm only the turns-specific error banner appears.
- [ ] Simulate a profile/user query failure — confirm the profile error banner appears (and not a turns banner).
- [ ] Confirm normal load path (no errors) shows no banners.

Closes #969

https://claude.ai/code/session_01WddUSng66C8jkJCFHmymY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01WddUSng66C8jkJCFHmymY3)_