### PR TITLE
fix: move setCatalog inside isMounted guard in loadCatalog

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3688,12 +3688,12 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
                 difficulty: activity.difficulty as Activity['difficulty'],
               }));
 
+          if (!isMounted) return;
           setCatalog({
             roles: nextRoles,
             events: nextEvents,
             activities: nextActivities,
           });
-          if (!isMounted) return;
           await refreshEventPlanning(nextEvents);
         },
         {


### PR DESCRIPTION
Closes #1010

## What changed
In `store.tsx` `loadCatalog`, `setCatalog` was called before the `isMounted` guard, risking a setState call on an unmounted component. Moved `setCatalog` to after the `if (!isMounted) return` check so it only fires when the component is still mounted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2vfAvaNQYJUvFk8G8urDa)_