### PR TITLE
fix: add .catch() to fire-and-forget calls in purchaseShopItem

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4519,9 +4519,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           },
         }));
 
-        void refreshActivitySlotsStatus();
+        refreshActivitySlotsStatus().catch(() => {});
         if (rpcResponse.theatre) {
-          void refreshTheatreReputation();
+          refreshTheatreReputation().catch(() => {});
         }
 
         return {


### PR DESCRIPTION
Closes #1013

## What changed
In `store.tsx` `purchaseShopItem`, replaced `void refreshActivitySlotsStatus()` and `void refreshTheatreReputation()` with `.catch(() => {})` to prevent unhandled promise rejections from propagating silently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2vfAvaNQYJUvFk8G8urDa)_