### PR TITLE
fix: gate setHasHydratedRemote on valid profile in loadRemoteState

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3843,7 +3843,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             }));
           }
 
-          if (profileRow || !profileRes.error) {
+          if (profileRow) {
             setHasHydratedRemote(true);
           }
         },


### PR DESCRIPTION
Closes #1046

## What was fixed

In `loadRemoteState`, the condition `if (profileRow || !profileRes.error)` allowed `setHasHydratedRemote(true)` to be called even when the profile INSERT failed. If `profileRes.data` was null (profile didn't exist) and the subsequent INSERT returned an error, `profileRow` would be `null` and `profileRes.error` would be set — but `!profileRes.error` would be `false`, so the OR condition could still pass via `profileRow` being falsy only if `!profileRes.error` was true.

More critically: the condition `profileRow || !profileRes.error` is semantically wrong — it allows hydration to proceed with a null profile as long as the *initial* fetch had no error, even if the INSERT that was supposed to create the profile failed.

Fixed by gating `setHasHydratedRemote(true)` exclusively on `profileRow` being non-null, ensuring hydration only proceeds when a valid profile (either fetched or newly inserted) is available.

---
_Generated by [Claude Code](https://claude.ai/code/session_014wK6Y8PLH8gESTJWAMQQZH)_