### PR TITLE
fix: allow any authenticated user to use resolve_hash action

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -149,11 +149,6 @@ serve(async (req: Request) => {
     }
 
     if (action === 'resolve_hash') {
-      const resolveRole = authenticatedUser?.app_metadata?.role as string | undefined;
-      if (resolveRole !== 'admin' && resolveRole !== 'staff') {
-        return jsonResponse({ error: 'Accesso negato: ruolo admin o staff richiesto' }, 403);
-      }
-
       if (!hash || typeof hash !== 'string') {
         return jsonResponse({ error: 'Missing hash' }, 400);
       }


### PR DESCRIPTION
Closes #1009

## What changed
Removed the admin/staff role check from the `resolve_hash` action handler in the `ticket-activation` edge function. Any authenticated user (valid JWT) can now call `resolve_hash` to preview QR hash data. The `reserve_hash` action still correctly requires admin-only access.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2vfAvaNQYJUvFk8G8urDa)_