### PR TITLE
fix: don't reset SupportChat conversation on displayName change after auth hydration

### DIFF
--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -35,6 +35,8 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
   const historyId = userId || displayName;
   const displayNameRef = useRef(displayName);
   displayNameRef.current = displayName;
+  const userIdRef = useRef(userId);
+  userIdRef.current = userId;
   const greetingMessage = useMemo(() => buildSupportMessage('assistant',
     `Ciao ${displayName}! Sono Maxwell, pronto a darti una mano. Come posso aiutarti?`), [displayName]);
   const isMobile = useIsMobile();
@@ -65,10 +67,12 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
 
   // Only re-initialize chat state when the user identity (historyId) changes,
   // not when displayName changes after auth hydration (which would wipe an
-  // in-progress conversation).
+  // in-progress conversation). Refs are used for displayName/userId so the
+  // effect captures their latest values without being re-triggered by them.
   useEffect(() => {
     const currentDisplayName = displayNameRef.current;
-    const stored = loadChatHistory(currentDisplayName, userId);
+    const currentUserId = userIdRef.current;
+    const stored = loadChatHistory(currentDisplayName, currentUserId);
     if (stored.length) {
       setChatSessions(stored);
       setActiveSessionId(stored[0].id);
@@ -83,7 +87,6 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
       setMessages(session.messages);
     }
     hasLoadedRef.current = true;
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [historyId]);
 
   useEffect(() => () => { abortControllerRef.current?.abort(); }, []);

--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -33,6 +33,8 @@ const ISSUE_DRAFT_MARKER = 'ISSUE_DRAFT:';
 export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
   const displayName = userName || 'Utente';
   const historyId = userId || displayName;
+  const displayNameRef = useRef(displayName);
+  displayNameRef.current = displayName;
   const greetingMessage = useMemo(() => buildSupportMessage('assistant',
     `Ciao ${displayName}! Sono Maxwell, pronto a darti una mano. Come posso aiutarti?`), [displayName]);
   const isMobile = useIsMobile();
@@ -61,21 +63,28 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
     scrollRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
   }, [messages, isLoading]);
 
+  // Only re-initialize chat state when the user identity (historyId) changes,
+  // not when displayName changes after auth hydration (which would wipe an
+  // in-progress conversation).
   useEffect(() => {
-    const stored = loadChatHistory(displayName, userId);
+    const currentDisplayName = displayNameRef.current;
+    const stored = loadChatHistory(currentDisplayName, userId);
     if (stored.length) {
       setChatSessions(stored);
       setActiveSessionId(stored[0].id);
       setMessages(stored[0].messages);
     } else {
       const sessionId = buildMessageId();
-      const session: ChatSession = { id: sessionId, createdAt: Date.now(), updatedAt: Date.now(), messages: [greetingMessage] };
+      const greeting = buildSupportMessage('assistant',
+        `Ciao ${currentDisplayName}! Sono Maxwell, pronto a darti una mano. Come posso aiutarti?`);
+      const session: ChatSession = { id: sessionId, createdAt: Date.now(), updatedAt: Date.now(), messages: [greeting] };
       setChatSessions([session]);
       setActiveSessionId(sessionId);
       setMessages(session.messages);
     }
     hasLoadedRef.current = true;
-  }, [historyId, greetingMessage]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [historyId]);
 
   useEffect(() => () => { abortControllerRef.current?.abort(); }, []);
 


### PR DESCRIPTION
Closes #1011

## What changed
The chat initialization `useEffect` previously depended on both `historyId` and `greetingMessage`. Since `greetingMessage` is derived from `displayName` (which can change after auth hydration while the same user is still logged in), any `displayName` update would wipe the in-progress conversation.

Fixed by making the init effect depend only on `historyId` (user identity). A `displayNameRef` tracks the latest `displayName` so the correct name is used when building the greeting for a new session, without causing the effect to re-run on subsequent display-name changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2vfAvaNQYJUvFk8G8urDa)_