### PR TITLE
fix: stabilize useAuth effect dep array to prevent re-registration on every render (closes #1092)

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -274,7 +274,8 @@ export function useAuth(
             mounted = false;
             authListener?.subscription.unsubscribe();
         };
-    }, [applyUserProfileFromAuth, onLogout]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     return {
         authError,


### PR DESCRIPTION
Closes #1092

Both `applyUserProfileFromAuth` and `onLogout` are already accessed inside the effect exclusively through stable refs (`applyUserProfileRef.current` / `onLogoutRef.current`), so listing the original callbacks in the dependency array caused the effect to tear down and re-run on every render. Removing them from the dep array (and suppressing the lint warning since the ref pattern is intentional) ensures the Supabase auth listener is registered exactly once.

---
_Generated by [Claude Code](https://claude.ai/code/session_019QNNhqJPBdBzFWGVrGWYzQ)_