### PR TITLE
Fix skip-link overflow into iOS status bar on mobile

### DIFF
--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -474,6 +474,8 @@ html[data-theme="light"] .text-white {
     z-index: 1000;
     padding: 10px 16px;
     max-width: calc(100vw - 32px);
+    overflow: hidden;
+    text-overflow: ellipsis;
     background: var(--color-bg-surface-elevated);
     color: var(--color-gold-400);
     border: 2px solid var(--color-gold-400);

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -468,11 +468,12 @@ html[data-theme="light"] .text-white {
   /* WCAG 2.1 — 2.4.1 Bypass Blocks: skip-link visible only on focus. */
   .skip-link {
     position: fixed;
-    top: calc(env(safe-area-inset-top, 0px) + 8px);
+    top: max(env(safe-area-inset-top, 0px) + 8px, 56px);
     left: 50%;
     transform: translate(-50%, -150%);
     z-index: 1000;
     padding: 10px 16px;
+    max-width: calc(100vw - 32px);
     background: var(--color-bg-surface-elevated);
     color: var(--color-gold-400);
     border: 2px solid var(--color-gold-400);
@@ -480,6 +481,7 @@ html[data-theme="light"] .text-white {
     font-size: 0.875rem;
     font-weight: 600;
     text-decoration: none;
+    white-space: nowrap;
     transition: transform 150ms ease-out;
   }
 

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -468,6 +468,7 @@ html[data-theme="light"] .text-white {
   /* WCAG 2.1 — 2.4.1 Bypass Blocks: skip-link visible only on focus. */
   .skip-link {
     position: fixed;
+    /* 56px floor: garantisce visibilità sotto status bar/notch quando env(safe-area-inset-top) è 0 (es. browser tab non-PWA). */
     top: max(env(safe-area-inset-top, 0px) + 8px, 56px);
     left: 50%;
     transform: translate(-50%, -150%);


### PR DESCRIPTION
The accessibility skip-link 'Salta al contenuto principale' was wrapping
to two lines on narrow phones, causing the first line to be clipped by
the iOS status bar/notch area and leaving only 'principale' visible.

- Add white-space: nowrap to keep the label on a single line
- Add max-width to prevent horizontal overflow on very narrow viewports
- Use max() so the top offset has a sensible minimum (56px) even when
  env(safe-area-inset-top) evaluates to 0 (e.g. non-PWA browser tabs)