### PR TITLE
Randomize minigame targets and extract balancing constants

### DIFF
--- a/apps/mobile/src/gameplay/minigames.ts
+++ b/apps/mobile/src/gameplay/minigames.ts
@@ -1,5 +1,5 @@
 import type { RoleId } from '../state/store';
-import { STAT_EFFECTS } from '../../../../shared/config/balancing';
+import { MINIGAME_TARGET_RANGE, STAT_EFFECTS } from '../../../../shared/config/balancing';
 
 // Closes #471 — tolleranza adattiva basata sulla stat primaria del ruolo.
 // Formula: effectiveTolerance = round(baseTolerance * (1 + (stat - statBaseline) / 200))
@@ -153,6 +153,14 @@ export function isMinigameAvailableForRole(activityId: string, roleId?: RoleId |
   return roleId ? config.allowedRoles.includes(roleId) : false;
 }
 
+function randomTarget(): number {
+  return Math.floor(Math.random() * (MINIGAME_TARGET_RANGE.max - MINIGAME_TARGET_RANGE.min + 1)) + MINIGAME_TARGET_RANGE.min;
+}
+
+function withRandomTargets(config: MinigameConfig): MinigameConfig {
+  return { ...config, rounds: config.rounds.map(r => ({ ...r, target: randomTarget() }) ) };
+}
+
 export function getMinigameConfig(activityId: string, roleId?: RoleId | null, roleStats?: RoleStats | null): MinigameConfig {
   const config = MINIGAME_BY_ACTIVITY[activityId] ?? FALLBACK_CONFIG;
 
@@ -168,17 +176,17 @@ export function getMinigameConfig(activityId: string, roleId?: RoleId | null, ro
     const statValue = statKey ? roleStats[statKey] : null;
     if (statValue != null) {
       const factor = 1 + (statValue - STAT_EFFECTS.statBaseline) / 200;
-      return {
+      return withRandomTargets({
         ...base,
         rounds: base.rounds.map(r => ({
           ...r,
           tolerance: Math.max(1, Math.round(r.tolerance * factor)),
         })),
-      };
+      });
     }
   }
 
-  return base;
+  return withRandomTargets(base);
 }
 
 export function computeRoundScore(target: number, hit: number, tolerance: number) {

--- a/apps/mobile/src/gameplay/minigames.ts
+++ b/apps/mobile/src/gameplay/minigames.ts
@@ -1,7 +1,8 @@
 import type { RoleId } from '../state/store';
+import { STAT_EFFECTS } from '../../../../shared/config/balancing';
 
 // Closes #471 — tolleranza adattiva basata sulla stat primaria del ruolo.
-// Formula: effectiveTolerance = round(baseTolerance * (1 + (stat - 50) / 200))
+// Formula: effectiveTolerance = round(baseTolerance * (1 + (stat - statBaseline) / 200))
 export type RoleStats = { presence: number; precision: number; leadership: number; creativity: number };
 
 // Stat primaria per attività; determina quale caratteristica allarga la finestra di tolleranza.
@@ -166,7 +167,7 @@ export function getMinigameConfig(activityId: string, roleId?: RoleId | null, ro
     const statKey = ACTIVITY_PRIMARY_STAT[activityId];
     const statValue = statKey ? roleStats[statKey] : null;
     if (statValue != null) {
-      const factor = 1 + (statValue - 50) / 200;
+      const factor = 1 + (statValue - STAT_EFFECTS.statBaseline) / 200;
       return {
         ...base,
         rounds: base.rounds.map(r => ({

--- a/apps/mobile/src/gameplay/narrative.ts
+++ b/apps/mobile/src/gameplay/narrative.ts
@@ -1,6 +1,7 @@
 import type { RoleId } from '../state/store';
 import type { RoleStats } from './minigames';
 import { resolveAiChatEndpoint } from '../services/ai';
+import { ACTIVITY_REWARDS } from '../../../../shared/config/balancing';
 
 // Pure narrative engine (no React, no DOM). See issue #328.
 // Loads scenes registered in `../data/narrative` and applies player choices.
@@ -283,11 +284,8 @@ export function markDailySceneCompleted(ctx: NarrativeContext): void {
   } catch { /* quota exceeded — ignore */ }
 }
 
-// Reward bounds from shared/config/balancing.ts ACTIVITY_REWARDS.narrative_scene
-const REWARD_XP_MIN = 15;
-const REWARD_XP_MAX = 30;
-const REWARD_CACHET_MIN = 5;
-const REWARD_CACHET_MAX = 15;
+const { xp: { min: REWARD_XP_MIN, max: REWARD_XP_MAX }, cachet: { min: REWARD_CACHET_MIN, max: REWARD_CACHET_MAX } } =
+  ACTIVITY_REWARDS.narrative_scene;
 
 const SCENE_GENERATION_SYSTEM_PROMPT =
   'Sei Maxwell, narratore del gioco teatrale "Turni di Palco". ' +

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -10,6 +10,7 @@ import {
 import { resolveDisplayName } from '../lib/profile-utils';
 import { COOKIE_CONSENT_KEY, GEO_CONSENT_KEY } from '../constants/privacy';
 import { formatErrorDetails, reportCriticalError } from '../services/error-handler';
+import { getXpToNextLevel } from '../../../../shared/config/balancing';
 import { withMobileWatchdog } from '../services/mobile-watchdog';
 import {
   applyMobileFeatureFlagOverrides,
@@ -2160,7 +2161,7 @@ function applyRewards(profile: PlayerProfile, rewards: Rewards, source: 'turn' |
   while (nextXp >= nextThreshold) {
     nextXp -= nextThreshold;
     nextLevel += 1;
-    nextThreshold = 800 + nextLevel * 200; // closes #475 — curva più morbida (ex 1000 + n*250)
+    nextThreshold = getXpToNextLevel(nextLevel);
   }
 
   return {

--- a/apps/mobile/src/test/minigames.test.ts
+++ b/apps/mobile/src/test/minigames.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { getMinigameConfig, isMinigameAvailableForRole } from '../gameplay/minigames';
+import { MINIGAME_TARGET_RANGE } from '../../../../shared/config/balancing';
+
+describe('minigames — target randomisation', () => {
+  it('every target falls within MINIGAME_TARGET_RANGE', () => {
+    const activityIds = ['ritardo', 'palco', 'audio', 'recitazione', 'copione', 'sequenza_luci', 'equalizzazione'];
+    for (const id of activityIds) {
+      const config = getMinigameConfig(id);
+      for (const round of config.rounds) {
+        expect(round.target).toBeGreaterThanOrEqual(MINIGAME_TARGET_RANGE.min);
+        expect(round.target).toBeLessThanOrEqual(MINIGAME_TARGET_RANGE.max);
+      }
+    }
+  });
+
+  it('targets are integers', () => {
+    const config = getMinigameConfig('ritardo');
+    for (const round of config.rounds) {
+      expect(Number.isInteger(round.target)).toBe(true);
+    }
+  });
+
+  it('produces different targets across calls (probabilistic)', () => {
+    const targets1 = getMinigameConfig('palco').rounds.map(r => r.target);
+    // With 71^3 possible combinations the probability of two identical draws is negligible.
+    let differs = false;
+    for (let i = 0; i < 10; i++) {
+      const t = getMinigameConfig('palco').rounds.map(r => r.target);
+      if (t.some((v, idx) => v !== targets1[idx])) { differs = true; break; }
+    }
+    expect(differs).toBe(true);
+  });
+
+  it('tolerance is still preserved after randomisation', () => {
+    const config = getMinigameConfig('ritardo', null, { presence: 50, precision: 80, leadership: 50, creativity: 50 });
+    // All tolerances must be ≥ 1 (stat-adjusted floor)
+    for (const round of config.rounds) {
+      expect(round.tolerance).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe('minigames — isMinigameAvailableForRole', () => {
+  it('unrestricted activities are available to everyone', () => {
+    expect(isMinigameAvailableForRole('ritardo')).toBe(true);
+    expect(isMinigameAvailableForRole('audio')).toBe(true);
+  });
+
+  it('restricted activities require the correct role', () => {
+    expect(isMinigameAvailableForRole('sequenza_luci', 'luci')).toBe(true);
+    expect(isMinigameAvailableForRole('sequenza_luci', 'fonico')).toBe(false);
+    expect(isMinigameAvailableForRole('sequenza_luci')).toBe(false);
+  });
+});

--- a/shared/config/balancing.ts
+++ b/shared/config/balancing.ts
@@ -120,6 +120,14 @@ export const STAT_EFFECTS = {
 } as const;
 
 /**
+ * Random target range for minigame rounds.
+ * Targets are re-rolled each time a minigame starts to prevent pattern memorisation.
+ * The range avoids the extremes [0, 14] and [86, 100] so the bar always has
+ * visible travel on both sides of the target.
+ */
+export const MINIGAME_TARGET_RANGE = { min: 15, max: 85 } as const;
+
+/**
  * Daily / weekly activity caps. The numbers exist to validate the principle
  * "1 corso ogni 2 settimane di gioco attivo" without inventing them ad-hoc
  * inside scheduling code.


### PR DESCRIPTION
## Summary
This PR introduces target randomization for minigames to prevent pattern memorization, extracts magic numbers into shared balancing constants, and adds comprehensive test coverage for the minigame system.

## Key Changes
- **Target Randomization**: Minigame targets are now randomly generated within a configurable range (15-85) each time a minigame starts, preventing players from memorizing patterns while ensuring the progress bar always has visible travel on both sides
- **Extracted Constants**: 
  - Added `MINIGAME_TARGET_RANGE` constant to `shared/config/balancing.ts` defining the valid range for randomized targets
  - Moved narrative scene reward bounds from hardcoded values to `ACTIVITY_REWARDS.narrative_scene` configuration
  - Extracted XP progression formula into `getXpToNextLevel()` function for consistency
- **Updated Tolerance Formula**: Changed stat baseline from hardcoded `50` to `STAT_EFFECTS.statBaseline` for maintainability
- **Test Coverage**: Added comprehensive test suite covering:
  - Target range validation across all minigames
  - Integer target verification
  - Randomization effectiveness (probabilistic test)
  - Tolerance preservation after randomization
  - Role-based minigame availability

## Implementation Details
- The `randomTarget()` function uses uniform distribution within the configured range
- Randomization is applied via `withRandomTargets()` wrapper that preserves all other config properties
- The range [15, 85] was chosen to avoid extremes where the progress bar would have minimal visible travel
- All existing minigame logic and stat-based tolerance adjustments remain unchanged

https://claude.ai/code/session_01VM35Wav9XWZetZgQUNk8gf