### PR TITLE
fix: guard against empty scannedEventId before calling registerTurn (closes #1093)

### DIFF
--- a/apps/mobile/src/handlers/useQrHandlers.ts
+++ b/apps/mobile/src/handlers/useQrHandlers.ts
@@ -219,8 +219,11 @@ export function useQrHandlers(deps: QrHandlerDeps) {
     }
 
     // Standard confirmation (no ticket activation)
+    if (!scannedEventId) {
+      return { ok: false, error: 'Evento non selezionato.' };
+    }
     const turnResult = await registerTurn({
-      eventId: scannedEventId ?? '',
+      eventId: scannedEventId,
       roleId: profileRoleId,
       eventOverride: confirmationEventOverride ?? undefined,
       boostRequested,


### PR DESCRIPTION
Closes #1093

Added an early-return guard before the `registerTurn` call in `handleEventConfirm`: when `scannedEventId` is falsy (empty string, null, or undefined) the function now returns `{ ok: false, error: 'Evento non selezionato.' }` immediately instead of passing an empty string to `registerTurn` and producing a silent "Evento non trovato" failure.

---
_Generated by [Claude Code](https://claude.ai/code/session_019QNNhqJPBdBzFWGVrGWYzQ)_