### PR TITLE
fix: handle video.play() rejection in QRScanner

### DIFF
--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -94,7 +94,15 @@ export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
         const video = videoRef.current;
         if (!video) throw new Error('Video element non disponibile.');
         video.srcObject = stream; video.muted = true;
-        await video.play().catch(() => {});
+        try {
+          await video.play();
+        } catch (playError) {
+          if (cancelled) return;
+          stopCamera();
+          setCameraError(formatCameraError(playError));
+          setIsStartingCamera(false);
+          return;
+        }
         if (cancelled) return;
         setIsStartingCamera(false);
 


### PR DESCRIPTION
Closes #994

`video.play()` returned a Promise whose rejection was silently swallowed with `.catch(() => {})`. This caused the scan loop to continue on a black frame with no feedback to the user.

The fix wraps `video.play()` in a proper try-catch block: on failure it stops the camera, sets a visible error message via `setCameraError(formatCameraError(playError))`, and returns early — preventing the scan loop from starting on an unusable stream.

---
_Generated by [Claude Code](https://claude.ai/code/session_014TQmRykpXoF9CseawUzA4J)_