### PR TITLE
fix: remove dead turnsRes.error ternary in loadRemoteState (#1113)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3870,7 +3870,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
                   : prev.profile.onboardingVariant,
               },
               eventPlans: prev.eventPlans,
-              turns: turnsRes.error ? prev.turns : remoteTurns,
+              turns: remoteTurns,
             }));
           }
 


### PR DESCRIPTION
## Intent

Fixes #1113: In `loadRemoteState`, the `setState` call used `turnsRes.error ? prev.turns : remoteTurns` as the `turns` value. This ternary is dead code — `turnsRes.error` is always falsy at that point because the guard at line ~3777 already returned early on a `turnsRes.error`. The intended "keep prev.turns on error" safety net never fires, giving a false sense of safety.

## Key Changes

- Replaced `turnsRes.error ? prev.turns : remoteTurns` with just `remoteTurns` in `store.tsx`
- The early-return guard at line ~3777 is the real error handler; the ternary was redundant and misleading

## Testing

Logic is unchanged — the `turnsRes.error` branch of the ternary was never reachable. The surviving guard at line ~3777 continues to handle turn-fetch errors correctly.

https://claude.ai/code/session_015PGvLdymkAzydjKEDF8N1V

---
_Generated by [Claude Code](https://claude.ai/code/session_015PGvLdymkAzydjKEDF8N1V)_