### PR TITLE
fix: restrict dev-gate role checks to app_metadata only

### DIFF
--- a/apps/pwa/src/services/dev-gate.ts
+++ b/apps/pwa/src/services/dev-gate.ts
@@ -10,8 +10,10 @@ function parseEnvList(value: string): string[] {
 
 function getUserRoles(user: User): string[] {
   const roles = new Set<string>();
-  for (const meta of [user.app_metadata, user.user_metadata]) {
-    if (!meta) continue;
+  // Only trust app_metadata (server-side, not writable by the client).
+  // user_metadata is intentionally excluded to prevent privilege escalation.
+  const meta = user.app_metadata;
+  if (meta) {
     const r = meta.role;
     const rs = meta.roles;
     if (typeof r === "string") roles.add(r);


### PR DESCRIPTION
Closes #995

`getUserRoles()` was iterating over both `app_metadata` and `user_metadata`. Since `user_metadata` is writable by any authenticated client via the Supabase API, a regular user could self-assign a dev role (e.g. `{ role: "dev" }`) and gain access to the dev dashboard.

The fix removes `user_metadata` from the role resolution loop entirely — only `app_metadata` is consulted, which is server-side only and cannot be modified by the client. A comment explains the intent to prevent future regressions.

---
_Generated by [Claude Code](https://claude.ai/code/session_014TQmRykpXoF9CseawUzA4J)_