### PR TITLE
fix: return zero rewards from completeNarrativeChoice already-applied guard (closes #1096)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4714,12 +4714,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       const choiceKey = `${input.sceneId}:${input.choiceId}`;
       if (appliedNarrativeChoicesRef.current.has(choiceKey)) {
         logOfflineSync('completeNarrativeChoice skipped — already applied', { choiceKey }, 'warn');
-        const rewards: Rewards = {
-          xp: Math.max(0, Math.round(input.rewards.xp ?? 0)),
-          cachet: Math.max(0, Math.round(input.rewards.cachet ?? 0)),
-          reputation: Math.max(0, Math.round(input.rewards.reputation ?? 0)),
-        };
-        return { ok: true, rewards };
+        return { ok: true, rewards: { xp: 0, cachet: 0, reputation: 0 } };
       }
       appliedNarrativeChoicesRef.current.add(choiceKey);
 


### PR DESCRIPTION
Closes #1096

When `completeNarrativeChoice` detects a choice was already applied (idempotency guard), it now returns `{ ok: true, rewards: { xp: 0, cachet: 0, reputation: 0 } }` instead of re-computing and returning the original reward amounts. This prevents `NarrativeScene` from showing a misleading reward confirmation screen (e.g. "+50 XP") when no rewards were actually credited — particularly visible in React 18 StrictMode where effects/callbacks run twice.

---
_Generated by [Claude Code](https://claude.ai/code/session_019QNNhqJPBdBzFWGVrGWYzQ)_