### PR TITLE
fix: validate Bearer scheme in delete-my-account Authorization header (#1114)

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -40,7 +40,7 @@ serve(async (req) => {
 
   // Verify the caller's JWT to obtain their user ID
   const authHeader = req.headers.get('Authorization');
-  if (!authHeader) {
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return errorResponse('Autenticazione richiesta', 401);
   }
 


### PR DESCRIPTION
## Intent

Fixes #1114: The `delete-my-account` edge function only checked for the presence of the `Authorization` header (`if (!authHeader)`) without validating that it uses the `Bearer` scheme. Every other edge function in the repo (app-version, cleanup-events, event-links, import-atcl-lazio, import-spazio-rossellini, mobile-logs, ticket-activation) uses the pattern `!authHeader || !authHeader.startsWith('Bearer ')`. A non-Bearer token would be silently forwarded to the Supabase client and result in a misleading 401 from `getUser()` rather than a clear 401 at the auth-header validation step.

## Key Changes

- `supabase/functions/delete-my-account/index.ts`: changed `if (!authHeader)` to `if (!authHeader || !authHeader.startsWith('Bearer '))`, matching the pattern used across all other edge functions

## Testing

Manual: non-Bearer tokens (e.g. `Basic xyz`) now receive an immediate 401 with `Autenticazione richiesta` rather than being forwarded to the Supabase JWT validation. Valid Bearer tokens continue to work as before.

https://claude.ai/code/session_015PGvLdymkAzydjKEDF8N1V

---
_Generated by [Claude Code](https://claude.ai/code/session_015PGvLdymkAzydjKEDF8N1V)_