### PR TITLE
fix: propagate duplicate activity status to prevent misleading success screen

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -586,7 +586,7 @@ export function AppShell() {
                 const completion = await completeActivity(nav.selectedActivityId, outcome);
                 if (!completion.ok) { setInfoToast(completion.error ?? 'Errore nel completamento attività.'); handleTabChange('activities'); return; }
                 setActivityOutcome(outcome);
-                setActivityCompletion({ activity: completion.activity, rewards: completion.rewards });
+                setActivityCompletion({ activity: completion.activity, rewards: completion.rewards, isDuplicate: completion.isDuplicate });
                 nav.navigate('activity-result');
               })();
             }} />
@@ -594,7 +594,7 @@ export function AppShell() {
 
       case 'activity-result':
         return activityCompletion && activityOutcome ? (
-          <ActivityResult activity={activityCompletion.activity} rewards={activityCompletion.rewards} outcome={activityOutcome} onDone={() => handleTabChange('activities')} />
+          <ActivityResult activity={activityCompletion.activity} rewards={activityCompletion.rewards} outcome={activityOutcome} isDuplicate={activityCompletion.isDuplicate} onDone={() => handleTabChange('activities')} />
         ) : (
           <Activities activities={visibleActivities} activeRole={roleJourneyEnabled ? selectedRole : undefined}
             slotsStatus={activitySlotsStatus} slotsLoading={activitySlotsLoading}

--- a/apps/mobile/src/components/screens/ActivityResult.tsx
+++ b/apps/mobile/src/components/screens/ActivityResult.tsx
@@ -10,10 +10,11 @@ interface ActivityResultProps {
   activity: Activity;
   rewards: Rewards;
   outcome: MinigameOutcome;
+  isDuplicate?: boolean;
   onDone: () => void;
 }
 
-export function ActivityResult({ activity, rewards, outcome, onDone }: ActivityResultProps) {
+export function ActivityResult({ activity, rewards, outcome, isDuplicate, onDone }: ActivityResultProps) {
   const durationLabel = useMemo(() => {
     if (!outcome.durationMs) return null;
     const seconds = Math.max(1, Math.round(outcome.durationMs / 1000));
@@ -37,11 +38,12 @@ export function ActivityResult({ activity, rewards, outcome, onDone }: ActivityR
     <div className="min-h-screen pb-24">
       <div className="app-content px-6 pt-6 space-y-6">
         <div className="text-center">
-          <div className="w-20 h-20 bg-gradient-to-br from-[#52c41a] to-[#389e0d] rounded-full flex items-center justify-center mx-auto mb-4">
+          <div className={`w-20 h-20 rounded-full flex items-center justify-center mx-auto mb-4 ${isDuplicate ? 'bg-gradient-to-br from-[#b8b2b3] to-[#9a9697]' : 'bg-gradient-to-br from-[#52c41a] to-[#389e0d]'}`}>
             <CheckCircle2 className="text-white" size={40} />
           </div>
-          <h2 className="text-white mb-2">Attivita completata</h2>
+          <h2 className="text-white mb-2">{isDuplicate ? 'Attivita gia completata' : 'Attivita completata'}</h2>
           <p className="text-sm text-[#b8b2b3]">{activity.title}</p>
+          {isDuplicate && <p className="text-sm text-[#9a9697] mt-1">Hai gia completato questa attivita. Nessun premio aggiuntivo e stato assegnato.</p>}
         </div>
 
         <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20]">

--- a/apps/mobile/src/handlers/useActivityState.ts
+++ b/apps/mobile/src/handlers/useActivityState.ts
@@ -10,7 +10,7 @@ export function useActivityState(
   roleJourneyEnabled: boolean,
 ) {
   const [activityOutcome, setActivityOutcome] = useState<MinigameOutcome | null>(null);
-  const [activityCompletion, setActivityCompletion] = useState<{ activity: Activity; rewards: Rewards } | null>(null);
+  const [activityCompletion, setActivityCompletion] = useState<{ activity: Activity; rewards: Rewards; isDuplicate?: boolean } | null>(null);
   const [activitiesSection, setActivitiesSection] = useState<ActivitiesHubSection>('activities');
 
   const selectedRole = useMemo(

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -142,6 +142,7 @@ export type CompleteActivityResult =
     slotsTotal: number;
     cachetBalanceAfter: number;
     reputationAfter: number;
+    isDuplicate?: boolean;
   }
   | {
     ok: false;
@@ -4641,6 +4642,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           slotsTotal,
           cachetBalanceAfter: rpcResponse.cachet_balance_after,
           reputationAfter: rpcResponse.reputation_after,
+          isDuplicate: rpcResponse.status === 'duplicate',
         };
       } catch (error) {
         const errorMessage = formatSyncError(error);


### PR DESCRIPTION
Closes #986

## What changed
- Added `isDuplicate?: boolean` to the `ok: true` branch of `CompleteActivityResult` in `store.tsx`.
- `completeActivity` now sets `isDuplicate: rpcResponse.status === 'duplicate'` on the returned result.
- `useActivityState.ts`: expanded the `activityCompletion` state type to include `isDuplicate?: boolean`.
- `AppShell.tsx`: passes `isDuplicate` from the completion result into `setActivityCompletion` and forwards it as a prop to `<ActivityResult>`.
- `ActivityResult.tsx`: accepts `isDuplicate?: boolean`; when true, renders a grey icon and "Attività già completata" heading with an explanatory subtitle ("Hai già completato questa attività. Nessun premio aggiuntivo è stato assegnato.") instead of the green "Attività completata" success UI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wn5eiFtcX3KiudDYaELUXu)_