### PR TITLE
fix: remove extraActivitySlots from refreshActivitySlotsStatus useCallback deps

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -2310,7 +2310,11 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   // in this session. Guards completeNarrativeChoice against double-credit on
   // re-render, offline-queue replay, or any other duplicate invocation.
   const appliedNarrativeChoicesRef = useRef<Set<string>>(new Set());
+  // Ref so refreshActivitySlotsStatus can read the latest extraActivitySlots
+  // without being recreated on every shop purchase.
+  const extraActivitySlotsRef = useRef(state.profile.extraActivitySlots);
   useEffect(() => { eventPlansRef.current = state.eventPlans; }, [state.eventPlans]);
+  useEffect(() => { extraActivitySlotsRef.current = state.profile.extraActivitySlots; }, [state.profile.extraActivitySlots]);
 
   const syncLocalEventPlanning = useCallback(
     (plans: EventPlanning[]) => {
@@ -3239,7 +3243,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
   const refreshActivitySlotsStatus = useCallback(async () => {
     if (!isSupabaseConfigured || !supabase || !authUserId) {
-      const totalSlots = 3 + state.profile.extraActivitySlots;
+      const totalSlots = 3 + extraActivitySlotsRef.current;
       setActivitySlotsStatus({
         usedToday: 0,
         totalSlots,
@@ -3280,7 +3284,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         message: 'Il controllo slot attività sta impiegando troppo tempo.',
       }
     );
-  }, [authUserId, state.profile.extraActivitySlots]);
+  }, [authUserId]);
 
   const applyFeatureFlagsSnapshot = useCallback(
     (


### PR DESCRIPTION
Closes #1016

## What changed
`refreshActivitySlotsStatus` had `state.profile.extraActivitySlots` in its `useCallback` dependency array, causing the function reference to be recreated on every shop purchase (which updates `extraActivitySlots`). This triggered spurious remote refetches.

Fixed by storing the latest `extraActivitySlots` in an `extraActivitySlotsRef` (kept in sync via a `useEffect`), and reading from the ref inside the callback instead of closing over `state.profile.extraActivitySlots`. The dependency is removed from the `useCallback` array, so the function reference is now stable across shop purchases.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2vfAvaNQYJUvFk8G8urDa)_