### PR TITLE
fix: handle onResetProgress errors with try/catch and user feedback

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -652,7 +652,7 @@ export function AppShell() {
             onViewPrivacy={() => nav.openLegal('privacy', 'account-settings')}
             onViewSupport={openSupport} onViewTicketPrototype={openTicketQrPrototype}
             onChangePassword={() => { nav.setIsPasswordRecovery(false); nav.navigate('change-password'); }}
-            onResetProgress={async () => { await resetProgress(); handleTabChange('home'); nav.navigate('role-selection'); }}
+            onResetProgress={async () => { try { await resetProgress(); handleTabChange('home'); nav.navigate('role-selection'); } catch (err) { console.error('[AppShell] resetProgress failed:', err); throw err; } }}
             onResetTutorial={() => { gameState.resetTutorial(); nav.navigate('home'); }}
             onDeleteAccount={deleteAccount}
             onExportData={exportUserData}
@@ -670,7 +670,7 @@ export function AppShell() {
               onViewPrivacy={() => nav.openLegal('privacy', 'account-settings')}
               onViewSupport={openSupport} onViewTicketPrototype={openTicketQrPrototype}
               onChangePassword={() => { nav.setIsPasswordRecovery(false); nav.navigate('change-password'); }}
-              onResetProgress={async () => { await resetProgress(); handleTabChange('home'); nav.navigate('role-selection'); }}
+              onResetProgress={async () => { try { await resetProgress(); handleTabChange('home'); nav.navigate('role-selection'); } catch (err) { console.error('[AppShell] resetProgress failed:', err); throw err; } }}
               onResetTutorial={() => { gameState.resetTutorial(); nav.navigate('home'); }}
               onDeleteAccount={deleteAccount}
               onExportData={exportUserData}
@@ -715,7 +715,7 @@ export function AppShell() {
               onViewPrivacy={() => nav.openLegal('privacy', 'account-settings')}
               onViewSupport={openSupport} onViewTicketPrototype={openTicketQrPrototype}
               onChangePassword={() => { nav.setIsPasswordRecovery(false); nav.navigate('change-password'); }}
-              onResetProgress={async () => { await resetProgress(); handleTabChange('home'); nav.navigate('role-selection'); }}
+              onResetProgress={async () => { try { await resetProgress(); handleTabChange('home'); nav.navigate('role-selection'); } catch (err) { console.error('[AppShell] resetProgress failed:', err); throw err; } }}
               onResetTutorial={() => { gameState.resetTutorial(); nav.navigate('home'); }}
               onDeleteAccount={deleteAccount}
               onExportData={exportUserData}

--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -29,7 +29,7 @@ interface AccountSettingsProps {
   onViewSupport: () => void;
   onViewTicketPrototype: () => void;
   onChangePassword: () => void;
-  onResetProgress: () => void;
+  onResetProgress: () => Promise<void>;
   onResetTutorial: () => void;
   onDeleteAccount: () => Promise<void>;
   onExportData: () => void;
@@ -53,6 +53,7 @@ export function AccountSettings({
   const supportStatus = useSupportStatus(showAiSupport);
   const { geoConsent, grantGeoConsent, denyGeoConsent } = useGeoConsent();
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [resetError, setResetError] = useState<string | null>(null);
 
   // In-app confirm dialog state (replaces window.confirm for all destructive actions)
   type ConfirmPending = 'tutorial' | 'reset' | 'delete' | null;
@@ -68,7 +69,13 @@ export function AccountSettings({
     if (action === 'tutorial') {
       onResetTutorial();
     } else if (action === 'reset') {
-      onResetProgress();
+      setResetError(null);
+      try {
+        await onResetProgress();
+      } catch (err) {
+        console.error('[AccountSettings] resetProgress failed:', err);
+        setResetError(err instanceof Error ? err.message : 'Impossibile resettare i progressi. Riprova.');
+      }
     } else if (action === 'delete') {
       setDeleteError(null);
       try {
@@ -173,6 +180,7 @@ export function AccountSettings({
         <SettingsActionCard icon={Trash2} label="Resetta progressi" subtitle="Azzeramento irreversibile della carriera" onClick={handleReset} iconColor="text-[#ff4d4f]" />
 
         <div className="mt-auto flex flex-col gap-4">
+          {resetError && <p className="text-[14px] leading-[20px] text-[#ff4d4f] text-center">{resetError}</p>}
           {deleteError && <p className="text-[14px] leading-[20px] text-[#ff4d4f] text-center">{deleteError}</p>}
           <CopyrightNotice />
           <button type="button" onClick={handleDeleteAccount}


### PR DESCRIPTION
Closes #985

## What changed
- Updated `onResetProgress` prop type in `AccountSettings` from `() => void` to `() => Promise<void>` so callers can be properly awaited.
- `handleConfirm` now awaits `onResetProgress()` inside a try/catch block; on failure it logs to console and sets a new `resetError` state which is displayed to the user in red below the action buttons (matching the existing `deleteError` pattern).
- All three `onResetProgress` callbacks in `AppShell.tsx` (cases `account-settings`, `support`, `ticket-qr-prototype`) now wrap `resetProgress()` in try/catch, logging the error and re-throwing so `AccountSettings` can surface it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wn5eiFtcX3KiudDYaELUXu)_