### PR TITLE
fix: clear appliedNarrativeChoicesRef on user session change

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3051,6 +3051,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     setHasHydratedRemote(false);
+    appliedNarrativeChoicesRef.current = new Set();
   }, [authUserId]);
 
   useEffect(() => {


### PR DESCRIPTION
Closes #1015

## What changed
Added `appliedNarrativeChoicesRef.current = new Set()` in the `useEffect` that fires on `authUserId` changes. This ensures the idempotency set for narrative choices is wiped whenever a new user logs in (or out), preventing cross-user pollution of already-applied choice keys.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2vfAvaNQYJUvFk8G8urDa)_