### PR TITLE
Fix unhandled rejection in handleUploadImage (#990)

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -278,9 +278,14 @@ export function AppShell() {
 
   const handleUploadImage = useCallback(async (file: File) => {
     if (!authUserId) return;
-    const url = await uploadProfileImage(authUserId, file);
-    updateProfile({ profileImage: url });
-  }, [authUserId, updateProfile]);
+    try {
+      const url = await uploadProfileImage(authUserId, file);
+      updateProfile({ profileImage: url });
+    } catch (err) {
+      console.error('[AppShell] uploadProfileImage failed:', err);
+      setInfoToast('Errore durante il caricamento dell\'immagine profilo.');
+    }
+  }, [authUserId, updateProfile, setInfoToast]);
 
   // === Effects ===
 


### PR DESCRIPTION
## Summary

- Wraps `uploadProfileImage` call in `handleUploadImage` (AppShell.tsx) with try/catch to prevent unhandled promise rejections on watchdog timeout or network/auth failure.
- On error, logs to console and surfaces a user-facing message via `setInfoToast`.
- Adds `setInfoToast` to the `useCallback` dependency array.

## Test plan

- [ ] Simulate a Supabase storage upload failure (e.g. revoke storage permissions or mock `uploadProfileImage` to throw) and confirm no unhandled rejection appears in the console.
- [ ] Verify the toast message is displayed to the user when upload fails.
- [ ] Verify normal upload flow still updates the profile image correctly.

Closes #990

https://claude.ai/code/session_016AjG6C8CXfobK9dpntmMmk

---
_Generated by [Claude Code](https://claude.ai/code/session_016AjG6C8CXfobK9dpntmMmk)_