### PR TITLE
fix: remove spurious initialEvents[0] fallback for scannedEventId

### DIFF
--- a/apps/mobile/src/hooks/useNavigation.ts
+++ b/apps/mobile/src/hooks/useNavigation.ts
@@ -147,7 +147,7 @@ export function useNavigation(initialEvents: { id: string }[], options?: UseNavi
     const [legalReturnScreen, setLegalReturnScreen] = useState<LegalReturnScreen>(() => persistedNavState?.legalReturnScreen ?? 'welcome');
     const [isPasswordRecovery, setIsPasswordRecovery] = useState(false);
     const [activeTab, setActiveTab] = useState<Tab>(() => persistedNavState?.activeTab ?? 'home');
-    const [scannedEventId, setScannedEventId] = useState<string>(() => persistedNavState?.scannedEventId ?? initialEvents[0]?.id ?? '');
+    const [scannedEventId, setScannedEventId] = useState<string>(() => persistedNavState?.scannedEventId ?? '');
     const [selectedActivityId, setSelectedActivityId] = useState<string>(() => persistedNavState?.selectedActivityId ?? '');
     const [currentNarrativeSceneId, setCurrentNarrativeSceneId] = useState<string>(() => persistedNavState?.currentNarrativeSceneId ?? '');
 


### PR DESCRIPTION
Closes #1088

Ensures `scannedEventId` defaults to `''` rather than the first event ID when no QR has been scanned.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKDUunykrCSAtwEFGafNac)_