### PR TITLE
fix: stabilize refreshEventPlanning via ref to prevent realtime resubscription on role change (closes #1104)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -2314,9 +2314,11 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   // without being recreated on every shop purchase.
   const extraActivitySlotsRef = useRef(state.profile.extraActivitySlots);
   const catalogEventsRef = useRef(catalog.events);
+  const profileRoleIdRef = useRef(state.profile.roleId);
   useEffect(() => { eventPlansRef.current = state.eventPlans; }, [state.eventPlans]);
   useEffect(() => { extraActivitySlotsRef.current = state.profile.extraActivitySlots; }, [state.profile.extraActivitySlots]);
   useEffect(() => { catalogEventsRef.current = catalog.events; }, [catalog.events]);
+  useEffect(() => { profileRoleIdRef.current = state.profile.roleId; }, [state.profile.roleId]);
 
   const syncLocalEventPlanning = useCallback(
     (plans: EventPlanning[]) => {
@@ -3175,7 +3177,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
                 .map((row) => {
                   const roleId = resolveEventPlanningRoleId(
                     row.role_id,
-                    state.profile.roleId
+                    profileRoleIdRef.current
                   );
                   const updatedAt = row.updated_at ? new Date(row.updated_at).getTime() : Date.now();
                   return {
@@ -3228,8 +3230,15 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         }
       );
     },
-    [authUserId, syncLocalEventPlanning, state.profile.roleId]
+    [authUserId, syncLocalEventPlanning]
   );
+
+  // Stable ref so the realtime channel useEffect does not re-subscribe on every
+  // role change (which would previously happen because refreshEventPlanning had
+  // state.profile.roleId in its useCallback deps, making the function reference
+  // change on every role update).
+  const refreshEventPlanningRef = useRef(refreshEventPlanning);
+  useEffect(() => { refreshEventPlanningRef.current = refreshEventPlanning; }, [refreshEventPlanning]);
 
   const refreshShopCatalog = useCallback(async () => {
     if (!isSupabaseConfigured || !supabase || !authUserId) {
@@ -4025,7 +4034,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         'postgres_changes',
         { event: '*', schema: 'public', table: 'planned_participations', filter: `user_id=eq.${authUserId}` },
         () => {
-          refreshEventPlanning(catalogEventsRef.current).catch(console.error);
+          refreshEventPlanningRef.current(catalogEventsRef.current).catch(console.error);
         }
       )
       .on(
@@ -4058,7 +4067,6 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     authUserId,
     refreshBadges,
     refreshActivitySlotsStatus,
-    refreshEventPlanning,
     refreshFeatureFlags,
     refreshShopCatalog,
     refreshTheatreReputation,


### PR DESCRIPTION
Closes #1104

`refreshEventPlanning`'s `useCallback` had `state.profile.roleId` in its dependency array, so every role change produced a new function reference. This new reference propagated into the realtime channel `useEffect`, which tore down and resubscribed the entire 7-table Supabase channel on every role change — creating a realtime coverage gap each time.

The fix introduces a `profileRoleIdRef` (kept in sync via `useEffect`, following the same pattern as `extraActivitySlotsRef`/`catalogEventsRef` already in this file) so `refreshEventPlanning` can read the current role ID without it being a reactive dependency. A `refreshEventPlanningRef` is then used to give the realtime channel a stable callback reference (mirroring the `applyUserProfileRef`/`onLogoutRef` pattern in `useAuth.ts`). `refreshEventPlanning` is removed from the realtime channel `useEffect` deps, so the channel is set up once per `authUserId` and stays alive across role changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYqhufZXn2aveqdhGcBpHQ)_