### PR TITLE
fix: wrap fetchWithTimeout in try/catch with URL and page context

### DIFF
--- a/supabase/functions/import-spazio-rossellini/index.ts
+++ b/supabase/functions/import-spazio-rossellini/index.ts
@@ -133,8 +133,16 @@ const fetchAllEvents = async () => {
   const visited = new Set<string>();
   while (nextUrl && !visited.has(nextUrl) && visited.size < MAX_PAGINATION_PAGES) {
     visited.add(nextUrl);
-    const res = await fetchWithTimeout(nextUrl);
-    if (!res.ok) throw new Error(`Events API fetch failed: ${res.status}`);
+    const page = visited.size;
+    let res: Response;
+    try {
+      res = await fetchWithTimeout(nextUrl);
+    } catch (err) {
+      throw new Error(
+        `Events API network error on page ${page} (url: ${nextUrl}): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    if (!res.ok) throw new Error(`Events API fetch failed: ${res.status} (page ${page}, url: ${nextUrl})`);
     let payload: { events?: SpazioEvent[]; next_rest_url?: string };
     try {
       payload = await res.json();


### PR DESCRIPTION
Closes #1080

`fetchAllEvents` called `fetchWithTimeout(nextUrl)` with no surrounding try/catch. Any network-level failure propagated through `Promise.all` to the outer handler which returned a generic 500, discarding all diagnostic context about which page and URL failed.

The fix wraps the call in a try/catch that rethrows with the page number and URL included in the error message. The existing `res.ok` check was also updated to include the same context.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FU7unkjXuyRSnTziQ6bCgG)_