### PR TITLE
fix: call setHasHydratedRemote unconditionally after profile INSERT failure (closes #1103)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3865,9 +3865,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             }));
           }
 
-          if (profileRow) {
-            setHasHydratedRemote(true);
-          }
+          setHasHydratedRemote(true);
         },
         {
           operation: 'loadRemoteState',


### PR DESCRIPTION
Closes #1103

When the Supabase profile INSERT fails in `loadRemoteState`, `profileRow` remains `null` and the `if (profileRow)` guard around `setHasHydratedRemote(true)` was never entered — permanently blocking the app (`isAuthValid === false`) with no recovery path. The fix removes the guard so `setHasHydratedRemote(true)` is always called after the INSERT attempt completes (whether successful or not), allowing the user to at least reach a state where they can log out. The `notifyCriticalError` call that surfaces the error to the user was already in place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYqhufZXn2aveqdhGcBpHQ)_