### PR TITLE
fix: send onboarded installed users to home not welcome from QR landing

### DIFF
--- a/apps/mobile/src/hooks/useQrLanding.ts
+++ b/apps/mobile/src/hooks/useQrLanding.ts
@@ -5,7 +5,7 @@ export function useQrLanding(
     _authReady: boolean,
     _isAuthValid: boolean,
     isOnboarded: boolean,
-    onLanding: (target: 'welcome' | 'install' | 'role-selection') => void,
+    onLanding: (target: 'welcome' | 'home' | 'install' | 'role-selection') => void,
 ) {
     const hasHandledQrLanding = useRef(false);
 
@@ -31,7 +31,8 @@ export function useQrLanding(
             // New user arriving via QR deep-link: skip first mission, just choose role
             onLanding('role-selection');
         } else {
-            onLanding('welcome');
+            // Onboarded user arriving via QR: go directly to home, not to the login screen
+            onLanding('home');
         }
 
         try {


### PR DESCRIPTION
Closes #1008

## What changed
In `useQrLanding.ts`, the `else` branch (onboarded + installed user arriving via QR) was calling `onLanding('welcome')` which sends users to the login screen. Changed to `onLanding('home')` so they go directly to the app home screen. Also added `'home'` to the callback type signature.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2vfAvaNQYJUvFk8G8urDa)_