### PR TITLE
fix: remove redundant setIsSubmitting(false) in ChangePassword success path (closes #981)

### DIFF
--- a/apps/mobile/src/components/screens/ChangePassword.tsx
+++ b/apps/mobile/src/components/screens/ChangePassword.tsx
@@ -75,7 +75,6 @@ export function ChangePassword({
       setPassword('');
       setConfirmPassword('');
       setSuccessMessage('Password aggiornata con successo.');
-      setIsSubmitting(false);
       if (backTimerRef.current !== null) {
         clearTimeout(backTimerRef.current);
       }


### PR DESCRIPTION
## Summary

- Fixes #981: in `ChangePassword.handleSubmit`, the success branch called `setIsSubmitting(false)` before the `return`, and then the `finally` block called it again — a double-set logic error.
- Fix: remove the redundant `setIsSubmitting(false)` from the `try` success branch; the `finally` block is now the single source of truth for resetting the submitting state.

## Test plan

- [ ] Submit a valid password change — verify the button re-enables once after success, not twice
- [ ] Submit a valid password change — verify the 1500 ms auto-back navigation still fires correctly
- [ ] Submit an invalid password change — verify the button re-enables once after the error

https://claude.ai/code/session_01VYLduuvDSzcuBtiVMJFvjk

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYLduuvDSzcuBtiVMJFvjk)_