### PR TITLE
fix: restrict getUserRoles to app_metadata only

### DIFF
--- a/supabase/functions/dev-access/index.ts
+++ b/supabase/functions/dev-access/index.ts
@@ -32,30 +32,30 @@ function parseEnvList(value: string | null) {
 
 function getUserRoles(user: Record<string, unknown>) {
   const roles = new Set<string>();
+  // Only read roles from app_metadata (server-controlled, written only with
+  // the service-role key). user_metadata is user-controlled and must NOT be
+  // used for access-control decisions to prevent privilege escalation.
   const appMetadata = user.app_metadata as Record<string, unknown> | null | undefined;
-  const userMetadata = user.user_metadata as Record<string, unknown> | null | undefined;
-  const metadataList = [appMetadata, userMetadata].filter(Boolean) as Record<string, unknown>[];
+  if (!appMetadata) return [];
 
-  metadataList.forEach((metadata) => {
-    const roleValue = metadata.role;
-    const rolesValue = metadata.roles;
+  const roleValue = appMetadata.role;
+  const rolesValue = appMetadata.roles;
 
-    if (typeof roleValue === 'string') roles.add(roleValue);
-    if (Array.isArray(roleValue)) {
-      roleValue.filter((item) => typeof item === 'string').forEach((item) => roles.add(item));
-    }
+  if (typeof roleValue === 'string') roles.add(roleValue);
+  if (Array.isArray(roleValue)) {
+    roleValue.filter((item) => typeof item === 'string').forEach((item) => roles.add(item));
+  }
 
-    if (typeof rolesValue === 'string') {
-      rolesValue
-        .split(',')
-        .map((item) => item.trim())
-        .filter(Boolean)
-        .forEach((item) => roles.add(item));
-    }
-    if (Array.isArray(rolesValue)) {
-      rolesValue.filter((item) => typeof item === 'string').forEach((item) => roles.add(item));
-    }
-  });
+  if (typeof rolesValue === 'string') {
+    rolesValue
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .forEach((item) => roles.add(item));
+  }
+  if (Array.isArray(rolesValue)) {
+    rolesValue.filter((item) => typeof item === 'string').forEach((item) => roles.add(item));
+  }
 
   return Array.from(roles);
 }


### PR DESCRIPTION
Closes #972

## Changes
`getUserRoles()` in `supabase/functions/dev-access/index.ts` previously iterated over both `app_metadata` and `user_metadata` when resolving a user's roles. Because `user_metadata` is freely writable by any authenticated user (via `supabase.auth.updateUser`), this allowed privilege escalation to the `dev` role.

The fix removes the `user_metadata` branch entirely. Role resolution now exclusively reads from `app_metadata`, which is only writable by the Supabase service-role key (server-side), eliminating the escalation path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMPbF455mGhptitW5pZp9T)_