### PR TITLE
fix: check app_metadata.roles array in cleanup-events

### DIFF
--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -50,7 +50,9 @@ serve(async (req) => {
     }
 
     const userRole = (user.app_metadata as Record<string, unknown>)?.role as string | undefined
-    if (userRole !== 'admin') {
+    const userRoles = (user.app_metadata as Record<string, unknown>)?.roles as string[] | undefined
+    const isAdmin = userRole === 'admin' || (Array.isArray(userRoles) && userRoles.includes('admin'))
+    if (!isAdmin) {
       return new Response(JSON.stringify({ error: 'Accesso negato: ruolo admin richiesto' }), {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         status: 403,


### PR DESCRIPTION
Closes #1043

## What was fixed

The `cleanup-events` function only checked the scalar `app_metadata.role` string when verifying admin access. Admins assigned via the `app_metadata.roles` array were incorrectly denied access with a 403.

Fixed by checking both `app_metadata.role` (scalar) and `app_metadata.roles` (array), matching the established pattern used in `ticket-activation` and `dev-access`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014wK6Y8PLH8gESTJWAMQQZH)_