### PR TITLE
fix: catch network errors in fetchShowPosts with page context (closes #1029)

### DIFF
--- a/supabase/functions/import-atcl-lazio/index.ts
+++ b/supabase/functions/import-atcl-lazio/index.ts
@@ -149,7 +149,13 @@ async function fetchShowPosts(categoryId: number, modifiedAfter: string): Promis
     const url =
       `${WP_API}/posts?categories=${categoryId}&per_page=${POSTS_PER_PAGE}&page=${page}` +
       `&modified_after=${encodeURIComponent(modifiedAfter)}&orderby=modified&order=desc&${fields}`;
-    const res = await fetchWithTimeout(url);
+    let res: Response;
+    try {
+      res = await fetchWithTimeout(url);
+    } catch (err) {
+      console.warn(`[import-atcl-lazio] fetchShowPosts network error on page ${page} (${url}):`, err);
+      break;
+    }
     if (!res.ok) break;
     const batch = (await res.json()) as WpPost[];
     if (!Array.isArray(batch) || batch.length === 0) break;


### PR DESCRIPTION
Closes #1029

## Changes
Wrap the `fetchWithTimeout` call inside `fetchShowPosts` in a try/catch block so DNS failures, TCP resets, and `AbortError` timeouts are caught, logged with the failing page number and URL for diagnosability, and result in a clean `break` rather than an uncaught exception propagating to the outer handler.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ca4FGeyeZ3hU6aPcL2hEvy)_