### PR TITLE
fix: add .limit(2) to activate_by_ticket_number SELECT query (closes #1002)

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -244,7 +244,7 @@ serve(async (req: Request) => {
           query = query.eq('event_id', payload.eventID.trim());
         }
 
-        const { data: tickets, error: searchError } = await query;
+        const { data: tickets, error: searchError } = await query.limit(2);
 
         if (searchError) throw searchError;
 


### PR DESCRIPTION
Closes #1002

The `activate_by_ticket_number` action was performing an unbounded SELECT on `ticket_activations`, fetching all rows matching the ticket number before the `tickets.length > 1` guard could fire. This could cause excessive memory usage (OOM) in the edge function if many rows share the same ticket number.

Fix: chain `.limit(2)` onto the query. Fetching at most 2 rows is sufficient to distinguish "not found" (0), "unique" (1), and "ambiguous" (2+) — the only three cases the logic needs to handle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3FuvKoHzrQbB8oJqDhMhp)_