### PR TITLE
fix: check app_metadata.roles array in import-spazio-rossellini

### DIFF
--- a/supabase/functions/import-spazio-rossellini/index.ts
+++ b/supabase/functions/import-spazio-rossellini/index.ts
@@ -185,7 +185,9 @@ serve(async (req) => {
     }
 
     const userRole = (user.app_metadata as Record<string, unknown>)?.role as string | undefined;
-    if (userRole !== 'admin') {
+    const userRoles = (user.app_metadata as Record<string, unknown>)?.roles as string[] | undefined;
+    const isAdmin = userRole === 'admin' || (Array.isArray(userRoles) && userRoles.includes('admin'));
+    if (!isAdmin) {
       return jsonResponse({ error: 'Accesso negato: ruolo admin richiesto' }, 403);
     }
   }


### PR DESCRIPTION
Closes #1045

## What was fixed

The `import-spazio-rossellini` function only checked the scalar `app_metadata.role` string when verifying admin access. Admins assigned via the `app_metadata.roles` array were incorrectly denied access with a 403.

Fixed by checking both `app_metadata.role` (scalar) and `app_metadata.roles` (array), matching the established pattern used in `ticket-activation` and `dev-access`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014wK6Y8PLH8gESTJWAMQQZH)_