### PR TITLE
fix: document in-memory rateBuckets isolate scope limitation (closes #1028)

### DIFF
--- a/supabase/functions/public-leaderboard/index.ts
+++ b/supabase/functions/public-leaderboard/index.ts
@@ -14,6 +14,14 @@ const MAX_LIMIT = 200;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 60;
 const RATE_LIMIT_SWEEP_EVERY = 128;
+// NOTE: rateBuckets is module-level state within a single Deno isolate instance.
+// Supabase Edge Functions may spin up multiple isolate instances concurrently (one per
+// request or per region), each with their own memory. This Map is NOT shared across
+// isolates, so rate limiting is only effective within a single isolate — concurrent
+// requests routed to different isolates bypass this check entirely.
+// For production-grade rate limiting, use a shared persistent store (e.g. Supabase KV,
+// a Redis-compatible store, or Supabase dashboard rate-limit rules applied before the
+// function is invoked). See issue #1028.
 const rateBuckets = new Map<string, number[]>();
 let rateLimitCallsSinceSweep = 0;
 


### PR DESCRIPTION
Closes #1028

## Changes
Add a prominent comment near the module-level `rateBuckets` Map in `public-leaderboard` explaining that it is not shared across Deno isolate instances, making the in-process rate limiting ineffective under real production concurrency, and documenting that a shared persistent store (Supabase KV, Redis, or dashboard-level rules) is needed for effective rate limiting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ca4FGeyeZ3hU6aPcL2hEvy)_