### PR TITLE
fix: add SUPABASE_ANON_KEY guard in delete-my-account before createClient

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -32,8 +32,9 @@ serve(async (req) => {
 
   const supabaseUrl = Deno.env.get('SUPABASE_URL');
   const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  const anonKey = Deno.env.get('SUPABASE_ANON_KEY');
 
-  if (!supabaseUrl || !serviceKey) {
+  if (!supabaseUrl || !serviceKey || !anonKey) {
     return errorResponse('Configurazione server non disponibile', 500);
   }
 
@@ -44,7 +45,7 @@ serve(async (req) => {
   }
 
   // User-scoped client (respects RLS) – used to verify identity
-  const userClient = createClient(supabaseUrl, Deno.env.get('SUPABASE_ANON_KEY') ?? '', {
+  const userClient = createClient(supabaseUrl, anonKey, {
     global: { headers: { Authorization: authHeader } },
     auth: { autoRefreshToken: false, persistSession: false },
   });


### PR DESCRIPTION
Closes #1062

Added `SUPABASE_ANON_KEY` to the env-var guard check alongside `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`. The guarded variable is now passed directly to `createClient` instead of using `Deno.env.get(...) ?? ''`, preventing the client from being initialized with an empty anon key in misconfigured deployments.

---
_Generated by [Claude Code](https://claude.ai/code/session_012eYbBQEfc6zK5QPbGbzwxu)_