### PR TITLE
Fix skip-link positioning on devices with large safe-area insets

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -60,7 +60,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 20"
+          claude_args: "--max-turns 40"
           prompt: |
             Sei la AI reviewer di **Turni-di-Palco**, app di gestione turni di
             ATCL-Lazio. Stack: Jekyll + Node/serverless, backend Supabase,

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -465,13 +465,19 @@ html[data-theme="light"] .text-white {
     outline-offset: 2px;
   }
 
-  /* WCAG 2.1 — 2.4.1 Bypass Blocks: skip-link visible only on focus. */
+  /* WCAG 2.1 — 2.4.1 Bypass Blocks: skip-link visible only on focus.
+     Bug fix: instead of anchoring to `top: max(safe-area + 8px, 56px)` and
+     translating up by -150% (which fails when top > 1.5 * element-height, e.g.
+     iPhone 14 Pro Max with 59 px safe-area-inset-top → top = 67 px, element
+     height ≈ 40 px → -150% = -60 px → visual top = +7 px → link visible).
+     Solution: anchor to `top: 0` so -100% always places the element fully above
+     the viewport; bring it into view on focus via translateY with the safe-area
+     offset. */
   .skip-link {
     position: fixed;
-    /* 56px floor: garantisce visibilità sotto status bar/notch quando env(safe-area-inset-top) è 0 (es. browser tab non-PWA). */
-    top: max(env(safe-area-inset-top, 0px) + 8px, 56px);
+    top: 0;
     left: 50%;
-    transform: translate(-50%, -150%);
+    transform: translate(-50%, -100%);
     z-index: 1000;
     padding: 10px 16px;
     max-width: calc(100vw - 32px);
@@ -490,7 +496,9 @@ html[data-theme="light"] .text-white {
 
   .skip-link:focus,
   .skip-link:focus-visible {
-    transform: translate(-50%, 0);
+    /* 56 px floor: ensures visibility below the status bar / notch when
+       env(safe-area-inset-top) is 0 (e.g. non-PWA browser tab). */
+    transform: translate(-50%, max(env(safe-area-inset-top, 0px) + 8px, 56px));
     outline: 2px solid var(--color-gold-400);
     outline-offset: 2px;
   }


### PR DESCRIPTION
## Summary
Fixes a critical accessibility bug where the skip-link would become visible on the viewport on devices with large safe-area insets (e.g., iPhone 14 Pro Max), breaking the "visible only on focus" requirement of WCAG 2.1 — 2.4.1 Bypass Blocks.

## Key Changes
- **Repositioned skip-link anchor point**: Changed from `top: max(env(safe-area-inset-top, 0px) + 8px, 56px)` to `top: 0` to ensure the element is always positioned at the viewport top
- **Updated default transform**: Changed from `transform: translate(-50%, -150%)` to `transform: translate(-50%, -100%)` so the element is consistently placed fully above the viewport
- **Moved safe-area offset to focus state**: The safe-area inset calculation now applies only when the skip-link receives focus via `transform: translate(-50%, max(env(safe-area-inset-top, 0px) + 8px, 56px))`, ensuring proper positioning below status bars/notches while remaining hidden by default
- **Improved code comments**: Added detailed explanation of the bug and solution for future maintainers

## Implementation Details
The previous approach failed when `top > 1.5 × element-height` (e.g., 67px top with ~40px element height), causing the -150% translateY to place the element partially visible on screen. The new approach uses -100% to guarantee the element is fully above the viewport, then brings it into view on focus with the appropriate safe-area offset applied via translateY.

## Additional Changes
- Updated Claude code review workflow max-turns from 20 to 40 for more thorough analysis

https://claude.ai/code/session_01GjgE8gPQyxfED4pWeKsnaS