### PR TITLE
fix: prevent double notifyCriticalError when both profile and turns errors are set (closes #1094)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3760,15 +3760,11 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
               userRes.error,
               profileRes.error,
             ]);
+            return;
           }
 
           if (turnsRes.error) {
             notifyCriticalError('Non riusciamo a caricare i turni dal database.', [turnsRes.error]);
-            return;
-          }
-
-          if (userRes.error) {
-            console.warn('[loadRemoteState] auth error, aborting profile load:', userRes.error);
             return;
           }
 


### PR DESCRIPTION
Closes #1094

Added a `return` after the first `notifyCriticalError` call in `loadRemoteState`. Previously, when both `userRes.error`/`profileRes.error` and `turnsRes.error` were set simultaneously (e.g. on a network outage), two error banners fired in rapid succession. Now only the first applicable error is surfaced and the function exits early.

---
_Generated by [Claude Code](https://claude.ai/code/session_019QNNhqJPBdBzFWGVrGWYzQ)_