### PR TITLE
fix: wrap res.json() in try/catch in fetchShowPosts

### DIFF
--- a/supabase/functions/import-atcl-lazio/index.ts
+++ b/supabase/functions/import-atcl-lazio/index.ts
@@ -160,7 +160,16 @@ async function fetchShowPosts(categoryId: number, modifiedAfter: string): Promis
       break;
     }
     if (!res.ok) break;
-    const batch = (await res.json()) as WpPost[];
+    let batch: WpPost[];
+    try {
+      batch = (await res.json()) as WpPost[];
+    } catch (err) {
+      console.warn(
+        `[import-atcl-lazio] fetchShowPosts invalid JSON on page ${page} (endpoint: ${WP_API}/posts):`,
+        err,
+      );
+      break;
+    }
     if (!Array.isArray(batch) || batch.length === 0) break;
     posts.push(...batch);
     if (batch.length < POSTS_PER_PAGE) break;


### PR DESCRIPTION
Closes #1053

In `supabase/functions/import-atcl-lazio/index.ts`, the `res.json()` call inside `fetchShowPosts` was not wrapped in a try/catch. If the server returns a non-JSON response body, this would throw an unhandled error and crash the function.

This fix wraps the `res.json()` call in a try/catch block that logs a warning and breaks out of the pagination loop gracefully, consistent with how the network error is handled above it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYteKEz54sS73P4MaEhdnP)_