### PR TITLE
fix: wrap res.json() in try/catch in fetchAllEvents

### DIFF
--- a/supabase/functions/import-spazio-rossellini/index.ts
+++ b/supabase/functions/import-spazio-rossellini/index.ts
@@ -122,7 +122,16 @@ const fetchAllEvents = async () => {
     visited.add(nextUrl);
     const res = await fetchWithTimeout(nextUrl);
     if (!res.ok) throw new Error(`Events API fetch failed: ${res.status}`);
-    const payload = await res.json();
+    let payload: { events?: SpazioEvent[]; next_rest_url?: string };
+    try {
+      payload = await res.json();
+    } catch (err) {
+      console.warn(
+        `[import-spazio-rossellini] fetchAllEvents invalid JSON (url: ${nextUrl}):`,
+        err,
+      );
+      break;
+    }
     if (Array.isArray(payload.events)) {
       events.push(...payload.events);
     }


### PR DESCRIPTION
Closes #1054

In `supabase/functions/import-spazio-rossellini/index.ts`, the `res.json()` call inside `fetchAllEvents` was not wrapped in a try/catch. If the server returns a non-JSON response body, this would throw an unhandled error and crash the function.

This fix wraps the `res.json()` call in a try/catch block that logs a warning and breaks out of the pagination loop gracefully. The `payload` variable is also given an explicit type annotation matching the expected shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYteKEz54sS73P4MaEhdnP)_