### PR TITLE
fix: check app_metadata.roles array in import-atcl-lazio

### DIFF
--- a/supabase/functions/import-atcl-lazio/index.ts
+++ b/supabase/functions/import-atcl-lazio/index.ts
@@ -210,7 +210,9 @@ serve(async (req) => {
     }
 
     const userRole = (user.app_metadata as Record<string, unknown>)?.role as string | undefined;
-    if (userRole !== 'admin') {
+    const userRoles = (user.app_metadata as Record<string, unknown>)?.roles as string[] | undefined;
+    const isAdmin = userRole === 'admin' || (Array.isArray(userRoles) && userRoles.includes('admin'));
+    if (!isAdmin) {
       return jsonResponse({ error: 'Accesso negato: ruolo admin richiesto' }, 403);
     }
   }


### PR DESCRIPTION
Closes #1044

## What was fixed

The `import-atcl-lazio` function only checked the scalar `app_metadata.role` string when verifying admin access. Admins assigned via the `app_metadata.roles` array were incorrectly denied access with a 403.

Fixed by checking both `app_metadata.role` (scalar) and `app_metadata.roles` (array), matching the established pattern used in `ticket-activation` and `dev-access`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014wK6Y8PLH8gESTJWAMQQZH)_