### PR TITLE
fix: check both role string and roles array for admin access (closes #1027)

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -95,8 +95,12 @@ serve(async (req: Request) => {
     }
 
     if (action === 'reserve_hash') {
-      const userRole = authenticatedUser?.app_metadata?.role as string | undefined;
-      if (userRole !== 'admin') {
+      const roleSingle = authenticatedUser?.app_metadata?.role as string | undefined;
+      const rolesArray = authenticatedUser?.app_metadata?.roles as string[] | undefined;
+      const isAdmin =
+        roleSingle === 'admin' ||
+        (Array.isArray(rolesArray) && rolesArray.includes('admin'));
+      if (!isAdmin) {
         return jsonResponse({ error: 'Accesso negato: ruolo admin richiesto' }, 403);
       }
 


### PR DESCRIPTION
Closes #1027

## Changes
Mirror the dual-field admin check from `dev-gate.ts` in `ticket-activation`: verify both `app_metadata.role` (string) and `app_metadata.roles` (array) so admins provisioned via the roles-array format are no longer denied with 403.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ca4FGeyeZ3hU6aPcL2hEvy)_