### PR TITLE
fix: add 'onboarding-first-mission' to VALID_SCREENS (closes #1102)

### DIFF
--- a/apps/mobile/src/hooks/useNavigation.ts
+++ b/apps/mobile/src/hooks/useNavigation.ts
@@ -8,7 +8,7 @@ const NAV_STATE_VERSION = 1 as const;
 
 const VALID_SCREENS = new Set<Screen>([
     'cookie-consent',
-    'welcome', 'login', 'signup', 'install', 'role-selection',
+    'welcome', 'login', 'signup', 'install', 'role-selection', 'onboarding-first-mission',
     'home', 'turns', 'leaderboard', 'qr-scanner', 'event-confirmation',
     'event-details', 'activities', 'shop', 'activity-detail', 'activity-minigame', 'activity-result', 'profile', 'public-profile',
     'account-settings', 'support', 'change-password', 'career',


### PR DESCRIPTION
Closes #1102

The `VALID_SCREENS` set in `useNavigation.ts` was missing `'onboarding-first-mission'`, causing `readNavState()` to silently discard any persisted navigation state pointing to that screen (returning `null`) when the app reloads during onboarding. The fix adds `'onboarding-first-mission'` to the set so the persisted state is correctly restored.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYqhufZXn2aveqdhGcBpHQ)_