### PR TITLE
fix: normalize roleId to null in resolve_deep_link when role_id param is absent

### DIFF
--- a/supabase/functions/event-links/index.ts
+++ b/supabase/functions/event-links/index.ts
@@ -200,7 +200,9 @@ serve(async (req) => {
     }
 
     const eventId = normalizeEventId(url.searchParams.get('event_id') ?? url.searchParams.get('eid'));
-    const roleId = url.searchParams.get('role_id');
+    // URLSearchParams.get() returns null when absent, which is correct.
+    // Normalise with || null so an empty string also becomes null, not "".
+    const roleId = url.searchParams.get('role_id') || null;
     if (!eventId) {
       return json({ error: 'event_id mancante' }, 400);
     }


### PR DESCRIPTION
Closes #1064

Changed `url.searchParams.get('role_id')` to `url.searchParams.get('role_id') || null` in the `resolve_deep_link` action handler. This ensures that when `role_id` is absent from the URL, `roleId` is always `null` (not an empty string), preventing consumers from inadvertently calling `String(roleId)` and getting `"null"` as a role ID.

---
_Generated by [Claude Code](https://claude.ai/code/session_012eYbBQEfc6zK5QPbGbzwxu)_