### PR TITLE
fix: handle getUser() network error in dev-gate to avoid session destruction (closes #1003)

### DIFF
--- a/apps/pwa/src/services/dev-gate.ts
+++ b/apps/pwa/src/services/dev-gate.ts
@@ -139,7 +139,12 @@ export async function requireDevAccess(): Promise<boolean> {
           return;
         }
 
-        const { data: fresh } = await supabase!.auth.getUser();
+        const { data: fresh, error: freshError } = await supabase!.auth.getUser();
+        if (freshError) {
+          setBusy(gate, false);
+          setMessage(gate.message, "Errore di rete. Riprova.", "error");
+          return;
+        }
         if (!isUserAllowed(fresh.user)) {
           await supabase!.auth.signOut();
           setBusy(gate, false);


### PR DESCRIPTION
Closes #1003

After a successful `signInWithPassword`, a second `getUser()` is called to verify role membership. The `error` return value was previously discarded. On a transient network failure, `getUser()` returns `error != null` and `user === null`, which caused `isUserAllowed(null)` to return `false` — triggering `signOut()` (destroying the valid session) and displaying the misleading "Utente non autorizzato" message.

Fix: destructure `error` from the second `getUser()` call. If `error` is non-null, show "Errore di rete. Riprova." and return early without signing the user out, preserving the valid session for a retry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3FuvKoHzrQbB8oJqDhMhp)_