### PR TITLE
fix: set voluntary logout flag before signOut in deleteAccount

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -164,7 +164,7 @@ export function AppShell() {
   );
 
   // Auth hook
-  const { authError, setAuthError, isDemoMode, handleLogin, handleSignup, handleLogout } = useAuth(
+  const { authError, setAuthError, isDemoMode, handleLogin, handleSignup, handleLogout, markVoluntaryLogout } = useAuth(
     state.profile,
     updateProfile,
     (screen, isRecovery) => {
@@ -191,6 +191,13 @@ export function AppShell() {
       nav.navigate('welcome');
     },
   );
+
+  // Wrap deleteAccount so the SIGNED_OUT listener knows this is a voluntary
+  // sign-out and does not show the misleading "session expired" error banner.
+  const handleDeleteAccount = useCallback(async () => {
+    markVoluntaryLogout();
+    await deleteAccount();
+  }, [markVoluntaryLogout, deleteAccount]);
 
   // Tab change handler with feature gates
   const handleTabChange = useCallback((tab: Tab) => {
@@ -685,7 +692,7 @@ export function AppShell() {
             onChangePassword={() => { nav.setIsPasswordRecovery(false); nav.navigate('change-password'); }}
             onResetProgress={async () => { try { await resetProgress(); handleTabChange('home'); nav.navigate('role-selection'); } catch (err) { console.error('[AppShell] resetProgress failed:', err); throw err; } }}
             onResetTutorial={() => { gameState.resetTutorial(); nav.navigate('home'); }}
-            onDeleteAccount={deleteAccount}
+            onDeleteAccount={handleDeleteAccount}
             onExportData={exportUserData}
             onToggleLeaderboard={(visible) => updateProfile({ leaderboardVisible: visible })}
             onLogout={handleLogout} />
@@ -703,7 +710,7 @@ export function AppShell() {
               onChangePassword={() => { nav.setIsPasswordRecovery(false); nav.navigate('change-password'); }}
               onResetProgress={async () => { try { await resetProgress(); handleTabChange('home'); nav.navigate('role-selection'); } catch (err) { console.error('[AppShell] resetProgress failed:', err); throw err; } }}
               onResetTutorial={() => { gameState.resetTutorial(); nav.navigate('home'); }}
-              onDeleteAccount={deleteAccount}
+              onDeleteAccount={handleDeleteAccount}
               onExportData={exportUserData}
               onToggleLeaderboard={(visible) => updateProfile({ leaderboardVisible: visible })}
               onLogout={handleLogout} />;
@@ -748,7 +755,7 @@ export function AppShell() {
               onChangePassword={() => { nav.setIsPasswordRecovery(false); nav.navigate('change-password'); }}
               onResetProgress={async () => { try { await resetProgress(); handleTabChange('home'); nav.navigate('role-selection'); } catch (err) { console.error('[AppShell] resetProgress failed:', err); throw err; } }}
               onResetTutorial={() => { gameState.resetTutorial(); nav.navigate('home'); }}
-              onDeleteAccount={deleteAccount}
+              onDeleteAccount={handleDeleteAccount}
               onExportData={exportUserData}
               onToggleLeaderboard={(visible) => updateProfile({ leaderboardVisible: visible })}
               onLogout={handleLogout} />;

--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -277,6 +277,12 @@ export function useAuth(
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    // Exposed so callers (e.g. deleteAccount in AppShell) can set the flag
+    // before triggering a signOut that was not initiated through handleLogout.
+    const markVoluntaryLogout = useCallback(() => {
+        isVoluntaryLogoutRef.current = true;
+    }, []);
+
     return {
         authError,
         setAuthError,
@@ -284,5 +290,6 @@ export function useAuth(
         handleLogin,
         handleSignup,
         handleLogout: handleLogoutAction,
+        markVoluntaryLogout,
     };
 }


### PR DESCRIPTION
Closes #1110

## Problem
`deleteAccount` in `apps/mobile/src/state/store.tsx` called `supabase.auth.signOut()` without setting the voluntary-logout flag (`isVoluntaryLogoutRef.current = true`). Because the flag remained `false`, the `SIGNED_OUT` auth listener in `useAuth` took the involuntary branch and displayed the misleading "Sessione scaduta. Effettua nuovamente l'accesso." error to users who had just successfully deleted their own account.

## Fix
Added a `markVoluntaryLogout()` function to `useAuth` that sets `isVoluntaryLogoutRef.current = true`. This function is returned alongside the existing hook values.

In `AppShell.tsx`, `deleteAccount` is now wrapped in a `handleDeleteAccount` callback that:
1. Calls `markVoluntaryLogout()` to arm the flag before the delete flow
2. Awaits `deleteAccount()` which ultimately calls `supabase.auth.signOut()`

All three `onDeleteAccount` prop sites now receive `handleDeleteAccount` instead of the raw `deleteAccount`. No changes to the store's public API were required.

https://claude.ai/code/session_014iuJ9qbDicK8hjy5gZrqJR

---
_Generated by [Claude Code](https://claude.ai/code/session_014iuJ9qbDicK8hjy5gZrqJR)_