### PR TITLE
fix: use plan's roleId in cancelEventPlan offline payload

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3532,6 +3532,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   const cancelEventPlan = useCallback(
     async (eventId: string) => {
       logOfflineSync('Action cancelEventPlan', { eventId });
+      const plan = eventPlans.find((p) => p.eventId === eventId);
+      const plannedRoleId = plan?.roleId ?? 'attore';
       setState((prev) => ({
         ...prev,
         eventPlans: removeEventPlan(prev.eventPlans, eventId),
@@ -3554,7 +3556,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         payload: {
           user_id: authUserId,
           event_id: eventId,
-          planned_role_id: state.profile.roleId,
+          planned_role_id: plannedRoleId,
           planning_status: 'planned',
         },
       };
@@ -3595,7 +3597,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         enqueueSupabaseMutation(queuedMutation);
       });
     },
-    [authUserId, enqueueSupabaseMutation, state.profile.roleId]
+    [authUserId, enqueueSupabaseMutation, eventPlans]
   );
 
   const followEvent = useCallback(


### PR DESCRIPTION
Closes #1078

`cancelEventPlan` was building the offline-queue payload with `state.profile.roleId` — the user's *current* role at callback-creation time — rather than the role stored on the plan being cancelled. This is both semantically wrong (the plan may have been created with a different role) and a stale-closure hazard.

The fix captures `plannedRoleId` from the plan object (`eventPlans.find(...)`) before any state mutation, and replaces `state.profile.roleId` in the `useCallback` dependency array with `eventPlans`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FU7unkjXuyRSnTziQ6bCgG)_