### PR TITLE
fix: bail out of loadRemoteState after turns fetch error

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3762,6 +3762,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
           if (turnsRes.error) {
             notifyCriticalError('Non riusciamo a caricare i turni dal database.', [turnsRes.error]);
+            return;
           }
 
           if (userRes.error) {


### PR DESCRIPTION
Closes #1079

`loadRemoteState` called `notifyCriticalError` when `turnsRes.error` was truthy but did not return early; profile hydration continued and `setHasHydratedRemote(true)` was still reached, leaving the UI in a mixed error-and-success state that silently masked the failed data load.

The fix adds a `return` immediately after the `notifyCriticalError` call for `turnsRes.error`, ensuring hydration is aborted when turns data cannot be loaded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FU7unkjXuyRSnTziQ6bCgG)_