### PR TITLE
fix: validate GitHub API response is array before processing (closes #1030)

### DIFF
--- a/supabase/functions/app-version/index.ts
+++ b/supabase/functions/app-version/index.ts
@@ -96,12 +96,17 @@ serve(async (req) => {
     return errorResponse('Impossibile caricare il changelog', 502);
   }
 
-  let json: any[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let json: any[];
   try {
     const parsed = await response.json();
-    json = Array.isArray(parsed) ? parsed : [];
+    if (!Array.isArray(parsed)) {
+      console.warn('[app-version] unexpected GitHub API response shape', parsed);
+      return errorResponse('GitHub API returned unexpected format', 502);
+    }
+    json = parsed;
   } catch {
-    json = [];
+    return errorResponse('Impossibile analizzare la risposta GitHub', 502);
   }
 
   const changelog: ChangelogEntry[] = json.map((item) => {


### PR DESCRIPTION
Closes #1030

## Changes
Replace the silent `Array.isArray(parsed) ? parsed : []` fallback in `app-version` with an explicit validation: if the GitHub API response is not an array (e.g. rate-limit error object), log a warning and return a 502 with a clear error message rather than silently returning an empty changelog that masks the root cause.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ca4FGeyeZ3hU6aPcL2hEvy)_