### PR TITLE
fix: build nextProfile inside setState updater in completeOnboarding

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4138,7 +4138,6 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   const completeOnboarding = useCallback(
     (variant: 'full' | 'skipped_qr' | 'skipped_manual', xpReward?: number) => {
       const completedAt = new Date().toISOString();
-      let nextProfile: PlayerProfile | null = null;
       setState((prev: GameState) => {
         let profile: PlayerProfile = {
           ...prev.profile,
@@ -4148,12 +4147,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         if (xpReward && xpReward > 0) {
           profile = applyRewards(profile, { xp: xpReward, cachet: 0, reputation: 0 }, 'activity');
         }
-        nextProfile = profile;
+        persistProfile(profile);
         return { ...prev, profile };
       });
-      if (nextProfile !== null) {
-        persistProfile(nextProfile);
-      }
     },
     [persistProfile],
   );


### PR DESCRIPTION
Closes #1047

## What was fixed

`completeOnboarding` captured `nextProfile` via a `let` variable outside the `setState` updater and called `persistProfile(nextProfile)` after `setState` returned. Under React 18 concurrent mode, the updater may be called multiple times or the synchronous assignment to `nextProfile` may not reflect the latest state when `persistProfile` is called.

Fixed by moving `persistProfile` inside the `setState` updater callback, so `profile` is always constructed from the latest `prev` snapshot and persisted atomically — matching the pattern established in the `updateProfile` fix (closes #947/PR related to #925).

---
_Generated by [Claude Code](https://claude.ai/code/session_014wK6Y8PLH8gESTJWAMQQZH)_