### PR TITLE
Fix floating promise in refreshEventPlanning useEffect (#991)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3614,7 +3614,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (!isSupabaseConfigured || !supabase || !authUserId) return;
-    refreshEventPlanning(catalog.events);
+    refreshEventPlanning(catalog.events).catch((err) => {
+      console.warn('[store] refreshEventPlanning failed in useEffect:', err);
+    });
   }, [authUserId, catalog.events, refreshEventPlanning]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Adds `.catch` handler to the `refreshEventPlanning(catalog.events)` call inside the `useEffect` in `store.tsx` (~line 3615).
- Prevents unhandled promise rejections caused by `WatchdogTimeoutError` or Supabase errors when `refreshEventPlanning` is invoked from this effect.
- Errors are logged via `console.warn` so they remain visible for debugging without crashing.

## Test plan

- [ ] Simulate a watchdog timeout by delaying the Supabase response beyond 12s and confirm no unhandled rejection appears in the console.
- [ ] Confirm the `.catch` log message appears in the console on error.
- [ ] Verify normal event planning refresh still works correctly on a healthy connection.

Closes #991

https://claude.ai/code/session_016AjG6C8CXfobK9dpntmMmk

---
_Generated by [Claude Code](https://claude.ai/code/session_016AjG6C8CXfobK9dpntmMmk)_