### PR TITLE
chore: ignore .claude/worktrees/ (ephemeral agent working dirs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ _site/
 docs and references/plan.md
 /.runner
 
+# Claude Code agent worktrees (ephemeral, never commit)
+.claude/worktrees/
+
 # Windows executable files
 *.exe
 


### PR DESCRIPTION
## What

Adds `.claude/worktrees/` to `.gitignore`.

## Why

The Claude Code `isolation: "worktree"` feature creates temporary git worktrees under `.claude/worktrees/` for agent tasks. These directories are ephemeral — auto-cleaned after the agent completes — and must never be committed. Without this entry the stop-hook git-check fires a warning on every session that uses an isolated agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYqhufZXn2aveqdhGcBpHQ)_