### PR TITLE
fix: add .catch() to refreshBadges fire-and-forget in completeActivity

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4636,7 +4636,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           };
         });
 
-        void refreshBadges();
+        refreshBadges().catch(() => {});
 
         return {
           ok: true,


### PR DESCRIPTION
Closes #1014

## What changed
In `store.tsx` `completeActivity`, replaced `void refreshBadges()` with `refreshBadges().catch(() => {})` to prevent unhandled `WatchdogTimeoutError` (and any other rejection) from propagating as an unhandled promise rejection.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2vfAvaNQYJUvFk8G8urDa)_