### PR TITLE
fix(mobile-ui): polish auth flow, metriche, bottom nav e EventCard

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -5,6 +5,7 @@ import { useFeatureGates } from './handlers';
 import { AppShell } from './components/AppShell';
 import { AccessibilityProvider } from './hooks/useAccessibilityPreferences';
 import { ThemeProvider } from './providers/ThemeProvider';
+import { LiveRegion } from './components/ui/LiveRegion';
 
 function AppWithNavigator() {
   const { events, featureFlags, isFeatureEnabled } = useGameState();
@@ -28,6 +29,7 @@ export default function App() {
     <AccessibilityProvider>
       <GameStateProvider>
         <ThemeProvider>
+          <LiveRegion />
           <AppWithNavigator />
         </ThemeProvider>
       </GameStateProvider>

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -4,6 +4,7 @@ import { NavigatorProvider } from './router';
 import { useFeatureGates } from './handlers';
 import { AppShell } from './components/AppShell';
 import { AccessibilityProvider } from './hooks/useAccessibilityPreferences';
+import { ThemeProvider } from './providers/ThemeProvider';
 
 function AppWithNavigator() {
   const { events, featureFlags, isFeatureEnabled } = useGameState();
@@ -26,7 +27,9 @@ export default function App() {
   return (
     <AccessibilityProvider>
       <GameStateProvider>
-        <AppWithNavigator />
+        <ThemeProvider>
+          <AppWithNavigator />
+        </ThemeProvider>
       </GameStateProvider>
     </AccessibilityProvider>
   );

--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -564,8 +564,8 @@ export function AppShell() {
               <div className="app-content px-6 pt-6 space-y-4">
                 <Card>
                   <h3 className="text-white mb-2">Registrazione non disponibile</h3>
-                  <p className="text-[#b8b2b3] text-sm mb-4">Questa funzione e temporaneamente disattivata dalla configurazione runtime.</p>
-                  <button type="button" className="text-sm text-[#f4bf4f] hover:text-[#e6a23c]" onClick={() => handleTabChange('home')}>Torna alla Home</button>
+                  <p className="text-[--color-text-secondary] text-sm mb-4">Questa funzione e temporaneamente disattivata dalla configurazione runtime.</p>
+                  <button type="button" className="text-sm text-[--color-gold-400] hover:text-[--color-gold-500]" onClick={() => handleTabChange('home')}>Torna alla Home</button>
                 </Card>
               </div>
             </div>
@@ -781,12 +781,12 @@ export function AppShell() {
     <div className="min-h-screen app-gradient app-shell">
       <a href="#main-content" className="skip-link">Salta al contenuto principale</a>
       {!isOnline && (
-        <div className="fixed top-0 left-0 right-0 z-[998] bg-[#2a1f14] border-b border-[#f4bf4f]/30 px-4 py-2 text-center text-sm text-[#f4bf4f]">
+        <div className="fixed top-0 left-0 right-0 z-[998] bg-[--color-warning-soft-bg] border-b border-[--color-gold-400]/30 px-4 py-2 text-center text-sm text-[--color-gold-400]">
           Sei offline — le modifiche saranno sincronizzate al ritorno della connessione
         </div>
       )}
       {isDemoMode && (
-        <div className="fixed top-0 left-0 right-0 z-[997] bg-[#1a1617] border-b border-[#a82847]/40 px-4 py-2 text-center text-sm text-[#b8b2b3]">
+        <div className="fixed top-0 left-0 right-0 z-[997] bg-[--color-bg-surface] border-b border-[--color-burgundy-600]/40 px-4 py-2 text-center text-sm text-[--color-text-secondary]">
           Modalità demo — i dati non vengono salvati
         </div>
       )}
@@ -799,7 +799,7 @@ export function AppShell() {
         </div>
       )}
       <ScreenTransition animationClass={screenAnimation} animationKey={screenAnimationKey}>
-        <Suspense fallback={<div className="min-h-screen app-gradient flex items-center justify-center"><div className="animate-shimmer h-8 w-32 rounded-lg bg-[#1a1617]" /></div>}>
+        <Suspense fallback={<div className="min-h-screen app-gradient flex items-center justify-center"><div className="animate-shimmer h-8 w-32 rounded-lg bg-[--color-bg-surface]" /></div>}>
         {routeConfig.showBottomNav ? (
           <MainLayout activeTab={nav.activeTab} enabledTabs={enabledNavTabs} onTabChange={handleTabChange}>
             {renderScreen()}

--- a/apps/mobile/src/components/AtclNewsTicker.tsx
+++ b/apps/mobile/src/components/AtclNewsTicker.tsx
@@ -15,13 +15,13 @@ export function AtclNewsTicker({ items }: AtclNewsTickerProps) {
   const durationSeconds = Math.max(70, items.length * 14);
 
   return (
-    <Card className="overflow-hidden border border-[#f4bf4f]/15 bg-gradient-to-r from-[#1a1617] via-[#221b1d] to-[#1a1617] p-0">
-      <div className="atcl-news-headline border-b border-[#f4bf4f]/10 px-3 py-2">
+    <Card className="overflow-hidden border border-[--color-gold-400]/15 bg-gradient-to-r from-[--color-bg-surface] via-[--color-bg-surface-elevated] to-[--color-bg-surface] p-0">
+      <div className="atcl-news-headline border-b border-[--color-gold-400]/10 px-3 py-2">
         <div className="flex items-center gap-2">
-          <div className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[#f4bf4f]/15 text-[#f4bf4f]">
+          <div className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[--color-gold-400]/15 text-[--color-gold-400]">
             <Radio size={13} />
           </div>
-          <p className="text-[11px] uppercase tracking-wide text-[#f4bf4f]">News ATCL Live</p>
+          <p className="text-[11px] uppercase tracking-wide text-[--color-gold-400]">News ATCL Live</p>
         </div>
 
         <button

--- a/apps/mobile/src/components/AtclPromoBanner.tsx
+++ b/apps/mobile/src/components/AtclPromoBanner.tsx
@@ -41,27 +41,27 @@ export function AtclPromoBanner({ promotion }: AtclPromoBannerProps) {
   return (
     <Card
       animateOnMount
-      className="overflow-hidden border border-[#f4bf4f]/20 bg-gradient-to-br from-[#2d0a0f] via-[#4a0e1a] to-[#1a1617]"
+      className="overflow-hidden border border-[--color-gold-400]/20 bg-gradient-to-br from-[--color-burgundy-950] via-[--color-burgundy-900] to-[--color-bg-surface]"
     >
       <div className="space-y-3">
         <div className="flex items-start justify-between gap-3">
-          <div className="inline-flex items-center gap-2 rounded-full bg-[#f4bf4f]/15 px-3 py-1 text-[11px] uppercase tracking-wide text-[#f4bf4f]">
+          <div className="inline-flex items-center gap-2 rounded-full bg-[--color-gold-400]/15 px-3 py-1 text-[11px] uppercase tracking-wide text-[--color-gold-400]">
             <Megaphone size={13} />
             <span>{promotion.badgeLabel}</span>
           </div>
-          {rangeLabel ? <span className="text-xs text-[#f5d9a8]">{rangeLabel}</span> : null}
+          {rangeLabel ? <span className="text-xs text-[--color-promo-accent-text]">{rangeLabel}</span> : null}
         </div>
 
         <div className="space-y-1">
           <h4 className="text-white leading-tight">{promotion.title}</h4>
-          <p className="text-sm text-[#f6ddd5] leading-relaxed">{promotion.description}</p>
+          <p className="text-sm text-[--color-promo-description-text] leading-relaxed">{promotion.description}</p>
         </div>
 
         {canOpenCta ? (
           <Button
             variant="secondary"
             size="sm"
-            className="min-h-[40px] border-[#f4bf4f] bg-[#f4bf4f]/10 text-[#f4bf4f] hover:bg-[#f4bf4f]/20"
+            className="min-h-[40px] border-[--color-gold-400] bg-[--color-gold-400]/10 text-[--color-gold-400] hover:bg-[--color-gold-400]/20"
             onClick={handleOpenCta}
           >
             {promotion.ctaLabel}

--- a/apps/mobile/src/components/BottomNav.tsx
+++ b/apps/mobile/src/components/BottomNav.tsx
@@ -83,7 +83,7 @@ const TabButton = React.memo(function TabButton({ id, icon: Icon, label, isActiv
         strokeWidth={isActive ? 2.5 : 1.8}
         className={isActive ? 'tab-icon-pulse' : ''}
       />
-      <span className="text-[9.5px] leading-none tracking-[0.02em] font-medium w-full px-1 text-center truncate">
+      <span className="text-[11px] leading-none tracking-[0.02em] font-medium w-full px-1 text-center truncate">
         {label}
       </span>
     </button>

--- a/apps/mobile/src/components/BottomNav.tsx
+++ b/apps/mobile/src/components/BottomNav.tsx
@@ -33,12 +33,12 @@ export function BottomNav({ activeTab, onTabChange, enabledTabs }: BottomNavProp
   } : undefined;
 
   return (
-    <nav data-tutorial="bottom-nav" role="tablist" aria-label="Navigazione principale" className="fixed bottom-0 left-0 right-0 w-full z-50 bg-[#0f0d0e]/90 backdrop-blur-2xl border-t border-white/[0.05]">
+    <nav data-tutorial="bottom-nav" role="tablist" aria-label="Navigazione principale" className="fixed bottom-0 left-0 right-0 w-full z-50 bg-[--color-bg-primary]/90 backdrop-blur-2xl border-t border-white/[0.05]">
       <div className="relative app-content flex items-stretch justify-around px-2 pt-1 min-h-[54px]" style={{ paddingBottom: 'calc(4px + env(safe-area-inset-bottom, 0px))' }}>
 
           {indicatorStyle && (
             <div
-              className="absolute top-0 h-[2px] bg-[#f4bf4f] rounded-full"
+              className="absolute top-0 h-[2px] bg-[--color-gold-400] rounded-full"
               style={indicatorStyle}
             />
           )}
@@ -74,8 +74,8 @@ const TabButton = React.memo(function TabButton({ id, icon: Icon, label, isActiv
       aria-selected={isActive}
       className={`relative flex flex-1 min-w-0 flex-col items-center justify-center gap-[3px] py-1 rounded-xl transition-colors duration-150 ${
         isActive
-          ? 'text-[#f4bf4f] tab-button-active'
-          : 'text-[#6a6566] hover:text-[#9a9697] active:text-[#b8b2b3]'
+          ? 'text-[--color-gold-400] tab-button-active'
+          : 'text-[--color-text-tertiary] hover:text-[--color-text-tertiary] active:text-[--color-text-secondary]'
       }`}
     >
       <Icon

--- a/apps/mobile/src/components/ScanQRCard.tsx
+++ b/apps/mobile/src/components/ScanQRCard.tsx
@@ -12,7 +12,7 @@ export function ScanQRCard({ onScanQR, className = '', style }: ScanQRCardProps)
     <button
       type="button"
       onClick={onScanQR}
-      className={`w-full border border-[#f4bf4f]/30 rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-px transition-all duration-200 hover:opacity-95 active:scale-[0.99] ${className}`}
+      className={`w-full border border-[--color-gold-400]/30 rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-px transition-all duration-200 hover:opacity-95 active:scale-[0.99] ${className}`}
       style={{
         backgroundImage:
           'linear-gradient(180deg, rgba(140, 28, 56, 1) 0%, rgba(168, 40, 71, 1) 100%), linear-gradient(90deg, rgba(26, 22, 23, 1) 0%, rgba(26, 22, 23, 1) 100%)',
@@ -20,13 +20,13 @@ export function ScanQRCard({ onScanQR, className = '', style }: ScanQRCardProps)
       }}
     >
       <div className="flex items-center gap-3 h-[58px] pl-[5px] pr-0">
-        <div className="bg-[#f4bf4f] rounded-[16.4px] size-[48px] flex items-center justify-center">
-          <Ticket className="text-[#2d0a0f]" size={24} />
+        <div className="bg-[--color-gold-400] rounded-[16.4px] size-[48px] flex items-center justify-center">
+          <Ticket className="text-[--color-burgundy-950]" size={24} />
         </div>
         <div className="flex-1 flex items-center justify-between">
           <div className="flex flex-col items-start">
-            <p className="text-[16px] leading-[25.6px] font-semibold !text-[#ffffff] !m-0">Registra Biglietto</p>
-            <p className="text-[16px] leading-[25.6px] !text-[#ffffff] !m-0">Inserisci il numero del tuo ticket</p>
+            <p className="text-[16px] leading-[25.6px] font-semibold !text-white !m-0">Registra Biglietto</p>
+            <p className="text-[16px] leading-[25.6px] !text-white !m-0">Inserisci il numero del tuo ticket</p>
           </div>
           <ChevronRight className="text-white" size={22} />
         </div>

--- a/apps/mobile/src/components/screens/ATCLTurns.tsx
+++ b/apps/mobile/src/components/screens/ATCLTurns.tsx
@@ -70,7 +70,7 @@ export function ATCLTurns({
     <div className={embedded ? 'space-y-6' : 'w-full app-content px-6 space-y-6 pt-6 pb-8'}>
       <div>
         <h2 className="text-white mb-2">Eventi ATCL</h2>
-        <p className="text-[#b8b2b3]">Tutti gli eventi disponibili</p>
+        <p className="text-[--color-text-secondary]">Tutti gli eventi disponibili</p>
       </div>
 
       {canScanQr ? <ScanQRCard onScanQR={onScanQR} /> : null}
@@ -84,25 +84,25 @@ export function ATCLTurns({
         <h4 className="text-white mb-4">Statistiche totali</h4>
         <div className="grid grid-cols-3 gap-4 text-center">
           <div>
-            <div className="w-10 h-10 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-lg flex items-center justify-center mx-auto mb-2">
-              <Theater className="text-[#f4bf4f]" size={20} />
+            <div className="w-10 h-10 bg-gradient-to-br from-[--color-burgundy-600] to-[--color-burgundy-800] rounded-lg flex items-center justify-center mx-auto mb-2">
+              <Theater className="text-[--color-gold-400]" size={20} />
             </div>
             <p className="text-2xl text-white mb-1">{stats.totalTurns}</p>
-            <p className="text-xs text-[#b8b2b3]">Eventi totali</p>
+            <p className="text-xs text-[--color-text-secondary]">Eventi totali</p>
           </div>
           <div>
-            <div className="w-10 h-10 bg-gradient-to-br from-[#e6a23c] to-[#f4bf4f] rounded-lg flex items-center justify-center mx-auto mb-2">
-              <TrendingUp className="text-[#0f0d0e]" size={20} />
+            <div className="w-10 h-10 bg-gradient-to-br from-[--color-gold-500] to-[--color-gold-400] rounded-lg flex items-center justify-center mx-auto mb-2">
+              <TrendingUp className="text-[--color-bg-primary]" size={20} />
             </div>
-            <p className="text-2xl text-[#f4bf4f] mb-1">{stats.totalXp}</p>
-            <p className="text-xs text-[#b8b2b3]">XP potenziali</p>
+            <p className="text-2xl text-[--color-gold-400] mb-1">{stats.totalXp}</p>
+            <p className="text-xs text-[--color-text-secondary]">XP potenziali</p>
           </div>
           <div>
-            <div className="w-10 h-10 bg-[#241f20] rounded-lg flex items-center justify-center mx-auto mb-2">
-              <MapPin className="text-[#f4bf4f]" size={20} />
+            <div className="w-10 h-10 bg-[--color-bg-surface-elevated] rounded-lg flex items-center justify-center mx-auto mb-2">
+              <MapPin className="text-[--color-gold-400]" size={20} />
             </div>
             <p className="text-2xl text-white mb-1">{stats.theatreCount}</p>
-            <p className="text-xs text-[#b8b2b3]">Teatri</p>
+            <p className="text-xs text-[--color-text-secondary]">Teatri</p>
           </div>
         </div>
       </Card>
@@ -112,7 +112,7 @@ export function ATCLTurns({
         <button
           type="button"
           onClick={onViewMap}
-          className="flex shrink-0 items-center gap-2 text-sm text-[#f4bf4f] hover:text-[#e6a23c] px-3 py-[12px] rounded-lg"
+          className="flex shrink-0 items-center gap-2 text-sm text-[--color-gold-400] hover:text-[--color-gold-500] px-3 py-[12px] rounded-lg"
           aria-label="Vedi mappa eventi"
         >
           <MapIcon size={16} />
@@ -128,24 +128,24 @@ export function ATCLTurns({
             const statusLabel = planning ? getPlanningStatusLabel(planning.status) : 'Da pianificare';
             const statusClassName = planning
               ? getPlanningStatusClassName(planning.status)
-              : 'border-white/10 bg-white/5 text-[#b8b2b3]';
+              : 'border-white/10 bg-white/5 text-[--color-text-secondary]';
 
             return (
               <Card
                 key={event.id}
                 hoverable
                 onClick={() => onViewEvent(event.id)}
-                className="border border-white/5 bg-gradient-to-br from-[#1a1617] via-[#1d1819] to-[#231e1f]"
+                className="border border-white/5 bg-gradient-to-br from-[--color-bg-surface] via-[--color-bg-surface-dim] to-[--color-bg-elevated-alt]"
               >
                 <div className="flex items-start gap-4">
-                  <div className="flex-shrink-0 w-12 h-12 rounded-2xl bg-gradient-to-br from-[#a82847] to-[#6b1529] flex items-center justify-center shadow-[0_8px_20px_rgba(168,40,71,0.25)]">
-                    <Theater className="text-[#f4bf4f]" size={24} />
+                  <div className="flex-shrink-0 w-12 h-12 rounded-2xl bg-gradient-to-br from-[--color-burgundy-600] to-[--color-burgundy-800] flex items-center justify-center shadow-[0_8px_20px_rgba(168,40,71,0.25)]">
+                    <Theater className="text-[--color-gold-400]" size={24} />
                   </div>
 
                   <div className="flex-1 min-w-0">
                     <div className="flex items-start justify-between gap-3">
                       <div>
-                        <p className="text-xs uppercase tracking-wide text-[#b8b2b3]">Evento ATCL</p>
+                        <p className="text-xs uppercase tracking-wide text-[--color-text-secondary]">Evento ATCL</p>
                         <h4 className="text-white text-lg leading-tight">{event.name}</h4>
                       </div>
                       <span
@@ -155,38 +155,38 @@ export function ATCLTurns({
                       </span>
                     </div>
 
-                    <div className="flex items-center gap-2 text-sm text-[#b8b2b3] mt-3">
+                    <div className="flex items-center gap-2 text-sm text-[--color-text-secondary] mt-3">
                       <MapPin size={14} />
                       <span>{event.theatre}</span>
                     </div>
 
-                    <div className="flex items-center gap-2 text-sm text-[#b8b2b3] mt-2">
+                    <div className="flex items-center gap-2 text-sm text-[--color-text-secondary] mt-2">
                       <Calendar size={14} />
                       <span>{event.date} · {event.time}</span>
                     </div>
 
                     {roleLabel ? (
-                      <p className="mt-3 text-sm text-[#f4bf4f]">
+                      <p className="mt-3 text-sm text-[--color-gold-400]">
                         Ruolo pianificato: <span className="text-white">{roleLabel}</span>
                       </p>
                     ) : (
-                      <p className="mt-3 text-sm text-[#b8b2b3]">
+                      <p className="mt-3 text-sm text-[--color-text-secondary]">
                         Apri il dettaglio evento per scegliere un ruolo e salvare la pianificazione.
                       </p>
                     )}
 
                     <div className="flex flex-wrap gap-2 mt-4">
                       {event.genre ? (
-                        <span className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-2 py-1 text-xs text-[#f4bf4f] backdrop-blur">
+                        <span className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-2 py-1 text-xs text-[--color-gold-400] backdrop-blur">
                           {event.genre}
                         </span>
                       ) : null}
                       <span className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-xs text-white/90 backdrop-blur">
-                        <TrendingUp size={12} className="text-[#f4bf4f]" />
+                        <TrendingUp size={12} className="text-[--color-gold-400]" />
                         +{event.baseRewards.xp} XP
                       </span>
                       <span className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-xs text-white/90 backdrop-blur">
-                        <Award size={12} className="text-[#f4bf4f]" />
+                        <Award size={12} className="text-[--color-gold-400]" />
                         +{event.baseRewards.reputation} Rep
                       </span>
                     </div>
@@ -229,11 +229,11 @@ export function ATCLTurns({
         </div>
       ) : (
         <Card className="text-center py-12">
-          <div className="w-16 h-16 bg-[#241f20] rounded-full flex items-center justify-center mx-auto mb-4">
-            <QrCode className="text-[#9a9697]" size={32} />
+          <div className="w-16 h-16 bg-[--color-bg-surface-elevated] rounded-full flex items-center justify-center mx-auto mb-4">
+            <QrCode className="text-[--color-text-tertiary]" size={32} />
           </div>
           <h4 className="text-white mb-2">Nessun evento disponibile</h4>
-          <p className="text-[#b8b2b3] mb-6 max-w-xs mx-auto">
+          <p className="text-[--color-text-secondary] mb-6 max-w-xs mx-auto">
             Torna piu tardi o aggiorna la lista eventi.
           </p>
           {canScanQr ? (
@@ -277,8 +277,8 @@ function getPlanningStatusClassName(status: EventPlanning['status']) {
     case 'confirmed':
       return 'border-emerald-400/40 bg-emerald-400/10 text-emerald-300';
     case 'cancelled':
-      return 'border-white/10 bg-white/5 text-[#b8b2b3]';
+      return 'border-white/10 bg-white/5 text-[--color-text-secondary]';
     default:
-      return 'border-[#f4bf4f]/40 bg-[#f4bf4f]/10 text-[#f4bf4f]';
+      return 'border-[--color-gold-400]/40 bg-[--color-gold-400]/10 text-[--color-gold-400]';
   }
 }

--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -135,13 +135,13 @@ export function AccountSettings({
     >
       <div className="flex h-full w-full flex-col gap-6">
         <button type="button" onClick={onBack}
-          className="flex items-center justify-center size-[44px] text-[#f4bf4f]" aria-label="Indietro">
+          className="flex items-center justify-center size-[44px] text-[--color-gold-400]" aria-label="Indietro">
           <ArrowLeft size={24} />
         </button>
 
         <div className="flex flex-col items-start gap-1">
-          <p className="text-[24px] leading-[31.2px] font-bold tracking-[-0.24px] text-[#f5f5f5]">Gestisci account</p>
-          <p className="text-[16px] leading-[25.6px] text-[#b8b2b3]">Impostazioni e privacy</p>
+          <p className="text-[24px] leading-[31.2px] font-bold tracking-[-0.24px] text-[--color-text-primary]">Gestisci account</p>
+          <p className="text-[16px] leading-[25.6px] text-[--color-text-secondary]">Impostazioni e privacy</p>
         </div>
 
         <UserInfoCard userName={userName} email={email} />
@@ -178,17 +178,17 @@ export function AccountSettings({
         />
         <SettingsActionCard icon={KeyRound} label="Cambia password" subtitle="Aggiorna le credenziali di accesso" onClick={onChangePassword} />
         <SettingsActionCard icon={RotateCcw} label="Reimposta tutorial" subtitle="Rivedi la guida di benvenuto" onClick={handleResetTutorial} />
-        <SettingsActionCard icon={Trash2} label="Resetta progressi" subtitle="Azzeramento irreversibile della carriera" onClick={handleReset} iconColor="text-[#ff4d4f]" />
+        <SettingsActionCard icon={Trash2} label="Resetta progressi" subtitle="Azzeramento irreversibile della carriera" onClick={handleReset} iconColor="text-[--color-error]" />
 
         <div className="mt-auto flex flex-col gap-4">
-          {resetError && <p className="text-[14px] leading-[20px] text-[#ff4d4f] text-center">{resetError}</p>}
-          {deleteError && <p className="text-[14px] leading-[20px] text-[#ff4d4f] text-center">{deleteError}</p>}
+          {resetError && <p className="text-[14px] leading-[20px] text-[--color-error] text-center">{resetError}</p>}
+          {deleteError && <p className="text-[14px] leading-[20px] text-[--color-error] text-center">{deleteError}</p>}
           <CopyrightNotice />
           <button
             type="button"
             onClick={handleDeleteAccount}
             aria-label="Elimina definitivamente il tuo account"
-            className="flex items-center justify-center gap-[6px] h-[44px] rounded-md text-[14px] leading-[20px] text-[#ff4d4f]/70 w-full"
+            className="flex items-center justify-center gap-[6px] h-[44px] rounded-md text-[14px] leading-[20px] text-[--color-error]/70 w-full"
           >
             <UserX aria-hidden="true" size={16} /> Elimina account
           </button>
@@ -196,7 +196,7 @@ export function AccountSettings({
             type="button"
             onClick={onLogout}
             aria-label="Disconnetti dal tuo account"
-            className="flex items-center justify-center gap-[6px] h-[44px] rounded-md text-[18px] leading-[28px] text-[#ff4d4f] w-full"
+            className="flex items-center justify-center gap-[6px] h-[44px] rounded-md text-[18px] leading-[28px] text-[--color-error] w-full"
           >
             <LogOut aria-hidden="true" size={20} /> Esci
           </button>
@@ -212,10 +212,10 @@ export function AccountSettings({
 function UserInfoCard({ userName, email }: { userName: string; email: string }) {
   return (
     <SettingsCard>
-      <div className="flex items-center justify-between text-[14px] leading-[20px] text-[#b8b2b3]">
+      <div className="flex items-center justify-between text-[14px] leading-[20px] text-[--color-text-secondary]">
         <span>Nome</span><span className="text-white">{userName || 'Utente'}</span>
       </div>
-      <div className="flex items-center justify-between text-[14px] leading-[20px] text-[#b8b2b3]">
+      <div className="flex items-center justify-between text-[14px] leading-[20px] text-[--color-text-secondary]">
         <span>Email</span><span className="text-white">{email || '—'}</span>
       </div>
     </SettingsCard>
@@ -329,25 +329,25 @@ function VersionCard({ appInfo, appInfoStatus, appInfoError }: {
   return (
     <SettingsCard className="gap-[12px]">
       <div className="flex items-center gap-[12px]">
-        <History className="text-[#f4bf4f]" size={24} />
+        <History className="text-[--color-gold-400]" size={24} />
         <div className="text-left">
           <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">Versione app</p>
-          <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">{appInfo?.version ? `v${appInfo.version}` : 'vdev'}</p>
+          <p className="text-[16px] leading-[25.6px] text-[--color-text-secondary] !m-0">{appInfo?.version ? `v${appInfo.version}` : 'vdev'}</p>
         </div>
       </div>
-      <div className="border-t border-[#2d2728] pt-[10px] flex flex-col gap-[8px]">
+      <div className="border-t border-[--color-bg-surface-hover] pt-[10px] flex flex-col gap-[8px]">
         <div className="flex items-center justify-between">
           <p className="text-[16px] leading-[25.6px] text-white !m-0">Changelog</p>
-          {appInfo?.repo && <span className="text-[12px] leading-[16px] text-[#9a9697]">{appInfo.repo}</span>}
+          {appInfo?.repo && <span className="text-[12px] leading-[16px] text-[--color-text-tertiary]">{appInfo.repo}</span>}
         </div>
-        {appInfoStatus === 'loading' && <p className="text-[14px] leading-[20px] text-[#b8b2b3]">Caricamento...</p>}
-        {appInfoStatus === 'error' && <p className="text-[14px] leading-[20px] text-[#ff4d4f]">{appInfoError ?? 'Impossibile caricare il changelog'}</p>}
+        {appInfoStatus === 'loading' && <p className="text-[14px] leading-[20px] text-[--color-text-secondary]">Caricamento...</p>}
+        {appInfoStatus === 'error' && <p className="text-[14px] leading-[20px] text-[--color-error]">{appInfoError ?? 'Impossibile caricare il changelog'}</p>}
         {appInfoStatus === 'idle' && appInfo?.changelog?.length ? (
           <div className="flex flex-col gap-[10px]">
             {appInfo.changelog.map(entry => (
               <div key={entry.sha} className="flex flex-col gap-[2px]">
                 <p className="text-[14px] leading-[20px] text-white !m-0">{entry.message}</p>
-                <p className="text-[12px] leading-[16px] text-[#9a9697] !m-0">
+                <p className="text-[12px] leading-[16px] text-[--color-text-tertiary] !m-0">
                   {entry.sha}{entry.date ? ` - ${formatChangelogDate(entry.date)}` : ''}{entry.author ? ` - ${entry.author}` : ''}
                 </p>
               </div>
@@ -355,7 +355,7 @@ function VersionCard({ appInfo, appInfoStatus, appInfoError }: {
           </div>
         ) : null}
         {appInfoStatus === 'idle' && !appInfo?.changelog?.length && (
-          <p className="text-[14px] leading-[20px] text-[#9a9697]">Nessun aggiornamento disponibile.</p>
+          <p className="text-[14px] leading-[20px] text-[--color-text-tertiary]">Nessun aggiornamento disponibile.</p>
         )}
       </div>
     </SettingsCard>
@@ -382,22 +382,22 @@ function PermissionsSection({ permissionStatuses, permissionMessages, onRequest 
   return (
     <SettingsCard className="gap-[12px]">
       <div className="flex items-center gap-[12px]">
-        <ShieldCheck className="text-[#f4bf4f]" size={24} />
+        <ShieldCheck className="text-[--color-gold-400]" size={24} />
         <div className="text-left">
           <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">Permessi app</p>
-          <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">Gestisci accessi e autorizzazioni</p>
+          <p className="text-[16px] leading-[25.6px] text-[--color-text-secondary] !m-0">Gestisci accessi e autorizzazioni</p>
         </div>
       </div>
-      <div className="border-t border-[#2d2728] pt-[10px] flex flex-col gap-[12px]">
+      <div className="border-t border-[--color-bg-surface-hover] pt-[10px] flex flex-col gap-[12px]">
         {PERMISSION_ROWS.map(({ key, icon: Icon, label }) => (
           <div key={key} className="flex items-start justify-between gap-[12px]">
             <div className="flex items-start gap-[10px]">
-              <Icon className="text-[#f4bf4f]" size={20} />
+              <Icon className="text-[--color-gold-400]" size={20} />
               <div>
                 <p className="text-[16px] leading-[25.6px] text-white !m-0">{label}</p>
-                <p className="text-[12px] leading-[18px] text-[#b8b2b3] !m-0">Stato: {formatPermissionStatus(permissionStatuses[key])}</p>
+                <p className="text-[12px] leading-[18px] text-[--color-text-secondary] !m-0">Stato: {formatPermissionStatus(permissionStatuses[key])}</p>
                 {permissionMessages[key] && (
-                  <p className="text-[12px] leading-[18px] text-[#9a9697] !m-0">{permissionMessages[key]}</p>
+                  <p className="text-[12px] leading-[18px] text-[--color-text-tertiary] !m-0">{permissionMessages[key]}</p>
                 )}
               </div>
             </div>
@@ -406,7 +406,7 @@ function PermissionsSection({ permissionStatuses, permissionMessages, onRequest 
               onClick={() => onRequest(key)}
               disabled={!canRequest[key]}
               aria-label={`Richiedi permesso: ${label}`}
-              className="text-[12px] leading-[18px] px-[10px] py-[6px] rounded-[10px] border border-[#2d2728] text-white disabled:opacity-50"
+              className="text-[12px] leading-[18px] px-[10px] py-[6px] rounded-[10px] border border-[--color-bg-surface-hover] text-white disabled:opacity-50"
             >
               Richiedi
             </button>
@@ -426,10 +426,10 @@ function NotificationToggleCard({ notificationPermission, notificationStatusLabe
     <SettingsCard className="gap-[8px]">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-[12px]">
-          <Bell className="text-[#f4bf4f]" size={24} />
+          <Bell className="text-[--color-gold-400]" size={24} />
           <div className="text-left">
             <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">Notifiche di sistema</p>
-            <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">Aggiornamenti su badge ed eventi</p>
+            <p className="text-[16px] leading-[25.6px] text-[--color-text-secondary] !m-0">Aggiornamenti su badge ed eventi</p>
           </div>
         </div>
         <Switch
@@ -439,9 +439,9 @@ function NotificationToggleCard({ notificationPermission, notificationStatusLabe
           aria-label={notificationPermission === 'granted' ? 'Disattiva notifiche di sistema' : 'Attiva notifiche di sistema'}
         />
       </div>
-      <p className="text-[14px] leading-[20px] text-[#b8b2b3]">Stato: {notificationStatusLabel}</p>
+      <p className="text-[14px] leading-[20px] text-[--color-text-secondary]">Stato: {notificationStatusLabel}</p>
       {notificationMessage && (
-        <p className="text-[12px] leading-[18px] text-[#9a9697]">{notificationMessage}</p>
+        <p className="text-[12px] leading-[18px] text-[--color-text-tertiary]">{notificationMessage}</p>
       )}
     </SettingsCard>
   );
@@ -460,7 +460,7 @@ function LinksSection({ showAiSupport, showTicketPrototype, supportStatus, onVie
       {showAiSupport && (
         <>
           <LinkRow icon={MessageCircle} label="Supporto" subtitle="Chat con Maxwell" onClick={onViewSupport} disabled={supportDisabled} />
-          {supportUnavailable && <p className="text-[14px] leading-[20px] text-[#ff4d4f]">Supporto AI attualmente non disponibile.</p>}
+          {supportUnavailable && <p className="text-[14px] leading-[20px] text-[--color-error]">Supporto AI attualmente non disponibile.</p>}
         </>
       )}
       {showTicketPrototype && (
@@ -484,18 +484,18 @@ function LinkRow({ icon: Icon, label, subtitle, onClick, disabled }: {
       className="min-h-[56px] py-[2px] flex items-center justify-between disabled:opacity-60 disabled:cursor-not-allowed"
     >
       <div className="flex items-center gap-[12px]">
-        <Icon aria-hidden="true" className="text-[#f4bf4f]" size={24} />
+        <Icon aria-hidden="true" className="text-[--color-gold-400]" size={24} />
         <div className="text-left">
           <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">{label}</p>
-          <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">{subtitle}</p>
+          <p className="text-[16px] leading-[25.6px] text-[--color-text-secondary] !m-0">{subtitle}</p>
         </div>
       </div>
-      <ChevronRight aria-hidden="true" className="text-[#9a9697]" size={20} />
+      <ChevronRight aria-hidden="true" className="text-[--color-text-tertiary]" size={20} />
     </button>
   );
 }
 
-function SettingsActionCard({ icon: Icon, label, subtitle, onClick, iconColor = 'text-[#f4bf4f]' }: {
+function SettingsActionCard({ icon: Icon, label, subtitle, onClick, iconColor = 'text-[--color-gold-400]' }: {
   icon: React.ElementType; label: string; subtitle: string; onClick: () => void; iconColor?: string;
 }) {
   return (
@@ -510,10 +510,10 @@ function SettingsActionCard({ icon: Icon, label, subtitle, onClick, iconColor = 
           <Icon aria-hidden="true" className={iconColor} size={24} />
           <div className="text-left">
             <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">{label}</p>
-            <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">{subtitle}</p>
+            <p className="text-[16px] leading-[25.6px] text-[--color-text-secondary] !m-0">{subtitle}</p>
           </div>
         </div>
-        <ChevronRight aria-hidden="true" className="text-[#9a9697]" size={20} />
+        <ChevronRight aria-hidden="true" className="text-[--color-text-tertiary]" size={20} />
       </button>
     </SettingsCard>
   );
@@ -521,7 +521,7 @@ function SettingsActionCard({ icon: Icon, label, subtitle, onClick, iconColor = 
 
 function SettingsCard({ children, className = 'gap-[10px]' }: { children: React.ReactNode; className?: string }) {
   return (
-    <div className={`bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] px-[12px] py-[12px] flex flex-col ${className}`}>
+    <div className={`bg-[--color-bg-surface] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] px-[12px] py-[12px] flex flex-col ${className}`}>
       {children}
     </div>
   );
@@ -746,19 +746,19 @@ function GdprPrivacyCard({
   return (
     <SettingsCard className="gap-[14px]">
       <div className="flex items-center gap-[12px]">
-        <Shield className="text-[#f4bf4f]" size={24} />
+        <Shield className="text-[--color-gold-400]" size={24} />
         <div className="text-left">
           <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">Privacy e dati</p>
-          <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">Controlli GDPR</p>
+          <p className="text-[16px] leading-[25.6px] text-[--color-text-secondary] !m-0">Controlli GDPR</p>
         </div>
       </div>
 
-      <div className="border-t border-[#2d2728] pt-[12px] flex flex-col gap-[16px]">
+      <div className="border-t border-[--color-bg-surface-hover] pt-[12px] flex flex-col gap-[16px]">
         {/* Leaderboard opt-out */}
         <div className="flex items-center justify-between gap-[12px]">
           <div className="flex-1">
             <p className="text-[16px] leading-[25.6px] text-white !m-0">Visibile in classifica</p>
-            <p className="text-[12px] leading-[18px] text-[#b8b2b3] !m-0">Il tuo profilo appare nella classifica pubblica</p>
+            <p className="text-[12px] leading-[18px] text-[--color-text-secondary] !m-0">Il tuo profilo appare nella classifica pubblica</p>
           </div>
           <Switch
             checked={leaderboardVisible}
@@ -772,7 +772,7 @@ function GdprPrivacyCard({
           <div className="flex items-start justify-between gap-[12px]">
             <div className="flex-1">
               <p className="text-[16px] leading-[25.6px] text-white !m-0">Verifica GPS ai turni</p>
-              <p className="text-[12px] leading-[18px] text-[#b8b2b3] !m-0">
+              <p className="text-[12px] leading-[18px] text-[--color-text-secondary] !m-0">
                 Consenti la raccolta della posizione GPS per la verifica presenza. Stato: {geoLabel}
               </p>
             </div>
@@ -784,7 +784,7 @@ function GdprPrivacyCard({
               disabled={geoConsent === 'granted'}
               aria-label="Consenti la verifica GPS ai turni"
               aria-pressed={geoConsent === 'granted'}
-              className="flex-1 py-[6px] px-[10px] rounded-[10px] border border-[#2d2728] text-[12px] text-white disabled:opacity-40"
+              className="flex-1 py-[6px] px-[10px] rounded-[10px] border border-[--color-bg-surface-hover] text-[12px] text-white disabled:opacity-40"
             >
               Consenti
             </button>
@@ -794,7 +794,7 @@ function GdprPrivacyCard({
               disabled={geoConsent === 'denied'}
               aria-label="Nega la verifica GPS ai turni"
               aria-pressed={geoConsent === 'denied'}
-              className="flex-1 py-[6px] px-[10px] rounded-[10px] border border-[#2d2728] text-[12px] text-white disabled:opacity-40"
+              className="flex-1 py-[6px] px-[10px] rounded-[10px] border border-[--color-bg-surface-hover] text-[12px] text-white disabled:opacity-40"
             >
               Nega
             </button>
@@ -808,10 +808,10 @@ function GdprPrivacyCard({
           aria-label="Scarica i miei dati: esporta profilo, turni e badge in JSON"
           className="flex items-center gap-[10px] py-[6px]"
         >
-          <Download aria-hidden="true" className="text-[#f4bf4f]" size={20} />
+          <Download aria-hidden="true" className="text-[--color-gold-400]" size={20} />
           <div className="text-left">
             <p className="text-[16px] leading-[25.6px] font-semibold text-white !m-0">Scarica i miei dati</p>
-            <p className="text-[12px] leading-[18px] text-[#b8b2b3] !m-0">Esporta profilo, turni e badge in JSON</p>
+            <p className="text-[12px] leading-[18px] text-[--color-text-secondary] !m-0">Esporta profilo, turni e badge in JSON</p>
           </div>
         </button>
       </div>
@@ -827,20 +827,20 @@ function AccessibilityCard() {
   return (
     <SettingsCard className="gap-[14px]">
       <div className="flex items-center gap-[12px]">
-        <Accessibility className="text-[#f4bf4f]" size={24} />
+        <Accessibility className="text-[--color-gold-400]" size={24} />
         <div className="text-left">
           <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">Accessibilità</p>
-          <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">Tema e aiuti nei minigiochi</p>
+          <p className="text-[16px] leading-[25.6px] text-[--color-text-secondary] !m-0">Tema e aiuti nei minigiochi</p>
         </div>
       </div>
 
-      <div className="border-t border-[#2d2728] pt-[12px] flex flex-col gap-[16px]">
+      <div className="border-t border-[--color-bg-surface-hover] pt-[12px] flex flex-col gap-[16px]">
         <div className="flex items-center justify-between gap-[12px]">
           <div className="flex items-start gap-[10px] flex-1">
-            <Sun className="text-[#f4bf4f]" size={20} />
+            <Sun className="text-[--color-gold-400]" size={20} />
             <div>
               <p className="text-[16px] leading-[25.6px] text-white !m-0">Tema chiaro</p>
-              <p className="text-[12px] leading-[18px] text-[#b8b2b3] !m-0">Interfaccia su sfondo chiaro per contrasti migliori</p>
+              <p className="text-[12px] leading-[18px] text-[--color-text-secondary] !m-0">Interfaccia su sfondo chiaro per contrasti migliori</p>
             </div>
           </div>
           <Switch
@@ -853,7 +853,7 @@ function AccessibilityCard() {
         <div className="flex items-center justify-between gap-[12px]">
           <div className="flex-1">
             <p className="text-[16px] leading-[25.6px] text-white !m-0">Modalità accessibile (minigiochi)</p>
-            <p className="text-[12px] leading-[18px] text-[#b8b2b3] !m-0">Rallenta la velocità e amplia la tolleranza nei minigiochi timing</p>
+            <p className="text-[12px] leading-[18px] text-[--color-text-secondary] !m-0">Rallenta la velocità e amplia la tolleranza nei minigiochi timing</p>
           </div>
           <Switch
             checked={accessibleMode}

--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -184,13 +184,21 @@ export function AccountSettings({
           {resetError && <p className="text-[14px] leading-[20px] text-[#ff4d4f] text-center">{resetError}</p>}
           {deleteError && <p className="text-[14px] leading-[20px] text-[#ff4d4f] text-center">{deleteError}</p>}
           <CopyrightNotice />
-          <button type="button" onClick={handleDeleteAccount}
-            className="flex items-center justify-center gap-[6px] h-[44px] rounded-md text-[14px] leading-[20px] text-[#ff4d4f]/70 w-full">
-            <UserX size={16} /> Elimina account
+          <button
+            type="button"
+            onClick={handleDeleteAccount}
+            aria-label="Elimina definitivamente il tuo account"
+            className="flex items-center justify-center gap-[6px] h-[44px] rounded-md text-[14px] leading-[20px] text-[#ff4d4f]/70 w-full"
+          >
+            <UserX aria-hidden="true" size={16} /> Elimina account
           </button>
-          <button type="button" onClick={onLogout}
-            className="flex items-center justify-center gap-[6px] h-[44px] rounded-md text-[18px] leading-[28px] text-[#ff4d4f] w-full">
-            <LogOut size={20} /> Esci
+          <button
+            type="button"
+            onClick={onLogout}
+            aria-label="Disconnetti dal tuo account"
+            className="flex items-center justify-center gap-[6px] h-[44px] rounded-md text-[18px] leading-[28px] text-[#ff4d4f] w-full"
+          >
+            <LogOut aria-hidden="true" size={20} /> Esci
           </button>
         </div>
       </div>
@@ -393,8 +401,13 @@ function PermissionsSection({ permissionStatuses, permissionMessages, onRequest 
                 )}
               </div>
             </div>
-            <button type="button" onClick={() => onRequest(key)} disabled={!canRequest[key]}
-              className="text-[12px] leading-[18px] px-[10px] py-[6px] rounded-[10px] border border-[#2d2728] text-white disabled:opacity-50">
+            <button
+              type="button"
+              onClick={() => onRequest(key)}
+              disabled={!canRequest[key]}
+              aria-label={`Richiedi permesso: ${label}`}
+              className="text-[12px] leading-[18px] px-[10px] py-[6px] rounded-[10px] border border-[#2d2728] text-white disabled:opacity-50"
+            >
               Richiedi
             </button>
           </div>
@@ -419,7 +432,12 @@ function NotificationToggleCard({ notificationPermission, notificationStatusLabe
             <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">Aggiornamenti su badge ed eventi</p>
           </div>
         </div>
-        <Switch checked={notificationPermission === 'granted'} onCheckedChange={onToggle} disabled={notificationPermission === 'unsupported'} />
+        <Switch
+          checked={notificationPermission === 'granted'}
+          onCheckedChange={onToggle}
+          disabled={notificationPermission === 'unsupported'}
+          aria-label={notificationPermission === 'granted' ? 'Disattiva notifiche di sistema' : 'Attiva notifiche di sistema'}
+        />
       </div>
       <p className="text-[14px] leading-[20px] text-[#b8b2b3]">Stato: {notificationStatusLabel}</p>
       {notificationMessage && (
@@ -458,16 +476,21 @@ function LinkRow({ icon: Icon, label, subtitle, onClick, disabled }: {
   icon: React.ElementType; label: string; subtitle: string; onClick: () => void; disabled?: boolean;
 }) {
   return (
-    <button type="button" onClick={onClick} disabled={disabled}
-      className="min-h-[56px] py-[2px] flex items-center justify-between disabled:opacity-60 disabled:cursor-not-allowed">
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={`${label}: ${subtitle}`}
+      className="min-h-[56px] py-[2px] flex items-center justify-between disabled:opacity-60 disabled:cursor-not-allowed"
+    >
       <div className="flex items-center gap-[12px]">
-        <Icon className="text-[#f4bf4f]" size={24} />
+        <Icon aria-hidden="true" className="text-[#f4bf4f]" size={24} />
         <div className="text-left">
           <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">{label}</p>
           <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">{subtitle}</p>
         </div>
       </div>
-      <ChevronRight className="text-[#9a9697]" size={20} />
+      <ChevronRight aria-hidden="true" className="text-[#9a9697]" size={20} />
     </button>
   );
 }
@@ -477,15 +500,20 @@ function SettingsActionCard({ icon: Icon, label, subtitle, onClick, iconColor = 
 }) {
   return (
     <SettingsCard className="gap-[8px]">
-      <button type="button" onClick={onClick} className="h-[51px] flex items-center justify-between">
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={`${label}: ${subtitle}`}
+        className="h-[51px] flex items-center justify-between"
+      >
         <div className="flex items-center gap-[12px]">
-          <Icon className={iconColor} size={24} />
+          <Icon aria-hidden="true" className={iconColor} size={24} />
           <div className="text-left">
             <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">{label}</p>
             <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">{subtitle}</p>
           </div>
         </div>
-        <ChevronRight className="text-[#9a9697]" size={20} />
+        <ChevronRight aria-hidden="true" className="text-[#9a9697]" size={20} />
       </button>
     </SettingsCard>
   );
@@ -732,7 +760,11 @@ function GdprPrivacyCard({
             <p className="text-[16px] leading-[25.6px] text-white !m-0">Visibile in classifica</p>
             <p className="text-[12px] leading-[18px] text-[#b8b2b3] !m-0">Il tuo profilo appare nella classifica pubblica</p>
           </div>
-          <Switch checked={leaderboardVisible} onCheckedChange={onToggleLeaderboard} />
+          <Switch
+            checked={leaderboardVisible}
+            onCheckedChange={onToggleLeaderboard}
+            aria-label={leaderboardVisible ? 'Nascondi profilo dalla classifica pubblica' : 'Mostra profilo nella classifica pubblica'}
+          />
         </div>
 
         {/* Geo consent */}
@@ -746,23 +778,37 @@ function GdprPrivacyCard({
             </div>
           </div>
           <div className="flex gap-[8px]">
-            <button type="button" onClick={onGrantGeoConsent}
+            <button
+              type="button"
+              onClick={onGrantGeoConsent}
               disabled={geoConsent === 'granted'}
-              className="flex-1 py-[6px] px-[10px] rounded-[10px] border border-[#2d2728] text-[12px] text-white disabled:opacity-40">
+              aria-label="Consenti la verifica GPS ai turni"
+              aria-pressed={geoConsent === 'granted'}
+              className="flex-1 py-[6px] px-[10px] rounded-[10px] border border-[#2d2728] text-[12px] text-white disabled:opacity-40"
+            >
               Consenti
             </button>
-            <button type="button" onClick={onDenyGeoConsent}
+            <button
+              type="button"
+              onClick={onDenyGeoConsent}
               disabled={geoConsent === 'denied'}
-              className="flex-1 py-[6px] px-[10px] rounded-[10px] border border-[#2d2728] text-[12px] text-white disabled:opacity-40">
+              aria-label="Nega la verifica GPS ai turni"
+              aria-pressed={geoConsent === 'denied'}
+              className="flex-1 py-[6px] px-[10px] rounded-[10px] border border-[#2d2728] text-[12px] text-white disabled:opacity-40"
+            >
               Nega
             </button>
           </div>
         </div>
 
         {/* Export data */}
-        <button type="button" onClick={onExportData}
-          className="flex items-center gap-[10px] py-[6px]">
-          <Download className="text-[#f4bf4f]" size={20} />
+        <button
+          type="button"
+          onClick={onExportData}
+          aria-label="Scarica i miei dati: esporta profilo, turni e badge in JSON"
+          className="flex items-center gap-[10px] py-[6px]"
+        >
+          <Download aria-hidden="true" className="text-[#f4bf4f]" size={20} />
           <div className="text-left">
             <p className="text-[16px] leading-[25.6px] font-semibold text-white !m-0">Scarica i miei dati</p>
             <p className="text-[12px] leading-[18px] text-[#b8b2b3] !m-0">Esporta profilo, turni e badge in JSON</p>

--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -11,11 +11,11 @@ import { getPermission, requestPermission, type NotificationPermissionState } fr
 import { checkAiSupportAvailability } from '../../services/ai';
 import { CopyrightNotice } from '../ui/CopyrightNotice';
 import { GEO_CONSENT_KEY } from '../../constants/privacy';
-import { useAccessibilityPreferences, type FontScale, type Theme } from '../../hooks/useAccessibilityPreferences';
 import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
 } from '../ui/alert-dialog';
+import { useGameState } from '../../state/store';
 
 interface AccountSettingsProps {
   userName: string;
@@ -217,107 +217,6 @@ function UserInfoCard({ userName, email }: { userName: string; email: string }) 
       </div>
       <div className="flex items-center justify-between text-[14px] leading-[20px] text-[--color-text-secondary]">
         <span>Email</span><span className="text-white">{email || '—'}</span>
-      </div>
-    </SettingsCard>
-  );
-}
-
-function AccessibilityCard() {
-  const { theme, accessibleMode, fontScale, setTheme, setAccessibleMode, setFontScale } = useAccessibilityPreferences();
-
-  const themeOptions: { value: Theme; label: string }[] = [
-    { value: 'dark', label: 'Scuro' },
-    { value: 'light', label: 'Chiaro' },
-  ];
-
-  const fontScaleOptions: { value: FontScale; label: string }[] = [
-    { value: 'sm', label: 'A−' },
-    { value: 'md', label: 'A' },
-    { value: 'lg', label: 'A+' },
-    { value: 'xl', label: 'A++' },
-  ];
-
-  return (
-    <SettingsCard className="gap-[14px]">
-      <div className="flex items-center gap-[12px]">
-        <Accessibility className="text-[#f4bf4f]" size={24} aria-hidden="true" />
-        <div className="text-left">
-          <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">Accessibilità</p>
-          <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">Tema, font e modalità accessibile</p>
-        </div>
-      </div>
-
-      <div className="border-t border-[#2d2728] pt-[12px] flex flex-col gap-[16px]">
-        {/* Theme */}
-        <div className="flex flex-col gap-[8px]" role="radiogroup" aria-label="Tema interfaccia">
-          <div className="flex items-center gap-[8px]">
-            <Sun size={16} className="text-[#f4bf4f]" aria-hidden="true" />
-            <p className="text-[16px] leading-[25.6px] text-white !m-0">Tema</p>
-          </div>
-          <p className="text-[12px] leading-[18px] text-[#b8b2b3] !m-0">
-            Il tema chiaro migliora la leggibilità per chi ha sensibilità ai contrasti elevati.
-          </p>
-          <div className="flex gap-[8px]">
-            {themeOptions.map(opt => (
-              <button
-                key={opt.value}
-                type="button"
-                role="radio"
-                aria-checked={theme === opt.value}
-                onClick={() => setTheme(opt.value)}
-                className={`flex-1 py-[8px] px-[12px] rounded-[10px] text-[14px] border transition-colors ${
-                  theme === opt.value
-                    ? 'border-[#f4bf4f] bg-[#f4bf4f]/15 text-[#f4bf4f]'
-                    : 'border-[#2d2728] text-white hover:border-[#3d3a3b]'
-                }`}
-              >
-                {opt.label}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Font scale */}
-        <div className="flex flex-col gap-[8px]" role="radiogroup" aria-label="Dimensione del testo">
-          <p className="text-[16px] leading-[25.6px] text-white !m-0">Dimensione testo</p>
-          <p className="text-[12px] leading-[18px] text-[#b8b2b3] !m-0">
-            Adatta la dimensione del testo a tutta l'app.
-          </p>
-          <div className="flex gap-[8px]">
-            {fontScaleOptions.map(opt => (
-              <button
-                key={opt.value}
-                type="button"
-                role="radio"
-                aria-checked={fontScale === opt.value}
-                aria-label={`Dimensione testo ${opt.label}`}
-                onClick={() => setFontScale(opt.value)}
-                className={`flex-1 min-h-[44px] px-[8px] rounded-[10px] border transition-colors ${
-                  fontScale === opt.value
-                    ? 'border-[#f4bf4f] bg-[#f4bf4f]/15 text-[#f4bf4f]'
-                    : 'border-[#2d2728] text-white hover:border-[#3d3a3b]'
-                }`}
-              >
-                {opt.label}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Accessible mode for timed minigames */}
-        <div className="flex items-center justify-between gap-[12px]">
-          <div className="flex-1">
-            <p className="text-[16px] leading-[25.6px] text-white !m-0">Modalità accessibile</p>
-            <p className="text-[12px] leading-[18px] text-[#b8b2b3] !m-0">
-              Tempi più lunghi e tolleranze più ampie nei minigiochi a tempo.
-            </p>
-          </div>
-          <Switch
-            checked={accessibleMode}
-            onCheckedChange={setAccessibleMode}
-            aria-label="Attiva modalità accessibile"
-          />
-        </div>
       </div>
     </SettingsCard>
   );

--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -166,6 +166,7 @@ export function AccountSettings({
           onDenyGeoConsent={denyGeoConsent}
           onExportData={onExportData}
         />
+        <AccessibilityCard />
         <LinksSection
           showAiSupport={showAiSupport}
           showTicketPrototype={showTicketPrototype}
@@ -767,6 +768,53 @@ function GdprPrivacyCard({
             <p className="text-[12px] leading-[18px] text-[#b8b2b3] !m-0">Esporta profilo, turni e badge in JSON</p>
           </div>
         </button>
+      </div>
+    </SettingsCard>
+  );
+}
+
+function AccessibilityCard() {
+  const { state, updateProfile } = useGameState();
+  const isLight = state.profile.theme === 'light';
+  const accessibleMode = state.profile.accessibleMode;
+
+  return (
+    <SettingsCard className="gap-[14px]">
+      <div className="flex items-center gap-[12px]">
+        <Accessibility className="text-[#f4bf4f]" size={24} />
+        <div className="text-left">
+          <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">Accessibilità</p>
+          <p className="text-[16px] leading-[25.6px] text-[#b8b2b3] !m-0">Tema e aiuti nei minigiochi</p>
+        </div>
+      </div>
+
+      <div className="border-t border-[#2d2728] pt-[12px] flex flex-col gap-[16px]">
+        <div className="flex items-center justify-between gap-[12px]">
+          <div className="flex items-start gap-[10px] flex-1">
+            <Sun className="text-[#f4bf4f]" size={20} />
+            <div>
+              <p className="text-[16px] leading-[25.6px] text-white !m-0">Tema chiaro</p>
+              <p className="text-[12px] leading-[18px] text-[#b8b2b3] !m-0">Interfaccia su sfondo chiaro per contrasti migliori</p>
+            </div>
+          </div>
+          <Switch
+            checked={isLight}
+            onCheckedChange={(checked) => updateProfile({ theme: checked ? 'light' : 'dark' })}
+            aria-label="Attiva tema chiaro"
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-[12px]">
+          <div className="flex-1">
+            <p className="text-[16px] leading-[25.6px] text-white !m-0">Modalità accessibile (minigiochi)</p>
+            <p className="text-[12px] leading-[18px] text-[#b8b2b3] !m-0">Rallenta la velocità e amplia la tolleranza nei minigiochi timing</p>
+          </div>
+          <Switch
+            checked={accessibleMode}
+            onCheckedChange={(checked) => updateProfile({ accessibleMode: checked })}
+            aria-label="Attiva modalità accessibile nei minigiochi"
+          />
+        </div>
       </div>
     </SettingsCard>
   );

--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
-  Accessibility,
-  ArrowLeft, Bell, Camera, ChevronRight, Download, FileText, History, KeyRound,
-  LogOut, MapPin, MessageCircle, QrCode, RotateCcw, Shield, ShieldCheck, Sun, Trash2, UserX,
+  Accessibility, ArrowLeft, Bell, Camera, ChevronRight, Download, FileText, History, KeyRound,
+  LogOut, MapPin, MessageCircle, Moon, Monitor, QrCode, RotateCcw, Shield, ShieldCheck, Sun, Trash2, UserX,
 } from 'lucide-react';
+import { useTheme, type ThemeSetting } from '../../providers/ThemeProvider';
 import { Screen } from '../ui/Screen';
 import { isSupabaseConfigured, supabase } from '../../lib/supabase';
 import { Switch } from '../ui/switch';
@@ -819,41 +819,78 @@ function GdprPrivacyCard({
   );
 }
 
+const THEME_OPTIONS: { value: ThemeSetting; label: string; Icon: React.ElementType; description: string }[] = [
+  { value: 'system', label: 'Automatico', Icon: Monitor, description: 'Segue il tema del dispositivo' },
+  { value: 'light',  label: 'Chiaro',     Icon: Sun,     description: 'Sfondo chiaro, contrasto alto' },
+  { value: 'dark',   label: 'Scuro',      Icon: Moon,    description: 'Sfondo scuro, stile teatro' },
+];
+
 function AccessibilityCard() {
+  const { theme, setTheme } = useTheme();
   const { state, updateProfile } = useGameState();
-  const isLight = state.profile.theme === 'light';
   const accessibleMode = state.profile.accessibleMode;
 
   return (
-    <SettingsCard className="gap-[14px]">
+    <SettingsCard className="gap-[18px]">
+      {/* Header */}
       <div className="flex items-center gap-[12px]">
-        <Accessibility className="text-[--color-gold-400]" size={24} />
+        <div className="w-[40px] h-[40px] rounded-[12px] bg-[--color-burgundy-900] flex items-center justify-center shrink-0">
+          <Accessibility className="text-[--color-gold-400]" size={20} />
+        </div>
         <div className="text-left">
-          <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">Accessibilità</p>
-          <p className="text-[16px] leading-[25.6px] text-[--color-text-secondary] !m-0">Tema e aiuti nei minigiochi</p>
+          <p className="text-[17px] leading-[22px] font-semibold text-[--color-text-primary] !m-0">Accessibilità</p>
+          <p className="text-[13px] leading-[18px] text-[--color-text-secondary] !m-0">Aspetto e aiuti nei minigiochi</p>
         </div>
       </div>
 
-      <div className="border-t border-[--color-bg-surface-hover] pt-[12px] flex flex-col gap-[16px]">
-        <div className="flex items-center justify-between gap-[12px]">
-          <div className="flex items-start gap-[10px] flex-1">
-            <Sun className="text-[--color-gold-400]" size={20} />
-            <div>
-              <p className="text-[16px] leading-[25.6px] text-white !m-0">Tema chiaro</p>
-              <p className="text-[12px] leading-[18px] text-[--color-text-secondary] !m-0">Interfaccia su sfondo chiaro per contrasti migliori</p>
-            </div>
-          </div>
-          <Switch
-            checked={isLight}
-            onCheckedChange={(checked) => updateProfile({ theme: checked ? 'light' : 'dark' })}
-            aria-label="Attiva tema chiaro"
-          />
+      {/* Theme selector */}
+      <div className="flex flex-col gap-[8px]">
+        <p className="text-[13px] font-medium text-[--color-text-tertiary] uppercase tracking-wider !m-0">Aspetto</p>
+        <div
+          className="grid grid-cols-3 gap-[6px]"
+          role="radiogroup"
+          aria-label="Scegli il tema dell'interfaccia"
+        >
+          {THEME_OPTIONS.map(({ value, label, Icon, description }) => {
+            const selected = theme === value;
+            return (
+              <button
+                key={value}
+                role="radio"
+                aria-checked={selected}
+                aria-label={`${label}: ${description}`}
+                onClick={() => setTheme(value)}
+                className={[
+                  'flex flex-col items-center gap-[6px] px-[8px] py-[10px] rounded-[12px] border transition-all',
+                  selected
+                    ? 'bg-[--color-gold-400]/10 border-[--color-gold-400] text-[--color-gold-400]'
+                    : 'bg-[--color-bg-surface-elevated] border-[--color-border] text-[--color-text-secondary]',
+                ].join(' ')}
+              >
+                <Icon size={20} aria-hidden="true" />
+                <span className="text-[12px] font-medium leading-none">{label}</span>
+              </button>
+            );
+          })}
         </div>
+        <p className="text-[12px] text-[--color-text-tertiary] !m-0">
+          {THEME_OPTIONS.find(o => o.value === theme)?.description}
+        </p>
+      </div>
 
-        <div className="flex items-center justify-between gap-[12px]">
-          <div className="flex-1">
-            <p className="text-[16px] leading-[25.6px] text-white !m-0">Modalità accessibile (minigiochi)</p>
-            <p className="text-[12px] leading-[18px] text-[--color-text-secondary] !m-0">Rallenta la velocità e amplia la tolleranza nei minigiochi timing</p>
+      {/* Accessible mode */}
+      <div className="border-t border-[--color-border] pt-[14px]">
+        <div className="flex items-start justify-between gap-[12px]">
+          <div className="flex items-start gap-[10px] flex-1">
+            <div className="w-[32px] h-[32px] rounded-[8px] bg-[--color-burgundy-900] flex items-center justify-center shrink-0 mt-[2px]">
+              <Accessibility size={16} className="text-[--color-gold-400]" aria-hidden="true" />
+            </div>
+            <div>
+              <p className="text-[15px] leading-[20px] font-medium text-[--color-text-primary] !m-0">Modalità accessibile</p>
+              <p className="text-[12px] leading-[17px] text-[--color-text-secondary] !mt-[2px] !mb-0">
+                Rallenta i minigiochi timing e amplia la finestra di tolleranza
+              </p>
+            </div>
           </div>
           <Switch
             checked={accessibleMode}

--- a/apps/mobile/src/components/screens/Activities.tsx
+++ b/apps/mobile/src/components/screens/Activities.tsx
@@ -42,7 +42,7 @@ export function Activities({
     <>
       <header className="space-y-2">
         <h2 className="text-white">Attività simulate</h2>
-        <p className="text-[#b8b2b3]">Migliora le tue skill e guadagna ricompense</p>
+        <p className="text-muted">Migliora le tue skill e guadagna ricompense</p>
       </header>
 
       <TrainingBanner />
@@ -81,8 +81,8 @@ export function Activities({
 
       {totalActivities === 0 && (
         <Card className="text-center">
-          <p className="text-sm text-[#9a9697]">Nuove attività in arrivo</p>
-          <p className="text-sm text-[#b8b2b3]">Stiamo preparando nuove sfide e attività</p>
+          <p className="text-sm text-subtle">Nuove attività in arrivo</p>
+          <p className="text-sm text-muted">Stiamo preparando nuove sfide e attività</p>
         </Card>
       )}
     </>
@@ -121,14 +121,14 @@ function ScenarioPreviewCard({ onOpen }: { onOpen: () => void }) {
 
 function TrainingBanner() {
   return (
-    <Card className="border border-[#f4bf4f]/30 bg-gradient-to-br from-[#1a1617] to-[#241f20]">
+    <Card className="border border-accent/30 bg-gradient-to-br from-surface to-surface-elevated">
       <div className="flex items-start gap-4">
-        <div className="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-xl flex items-center justify-center">
-          <TrendingUp className="text-[#f4bf4f]" size={22} />
+        <div className="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-burgundy-600 to-burgundy-800 rounded-xl flex items-center justify-center">
+          <TrendingUp className="text-accent" size={22} />
         </div>
         <div className="space-y-1">
           <h3 className="text-white">Allenati ogni giorno</h3>
-          <p className="text-sm text-[#b8b2b3]">
+          <p className="text-sm text-muted">
             Completa le attività per migliorare le tue competenze e prepararti per gli eventi reali
           </p>
         </div>
@@ -146,15 +146,15 @@ function DailyProgressCard({
   slotsLoading: boolean;
 }) {
   return (
-    <Card className="border border-[#2d2728] bg-[#1a1617]">
+    <Card className="border border-surface-hover bg-surface">
       <div className="flex items-center justify-between gap-4">
         <div className="space-y-1">
-          <p className="text-xs uppercase tracking-wide text-[#b8b2b3]">Missioni giornaliere</p>
+          <p className="text-xs uppercase tracking-wide text-muted">Missioni giornaliere</p>
           <h3 className="text-white text-lg font-semibold">{completedToday}/{dailyGoal} completate oggi</h3>
-          {slotsLoading && <p className="text-sm text-[#b8b2b3]">Verifica slot in corso...</p>}
+          {slotsLoading && <p className="text-sm text-muted">Verifica slot in corso...</p>}
         </div>
-        <div className="w-12 h-12 rounded-full bg-[#241f20] flex items-center justify-center">
-          <Flag className="text-[#f4bf4f]" size={22} />
+        <div className="w-12 h-12 rounded-full bg-surface-elevated flex items-center justify-center">
+          <Flag className="text-accent" size={22} />
         </div>
       </div>
       <div className="mt-4">
@@ -190,24 +190,24 @@ function ActivityCard({
       onClick={canStart ? onStart : undefined}
       aria-label={cardLabel}
       aria-disabled={!canStart}
-      className="border border-white/5 bg-gradient-to-br from-[#1a1617] via-[#1d1819] to-[#221d1e]"
+      className="border border-white/5 bg-gradient-to-br from-surface via-surface to-surface-elevated"
     >
       <div className="flex items-start gap-4">
-        <div aria-hidden="true" className="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-2xl flex items-center justify-center">
-          <Play className="text-[#f4bf4f]" size={22} />
+        <div aria-hidden="true" className="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-burgundy-600 to-burgundy-800 rounded-2xl flex items-center justify-center">
+          <Play className="text-accent" size={22} />
         </div>
         <div className="flex-1 space-y-3">
           <div className="flex items-start justify-between gap-2">
             <div>
-              <p className="text-xs uppercase tracking-wide text-[#b8b2b3]">Missione {index + 1}</p>
+              <p className="text-xs uppercase tracking-wide text-muted">Missione {index + 1}</p>
               <h4 className="text-white text-lg">{activity.title}</h4>
             </div>
-            <div aria-hidden="true" className="flex items-center gap-2 text-[#f4bf4f]"><Play size={18} /></div>
+            <div aria-hidden="true" className="flex items-center gap-2 text-accent"><Play size={18} /></div>
           </div>
 
-          <p className="text-sm text-[#b8b2b3]">{activity.description}</p>
+          <p className="text-sm text-muted">{activity.description}</p>
 
-          <div className="flex flex-wrap items-center gap-2 text-sm text-[#b8b2b3]">
+          <div className="flex flex-wrap items-center gap-2 text-sm text-muted">
             <span className="inline-flex items-center gap-2"><Clock size={14} />{activity.duration}</span>
             <Badge variant="outline" size="sm">{difficultyLabel}</Badge>
             {isRecommended && (
@@ -219,7 +219,7 @@ function ActivityCard({
           <RewardTags xp={rewardPreview.xp} cachet={rewardPreview.cachet} />
 
           {!canStart && (
-            <p className="text-xs text-[#ff9aac]">
+            <p className="text-xs text-[--color-error]">
               {!canStartActivities ? 'Funzione temporaneamente disattivata.'
                 : !isOnline ? 'Per completare attività serve connessione online.'
                 : 'Limite slot giornalieri raggiunto.'}
@@ -235,10 +235,10 @@ function RewardTags({ xp, cachet }: { xp: number; cachet: number }) {
   return (
     <div className="flex flex-wrap items-center gap-2">
       <span className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-xs text-white/90 backdrop-blur">
-        <TrendingUp size={12} className="text-[#f4bf4f]" /> +{xp} XP
+        <TrendingUp size={12} className="text-accent" /> +{xp} XP
       </span>
       <span className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-xs text-white/90 backdrop-blur">
-        <Coins size={12} className="text-[#f4bf4f]" /> +{cachet}
+        <Coins size={12} className="text-accent" /> +{cachet}
       </span>
     </div>
   );

--- a/apps/mobile/src/components/screens/Activities.tsx
+++ b/apps/mobile/src/components/screens/Activities.tsx
@@ -180,14 +180,20 @@ function ActivityCard({
   const rewardPreview = computeActivityRewards(activity, activeRole);
   const roleHighlight = getRoleActivityOverride(activeRole, activity.id)?.highlightLabel;
 
+  const cardLabel = canStart
+    ? `Avvia attività: ${activity.title}. Difficoltà ${difficultyLabel}. Ricompensa ${rewardPreview.xp} XP e ${rewardPreview.cachet} cachet`
+    : `${activity.title} (non disponibile)`;
+
   return (
     <Card
       hoverable={canStart}
       onClick={canStart ? onStart : undefined}
+      aria-label={cardLabel}
+      aria-disabled={!canStart}
       className="border border-white/5 bg-gradient-to-br from-[#1a1617] via-[#1d1819] to-[#221d1e]"
     >
       <div className="flex items-start gap-4">
-        <div className="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-2xl flex items-center justify-center">
+        <div aria-hidden="true" className="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-2xl flex items-center justify-center">
           <Play className="text-[#f4bf4f]" size={22} />
         </div>
         <div className="flex-1 space-y-3">
@@ -196,7 +202,7 @@ function ActivityCard({
               <p className="text-xs uppercase tracking-wide text-[#b8b2b3]">Missione {index + 1}</p>
               <h4 className="text-white text-lg">{activity.title}</h4>
             </div>
-            <div className="flex items-center gap-2 text-[#f4bf4f]"><Play size={18} /></div>
+            <div aria-hidden="true" className="flex items-center gap-2 text-[#f4bf4f]"><Play size={18} /></div>
           </div>
 
           <p className="text-sm text-[#b8b2b3]">{activity.description}</p>

--- a/apps/mobile/src/components/screens/ActivitiesHub.tsx
+++ b/apps/mobile/src/components/screens/ActivitiesHub.tsx
@@ -43,8 +43,8 @@ export function ActivitiesHub({
 
       {!resolvedSection && (
         <Card className="text-center py-10">
-          <p className="text-sm text-[#9a9697]">Sezione non disponibile</p>
-          <p className="text-sm text-[#b8b2b3] mt-1">
+          <p className="text-sm text-[--color-text-tertiary]">Sezione non disponibile</p>
+          <p className="text-sm text-[--color-text-secondary] mt-1">
             Turni e attivita sono temporaneamente disattivati dalle feature flag.
           </p>
         </Card>
@@ -62,7 +62,7 @@ function SectionSwitcher({
   onSectionChange: (section: ActivitiesHubSection) => void;
 }) {
   return (
-    <div className="rounded-[14px] border border-[#2d2728] bg-[#1a1617] p-1 grid grid-cols-2 gap-1">
+    <div className="rounded-[14px] border border-[--color-bg-surface-hover] bg-[--color-bg-surface] p-1 grid grid-cols-2 gap-1">
       <SwitcherButton
         active={activeSection === 'turns'}
         icon={<Ticket size={16} />}
@@ -93,8 +93,8 @@ function SwitcherButton({
       onClick={onClick}
       className={`min-h-[44px] rounded-[10px] px-3 text-sm font-medium transition-colors ${
         active
-          ? 'bg-[#f4bf4f] text-[#1a1617]'
-          : 'text-[#b8b2b3] hover:text-white hover:bg-[#2a2425]'
+          ? 'bg-[--color-gold-400] text-[--color-bg-surface]'
+          : 'text-[--color-text-secondary] hover:text-white hover:bg-[--color-bg-surface-elevated]'
       }`}
     >
       <span className="inline-flex items-center gap-2 justify-center w-full">

--- a/apps/mobile/src/components/screens/ActivityDetail.tsx
+++ b/apps/mobile/src/components/screens/ActivityDetail.tsx
@@ -25,15 +25,15 @@ export function ActivityDetail({ activity, role, onStart, onClose }: ActivityDet
       aria-describedby="activity-detail-description"
       className="fixed inset-0 app-gradient z-50 overflow-y-auto pb-24"
     >
-      <div className="sticky top-0 bg-[#1a1617] border-b border-[#2d2728] p-4 flex items-center justify-between z-10">
+      <div className="sticky top-0 bg-surface border-b border-surface-hover p-4 flex items-center justify-between z-10">
         <h3 className="text-white">Dettagli attività</h3>
         <button
           type="button"
           onClick={onClose}
           aria-label="Chiudi dettagli attività"
-          className="flex items-center justify-center size-[44px] hover:bg-[#241f20] rounded-lg transition-colors"
+          className="flex items-center justify-center size-[44px] hover:bg-surface-elevated rounded-lg transition-colors"
         >
-          <X aria-hidden="true" className="text-[#f4bf4f]" size={24} />
+          <X aria-hidden="true" className="text-accent" size={24} />
         </button>
       </div>
 
@@ -45,48 +45,48 @@ export function ActivityDetail({ activity, role, onStart, onClose }: ActivityDet
               <Clock aria-hidden="true" size={14} />
               <span aria-label={`Durata ${activity.duration}`}>{activity.duration}</span>
             </Badge>
-            <span className="text-[#b8b2b3]" aria-label={`Difficoltà ${activity.difficulty}`}>{activity.difficulty}</span>
+            <span className="text-muted" aria-label={`Difficoltà ${activity.difficulty}`}>{activity.difficulty}</span>
           </div>
         </section>
 
         <Card>
-          <p id="activity-detail-description" className="text-[#b8b2b3]">{activity.description}</p>
+          <p id="activity-detail-description" className="text-muted">{activity.description}</p>
         </Card>
 
-        <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20]">
+        <Card className="bg-gradient-to-br from-surface to-surface-elevated">
           <section aria-labelledby="activity-rewards-heading">
-            <h4 id="activity-rewards-heading" className="text-[#f4bf4f] mb-4">Ricompense</h4>
+            <h4 id="activity-rewards-heading" className="text-accent mb-4">Ricompense</h4>
             <div className="grid grid-cols-2 gap-4">
               <div className="text-center" aria-label={`Ricompensa esperienza: ${rewards.xp} XP`}>
-                <div aria-hidden="true" className="w-12 h-12 bg-gradient-to-br from-[#e6a23c] to-[#f4bf4f] rounded-lg flex items-center justify-center mx-auto mb-2">
-                  <TrendingUp className="text-[#0f0d0e]" size={24} />
+                <div aria-hidden="true" className="w-12 h-12 bg-gradient-to-br from-accent-hover to-accent rounded-lg flex items-center justify-center mx-auto mb-2">
+                  <TrendingUp className="text-primary-bg" size={24} />
                 </div>
                 <p className="text-2xl text-white mb-1">+{rewards.xp}</p>
-                <p className="text-xs text-[#b8b2b3]">XP</p>
+                <p className="text-xs text-muted">XP</p>
               </div>
 
               <div className="text-center" aria-label={`Ricompensa cachet: ${rewards.cachet}`}>
-                <div aria-hidden="true" className="w-12 h-12 bg-[#241f20] rounded-lg flex items-center justify-center mx-auto mb-2">
-                  <Coins className="text-[#f4bf4f]" size={24} />
+                <div aria-hidden="true" className="w-12 h-12 bg-surface-elevated rounded-lg flex items-center justify-center mx-auto mb-2">
+                  <Coins className="text-accent" size={24} />
                 </div>
                 <p className="text-2xl text-white mb-1">+{rewards.cachet}</p>
-                <p className="text-xs text-[#b8b2b3]">Cachet</p>
+                <p className="text-xs text-muted">Cachet</p>
               </div>
             </div>
           </section>
         </Card>
 
-        <Card className="border border-[#f4bf4f]/30">
+        <Card className="border border-accent/30">
           <div className="flex gap-3">
-            <AlertCircle aria-hidden="true" className="text-[#f4bf4f] flex-shrink-0" size={20} />
+            <AlertCircle aria-hidden="true" className="text-accent flex-shrink-0" size={20} />
             <div className="space-y-1">
               <p className="text-sm text-white">{minigame.title}</p>
-              <p className="text-xs text-[#b8b2b3]">{minigame.subtitle}</p>
+              <p className="text-xs text-muted">{minigame.subtitle}</p>
               {roleHighlight?.highlightLabel ? (
-                <p className="text-xs text-[#f4bf4f]">{roleHighlight.highlightLabel}</p>
+                <p className="text-xs text-accent">{roleHighlight.highlightLabel}</p>
               ) : null}
               {roleHighlight?.homeNote ? (
-                <p className="text-xs text-[#9b9496]">{roleHighlight.homeNote}</p>
+                <p className="text-xs text-subtle">{roleHighlight.homeNote}</p>
               ) : null}
             </div>
           </div>

--- a/apps/mobile/src/components/screens/ActivityDetail.tsx
+++ b/apps/mobile/src/components/screens/ActivityDetail.tsx
@@ -18,55 +18,67 @@ export function ActivityDetail({ activity, role, onStart, onClose }: ActivityDet
   const rewards = computeActivityRewards(activity, role);
   const roleHighlight = getRoleActivityOverride(role, activity.id);
   return (
-    <div className="fixed inset-0 app-gradient z-50 overflow-y-auto pb-24">
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="activity-detail-title"
+      aria-describedby="activity-detail-description"
+      className="fixed inset-0 app-gradient z-50 overflow-y-auto pb-24"
+    >
       <div className="sticky top-0 bg-[#1a1617] border-b border-[#2d2728] p-4 flex items-center justify-between z-10">
         <h3 className="text-white">Dettagli attività</h3>
-        <button type="button" onClick={onClose} aria-label="Chiudi"
-          className="flex items-center justify-center size-[44px] hover:bg-[#241f20] rounded-lg transition-colors">
-          <X className="text-[#f4bf4f]" size={24} aria-hidden="true" />
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Chiudi dettagli attività"
+          className="flex items-center justify-center size-[44px] hover:bg-[#241f20] rounded-lg transition-colors"
+        >
+          <X aria-hidden="true" className="text-[#f4bf4f]" size={24} />
         </button>
       </div>
 
       <div className="app-content px-6 py-6 space-y-6">
-        <div>
-          <h2 className="text-white mb-2">{activity.title}</h2>
+        <section aria-labelledby="activity-detail-title">
+          <h2 id="activity-detail-title" className="text-white mb-2">{activity.title}</h2>
           <div className="flex items-center gap-3">
             <Badge variant="outline" size="md">
-              <Clock size={14} />
-              {activity.duration}
+              <Clock aria-hidden="true" size={14} />
+              <span aria-label={`Durata ${activity.duration}`}>{activity.duration}</span>
             </Badge>
-            <span className="text-[#b8b2b3]">{activity.difficulty}</span>
+            <span className="text-[#b8b2b3]" aria-label={`Difficoltà ${activity.difficulty}`}>{activity.difficulty}</span>
           </div>
-        </div>
+        </section>
 
         <Card>
-          <p className="text-[#b8b2b3]">{activity.description}</p>
+          <p id="activity-detail-description" className="text-[#b8b2b3]">{activity.description}</p>
         </Card>
 
         <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20]">
-          <h4 className="text-[#f4bf4f] mb-4">Ricompense</h4>
-          <div className="grid grid-cols-2 gap-4">
-            <div className="text-center">
-              <div className="w-12 h-12 bg-gradient-to-br from-[#e6a23c] to-[#f4bf4f] rounded-lg flex items-center justify-center mx-auto mb-2">
-                <TrendingUp className="text-[#0f0d0e]" size={24} />
+          <section aria-labelledby="activity-rewards-heading">
+            <h4 id="activity-rewards-heading" className="text-[#f4bf4f] mb-4">Ricompense</h4>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="text-center" aria-label={`Ricompensa esperienza: ${rewards.xp} XP`}>
+                <div aria-hidden="true" className="w-12 h-12 bg-gradient-to-br from-[#e6a23c] to-[#f4bf4f] rounded-lg flex items-center justify-center mx-auto mb-2">
+                  <TrendingUp className="text-[#0f0d0e]" size={24} />
+                </div>
+                <p className="text-2xl text-white mb-1">+{rewards.xp}</p>
+                <p className="text-xs text-[#b8b2b3]">XP</p>
               </div>
-              <p className="text-2xl text-white mb-1">+{rewards.xp}</p>
-              <p className="text-xs text-[#b8b2b3]">XP</p>
-            </div>
 
-            <div className="text-center">
-              <div className="w-12 h-12 bg-[#241f20] rounded-lg flex items-center justify-center mx-auto mb-2">
-                <Coins className="text-[#f4bf4f]" size={24} />
+              <div className="text-center" aria-label={`Ricompensa cachet: ${rewards.cachet}`}>
+                <div aria-hidden="true" className="w-12 h-12 bg-[#241f20] rounded-lg flex items-center justify-center mx-auto mb-2">
+                  <Coins className="text-[#f4bf4f]" size={24} />
+                </div>
+                <p className="text-2xl text-white mb-1">+{rewards.cachet}</p>
+                <p className="text-xs text-[#b8b2b3]">Cachet</p>
               </div>
-              <p className="text-2xl text-white mb-1">+{rewards.cachet}</p>
-              <p className="text-xs text-[#b8b2b3]">Cachet</p>
             </div>
-          </div>
+          </section>
         </Card>
 
         <Card className="border border-[#f4bf4f]/30">
           <div className="flex gap-3">
-            <AlertCircle className="text-[#f4bf4f] flex-shrink-0" size={20} />
+            <AlertCircle aria-hidden="true" className="text-[#f4bf4f] flex-shrink-0" size={20} />
             <div className="space-y-1">
               <p className="text-sm text-white">{minigame.title}</p>
               <p className="text-xs text-[#b8b2b3]">{minigame.subtitle}</p>
@@ -81,12 +93,12 @@ export function ActivityDetail({ activity, role, onStart, onClose }: ActivityDet
         </Card>
 
         <div className="space-y-3">
-          <Button variant="primary" size="lg" fullWidth onClick={onStart}>
-            <Play size={20} />
+          <Button variant="primary" size="lg" fullWidth onClick={onStart} aria-label={`Avvia minigioco: ${minigame.title}`}>
+            <Play aria-hidden="true" size={20} />
             Avvia minigioco
           </Button>
 
-          <Button variant="ghost" size="lg" fullWidth onClick={onClose}>
+          <Button variant="ghost" size="lg" fullWidth onClick={onClose} aria-label="Torna alla lista attività">
             Torna indietro
           </Button>
         </div>

--- a/apps/mobile/src/components/screens/ActivityMinigame.tsx
+++ b/apps/mobile/src/components/screens/ActivityMinigame.tsx
@@ -59,10 +59,10 @@ function MinigameShell({
           <button
             type="button"
             onClick={onCancel}
-            className="flex items-center justify-center size-[44px] hover:bg-[#241f20] rounded-lg transition-colors"
+            className="flex items-center justify-center size-[44px] hover:bg-surface-elevated rounded-lg transition-colors"
             aria-label="Chiudi"
           >
-            <X className="text-[#f4bf4f]" size={22} />
+            <X className="text-accent" size={22} />
           </button>
           <Tag size="sm" variant="info">
             {roundLabel}
@@ -70,7 +70,7 @@ function MinigameShell({
         </header>
 
         <div className="flex items-center gap-3">
-          <div className="w-12 h-12 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-xl flex items-center justify-center">
+          <div className="w-12 h-12 bg-gradient-to-br from-burgundy-600 to-burgundy-800 rounded-xl flex items-center justify-center">
             {icon}
           </div>
           <div>
@@ -236,7 +236,7 @@ function TimingMinigame({ config, activityTitle, statBenefits, accessibleMode, o
       title={config.title}
       activityTitle={activityTitle}
       roundLabel={roundLabel}
-      icon={<Timer className="text-[#f4bf4f]" size={24} />}
+      icon={<Timer className="text-accent" size={24} />}
       statBenefits={statBenefits}
       onCancel={onCancel}
     >
@@ -249,7 +249,7 @@ function TimingMinigame({ config, activityTitle, statBenefits, accessibleMode, o
         </span>
       )}
       <Card
-        className={`bg-gradient-to-br from-[#1a1617] to-[#241f20] ${isPlaying ? 'touch-none select-none' : ''}`}
+        className={`bg-gradient-to-br from-surface to-surface-elevated ${isPlaying ? 'touch-none select-none' : ''}`}
         onPointerDown={isPlaying ? handleStop : undefined}
         role={isPlaying ? 'button' : undefined}
         aria-label={isPlaying ? 'Blocca il cue' : undefined}
@@ -264,24 +264,24 @@ function TimingMinigame({ config, activityTitle, statBenefits, accessibleMode, o
           </Tag>
         </div>
 
-        <div className="relative h-6 rounded-full bg-[#241f20] overflow-hidden">
+        <div className="relative h-6 rounded-full bg-surface-elevated overflow-hidden">
           <div
-            className="absolute top-0 bottom-0 w-2 bg-[#f4bf4f]/40"
+            className="absolute top-0 bottom-0 w-2 bg-accent/40"
             style={{ left: `${round.target}%`, transform: 'translateX(-50%)' }}
           />
           <div
-            className="absolute top-0 bottom-0 w-3 bg-[#f4bf4f] rounded-full shadow-[0_0_8px_rgba(244,191,79,0.6)]"
+            className="absolute top-0 bottom-0 w-3 bg-accent rounded-full shadow-[0_0_8px_rgba(244,191,79,0.6)]"
             style={{ left: `${progress}%`, transform: 'translateX(-50%)' }}
           />
         </div>
 
-        <div className="flex items-center justify-between mt-2 text-xs text-[#9a9697]">
+        <div className="flex items-center justify-between mt-2 text-xs text-subtle">
           <span>0</span>
           <span>100</span>
         </div>
 
         {isPlaying ? (
-          <p className="mt-3 text-xs text-center text-[#9a9697]">
+          <p className="mt-3 text-xs text-center text-subtle">
             Tocca ovunque sul pannello per bloccare subito
           </p>
         ) : null}
@@ -300,7 +300,7 @@ function TimingMinigame({ config, activityTitle, statBenefits, accessibleMode, o
             >
               {feedback.label}
             </Badge>
-            <span className="text-xs text-[#b8b2b3]">Scarto {Math.round(feedback.delta)}%</span>
+            <span className="text-xs text-muted">Scarto {Math.round(feedback.delta)}%</span>
           </div>
         ) : null}
       </Card>
@@ -417,11 +417,11 @@ function AudioMinigame({ config, activityTitle, statBenefits, onComplete, onCanc
       title={config.title}
       activityTitle={activityTitle}
       roundLabel={roundLabel}
-      icon={<SlidersHorizontal className="text-[#f4bf4f]" size={22} />}
+      icon={<SlidersHorizontal className="text-accent" size={22} />}
       statBenefits={statBenefits}
       onCancel={onCancel}
     >
-      <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20]">
+      <Card className="bg-gradient-to-br from-surface to-surface-elevated">
         <div className="flex items-center justify-between mb-4">
           <div>
             <p className="text-white font-semibold">{round.label}</p>
@@ -439,11 +439,11 @@ function AudioMinigame({ config, activityTitle, statBenefits, onComplete, onCanc
             step={1}
             onValueChange={setLevel}
             disabled={phase !== 'adjust'}
-            trackClassName="bg-[#241f20] data-[orientation=horizontal]:h-5"
-            rangeClassName="bg-[#f4bf4f]"
-            thumbClassName="size-6 border-[#f4bf4f] bg-[#f4bf4f] shadow-[0_0_10px_rgba(244,191,79,0.6)]"
+            trackClassName="bg-surface-elevated data-[orientation=horizontal]:h-5"
+            rangeClassName="bg-accent"
+            thumbClassName="size-6 border-accent bg-accent shadow-[0_0_10px_rgba(244,191,79,0.6)]"
           />
-          <div className="flex items-center justify-between text-xs text-[#9a9697]">
+          <div className="flex items-center justify-between text-xs text-subtle">
             <span>0</span>
             <span>100</span>
           </div>
@@ -452,13 +452,13 @@ function AudioMinigame({ config, activityTitle, statBenefits, onComplete, onCanc
               type="button"
               onClick={() => bumpLevel(-step)}
               disabled={phase !== 'adjust'}
-              className="min-w-[72px] h-[48px] rounded-xl border border-[#2d2728] text-[#f4bf4f] text-sm font-semibold disabled:opacity-50"
+              className="min-w-[72px] h-[48px] rounded-xl border border-surface-hover text-accent text-sm font-semibold disabled:opacity-50"
               aria-label={`Riduci di ${step}`}
             >
               -{step}
             </button>
             <div className="text-center">
-              <div className="inline-flex items-center gap-2 text-[#f4bf4f]">
+              <div className="inline-flex items-center gap-2 text-accent">
                 <Target size={16} />
                 <span className="text-xs">Livello attuale</span>
               </div>
@@ -468,7 +468,7 @@ function AudioMinigame({ config, activityTitle, statBenefits, onComplete, onCanc
               type="button"
               onClick={() => bumpLevel(step)}
               disabled={phase !== 'adjust'}
-              className="min-w-[72px] h-[48px] rounded-xl border border-[#2d2728] text-[#f4bf4f] text-sm font-semibold disabled:opacity-50"
+              className="min-w-[72px] h-[48px] rounded-xl border border-surface-hover text-accent text-sm font-semibold disabled:opacity-50"
               aria-label={`Aumenta di ${step}`}
             >
               +{step}
@@ -490,7 +490,7 @@ function AudioMinigame({ config, activityTitle, statBenefits, onComplete, onCanc
             >
               {feedback.label}
             </Badge>
-            <span className="text-xs text-[#b8b2b3]">Scarto {Math.round(feedback.delta)}%</span>
+            <span className="text-xs text-muted">Scarto {Math.round(feedback.delta)}%</span>
           </div>
         ) : null}
       </Card>

--- a/apps/mobile/src/components/screens/ActivityMinigame.tsx
+++ b/apps/mobile/src/components/screens/ActivityMinigame.tsx
@@ -1,12 +1,12 @@
 ﻿import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { X, Timer, SlidersHorizontal, Target, Sparkles } from 'lucide-react';
-import { Activity, RoleId } from '../../state/store';
+import { Activity, RoleId, useGameState } from '../../state/store';
 import {
   computeOutcome,
   computeRoundScore,
   getMinigameConfig,
-  MinigameConfig,
   MinigameOutcome,
+  ResolvedMinigameConfig,
   RoleStats,
 } from '../../gameplay/minigames';
 import { getActiveStatBenefitsForActivity } from '../../gameplay/role-effects';
@@ -106,21 +106,18 @@ function MinigameShell({
 }
 
 interface TimingMinigameProps {
-  config: MinigameConfig;
+  config: ResolvedMinigameConfig;
   activityTitle: string;
   statBenefits?: Array<{ stat: string; label: string }>;
+  accessibleMode: boolean;
   onComplete: (outcome: MinigameOutcome) => void;
   onCancel: () => void;
 }
 
-function TimingMinigame({ config, activityTitle, statBenefits, onComplete, onCancel }: TimingMinigameProps) {
-  const { accessibleMode } = useAccessibilityPreferences();
-  const rounds = useMemo(
-    () => (accessibleMode
-      ? config.rounds.map(r => ({ ...r, tolerance: Math.round(r.tolerance * 1.6) }))
-      : config.rounds),
-    [config.rounds, accessibleMode],
-  );
+function TimingMinigame({ config, activityTitle, statBenefits, accessibleMode, onComplete, onCancel }: TimingMinigameProps) {
+  const rounds = config.rounds;
+  const speed = config.speed;
+  const feedbackDelayMs = config.feedbackDelayMs;
   const [phase, setPhase] = useState<'intro' | 'playing' | 'feedback' | 'done'>('intro');
   const [roundIndex, setRoundIndex] = useState(0);
   const [progress, setProgress] = useState(0);
@@ -132,8 +129,6 @@ function TimingMinigame({ config, activityTitle, statBenefits, onComplete, onCan
   const hasStoppedRef = useRef(false);
   const attemptCountRef = useRef(0);
   const startedAtRef = useRef<number | null>(null);
-  const speed = accessibleMode ? 0.022 : 0.045;
-  const feedbackHoldMs = accessibleMode ? 1800 : 900;
 
   const round = rounds[roundIndex];
   const roundLabel = `Round ${roundIndex + 1}/${rounds.length}`;
@@ -233,7 +228,7 @@ function TimingMinigame({ config, activityTitle, statBenefits, onComplete, onCan
           })
         );
       }
-    }, feedbackHoldMs);
+    }, feedbackDelayMs);
   };
 
   return (
@@ -245,6 +240,14 @@ function TimingMinigame({ config, activityTitle, statBenefits, onComplete, onCan
       statBenefits={statBenefits}
       onCancel={onCancel}
     >
+      {accessibleMode && (
+        <span
+          className="inline-block text-xs bg-amber-900/50 text-amber-200 px-2 py-0.5 rounded-full"
+          aria-label="Modalità accessibile attiva: tempi più lunghi"
+        >
+          Modalità accessibile
+        </span>
+      )}
       <Card
         className={`bg-gradient-to-br from-[#1a1617] to-[#241f20] ${isPlaying ? 'touch-none select-none' : ''}`}
         onPointerDown={isPlaying ? handleStop : undefined}
@@ -329,7 +332,7 @@ function TimingMinigame({ config, activityTitle, statBenefits, onComplete, onCan
 }
 
 interface AudioMinigameProps {
-  config: MinigameConfig;
+  config: ResolvedMinigameConfig;
   activityTitle: string;
   statBenefits?: Array<{ stat: string; label: string }>;
   onComplete: (outcome: MinigameOutcome) => void;
@@ -512,7 +515,12 @@ function AudioMinigame({ config, activityTitle, statBenefits, onComplete, onCanc
 }
 
 export function ActivityMinigame({ activity, roleId, roleStats, onComplete, onCancel }: ActivityMinigameProps) {
-  const config = useMemo(() => getMinigameConfig(activity.id, roleId, roleStats), [activity.id, roleId, roleStats]);
+  const { state } = useGameState();
+  const accessibleMode = state.profile.accessibleMode ?? false;
+  const config = useMemo(
+    () => getMinigameConfig(activity.id, roleId, roleStats, { accessibleMode }),
+    [activity.id, roleId, roleStats, accessibleMode],
+  );
   const statBenefits = useMemo(
     () => getActiveStatBenefitsForActivity(activity.id, roleStats),
     [activity.id, roleStats],
@@ -522,5 +530,14 @@ export function ActivityMinigame({ activity, roleId, roleStats, onComplete, onCa
     return <AudioMinigame config={config} activityTitle={activity.title} statBenefits={statBenefits} onComplete={onComplete} onCancel={onCancel} />;
   }
 
-  return <TimingMinigame config={config} activityTitle={activity.title} statBenefits={statBenefits} onComplete={onComplete} onCancel={onCancel} />;
+  return (
+    <TimingMinigame
+      config={config}
+      activityTitle={activity.title}
+      statBenefits={statBenefits}
+      accessibleMode={accessibleMode}
+      onComplete={onComplete}
+      onCancel={onCancel}
+    />
+  );
 }

--- a/apps/mobile/src/components/screens/ActivityResult.tsx
+++ b/apps/mobile/src/components/screens/ActivityResult.tsx
@@ -71,19 +71,19 @@ export function ActivityResult({ activity, rewards, outcome, isDuplicate, roleSt
           aria-atomic="true"
           aria-label={resultSummary}
         >
-          <div aria-hidden="true" className={`w-20 h-20 rounded-full flex items-center justify-center mx-auto mb-4 ${isDuplicate ? 'bg-gradient-to-br from-[#b8b2b3] to-[#9a9697]' : 'bg-gradient-to-br from-[#52c41a] to-[#389e0d]'}`}>
+          <div aria-hidden="true" className={`w-20 h-20 rounded-full flex items-center justify-center mx-auto mb-4 ${isDuplicate ? 'bg-gradient-to-br from-[--color-text-secondary] to-[--color-text-tertiary]' : 'bg-gradient-to-br from-[--color-success] to-[--color-success]/80'}`}>
             <CheckCircle2 className="text-white" size={40} />
           </div>
           <h2 className="text-white mb-2">{isDuplicate ? 'Attivita gia completata' : 'Attivita completata'}</h2>
-          <p className="text-sm text-[#b8b2b3]">{activity.title}</p>
-          {isDuplicate && <p className="text-sm text-[#9a9697] mt-1">Hai gia completato questa attivita. Nessun premio aggiuntivo e stato assegnato.</p>}
+          <p className="text-sm text-muted">{activity.title}</p>
+          {isDuplicate && <p className="text-sm text-subtle mt-1">Hai gia completato questa attivita. Nessun premio aggiuntivo e stato assegnato.</p>}
         </div>
 
-        <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20]">
+        <Card className="bg-gradient-to-br from-surface to-surface-elevated">
           <div className="flex items-center justify-between mb-4">
             <div>
               <h4 className="text-white">Prestazione</h4>
-              <p className="text-sm text-[#b8b2b3]">Punteggio medio</p>
+              <p className="text-sm text-muted">Punteggio medio</p>
             </div>
             <Badge variant={ratingVariant} size="md">
               <Star size={14} />
@@ -92,7 +92,7 @@ export function ActivityResult({ activity, rewards, outcome, isDuplicate, roleSt
           </div>
           <div className="flex items-end justify-between">
             <p className="text-4xl text-white">{outcome.score}</p>
-            <p className="text-sm text-[#9a9697]">/100</p>
+            <p className="text-sm text-subtle">/100</p>
           </div>
           <div className="flex flex-wrap gap-2 mt-4">
             {outcome.roundScores.map((score, index) => (
@@ -111,42 +111,42 @@ export function ActivityResult({ activity, rewards, outcome, isDuplicate, roleSt
           </div>
         </Card>
 
-        <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20]">
-          <h4 className="text-[#f4bf4f] mb-4">Ricompense</h4>
+        <Card className="bg-gradient-to-br from-surface to-surface-elevated">
+          <h4 className="text-accent mb-4">Ricompense</h4>
           <div className="grid grid-cols-3 gap-4">
             <div className="text-center">
-              <div className="w-12 h-12 bg-gradient-to-br from-[#e6a23c] to-[#f4bf4f] rounded-lg flex items-center justify-center mx-auto mb-2">
-                <TrendingUp className="text-[#0f0d0e]" size={24} />
+              <div className="w-12 h-12 bg-gradient-to-br from-accent-hover to-accent rounded-lg flex items-center justify-center mx-auto mb-2">
+                <TrendingUp className="text-primary-bg" size={24} />
               </div>
               <p className="text-2xl text-white mb-1">+{rewards.xp}</p>
-              <p className="text-xs text-[#b8b2b3]">XP</p>
+              <p className="text-xs text-muted">XP</p>
             </div>
 
             <div className="text-center">
-              <div className="w-12 h-12 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-lg flex items-center justify-center mx-auto mb-2">
-                <Award className="text-[#f4bf4f]" size={24} />
+              <div className="w-12 h-12 bg-gradient-to-br from-burgundy-600 to-burgundy-800 rounded-lg flex items-center justify-center mx-auto mb-2">
+                <Award className="text-accent" size={24} />
               </div>
               <p className="text-2xl text-white mb-1">+{rewards.reputation}</p>
-              <p className="text-xs text-[#b8b2b3]">Reputazione</p>
+              <p className="text-xs text-muted">Reputazione</p>
             </div>
 
             <div className="text-center">
-              <div className="w-12 h-12 bg-[#241f20] rounded-lg flex items-center justify-center mx-auto mb-2">
-                <Coins className="text-[#f4bf4f]" size={24} />
+              <div className="w-12 h-12 bg-surface-elevated rounded-lg flex items-center justify-center mx-auto mb-2">
+                <Coins className="text-accent" size={24} />
               </div>
               <p className="text-2xl text-white mb-1">+{rewards.cachet}</p>
-              <p className="text-xs text-[#b8b2b3]">Cachet</p>
+              <p className="text-xs text-muted">Cachet</p>
             </div>
           </div>
         </Card>
 
         {statBreakdown ? (
-          <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20] border border-[#f4bf4f]/20">
+          <Card className="bg-gradient-to-br from-surface to-surface-elevated border border-accent/20">
             <div className="flex items-center gap-2 mb-2">
-              <Sparkles className="text-[#f4bf4f]" size={16} aria-hidden="true" />
-              <h4 className="text-[#f4bf4f]">Impatto teorico delle tue stat</h4>
+              <Sparkles className="text-accent" size={16} aria-hidden="true" />
+              <h4 className="text-accent">Impatto teorico delle tue stat</h4>
             </div>
-            <p className="text-xs text-[#b8b2b3] mb-3">
+            <p className="text-xs text-muted mb-3">
               Stima del contributo di ogni statistica rispetto alla base
               ({statBreakdown.baseXp} XP · {statBreakdown.baseCachet} Cachet).
               Il reward finale può differire per i moltiplicatori specifici di ruolo applicati alle attività.
@@ -160,7 +160,7 @@ export function ActivityResult({ activity, rewards, outcome, isDuplicate, roleSt
                   <span className="text-white">
                     {BONUS_SOURCE_LABEL[bonus.source] ?? bonus.source}
                   </span>
-                  <span className="text-[#f4bf4f] font-semibold">
+                  <span className="text-accent font-semibold">
                     +{bonus.delta} {bonus.kind === 'xp' ? 'XP' : 'Cachet'}
                   </span>
                 </div>

--- a/apps/mobile/src/components/screens/ActivityResult.tsx
+++ b/apps/mobile/src/components/screens/ActivityResult.tsx
@@ -59,11 +59,19 @@ export function ActivityResult({ activity, rewards, outcome, isDuplicate, roleSt
     }
   }, [outcome.rating]);
 
+  const resultSummary = `Attività ${activity.title} completata. Valutazione ${outcome.rating}, punteggio ${outcome.score} su 100. Ricompense: ${rewards.xp} XP, ${rewards.reputation} reputazione, ${rewards.cachet} cachet.`;
+
   return (
     <div className="min-h-screen pb-24">
       <div className="app-content px-6 pt-6 space-y-6">
-        <div className="text-center">
-          <div className={`w-20 h-20 rounded-full flex items-center justify-center mx-auto mb-4 ${isDuplicate ? 'bg-gradient-to-br from-[#b8b2b3] to-[#9a9697]' : 'bg-gradient-to-br from-[#52c41a] to-[#389e0d]'}`}>
+        <div
+          className="text-center"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          aria-label={resultSummary}
+        >
+          <div aria-hidden="true" className={`w-20 h-20 rounded-full flex items-center justify-center mx-auto mb-4 ${isDuplicate ? 'bg-gradient-to-br from-[#b8b2b3] to-[#9a9697]' : 'bg-gradient-to-br from-[#52c41a] to-[#389e0d]'}`}>
             <CheckCircle2 className="text-white" size={40} />
           </div>
           <h2 className="text-white mb-2">{isDuplicate ? 'Attivita gia completata' : 'Attivita completata'}</h2>
@@ -161,7 +169,7 @@ export function ActivityResult({ activity, rewards, outcome, isDuplicate, roleSt
           </Card>
         ) : null}
 
-        <Button variant="primary" size="lg" fullWidth onClick={onDone}>
+        <Button variant="primary" size="lg" fullWidth onClick={onDone} aria-label="Torna alla lista attività">
           Torna alle attivita
         </Button>
       </div>

--- a/apps/mobile/src/components/screens/Career.tsx
+++ b/apps/mobile/src/components/screens/Career.tsx
@@ -64,13 +64,13 @@ export function Career({
     >
       <div className="flex flex-col">
         <button type="button" onClick={onBack}
-          className="flex items-center justify-center size-[44px] text-[#f4bf4f]" aria-label="Indietro">
+          className="flex items-center justify-center size-[44px] text-[--color-gold-400]" aria-label="Indietro">
           <ArrowLeft size={24} />
         </button>
 
         <div className="mt-4">
           <h2 className="text-white mb-2">Carriera completa</h2>
-          <p className="text-[#b8b2b3]">Il tuo percorso professionale a teatro</p>
+          <p className="text-[--color-text-secondary]">Il tuo percorso professionale a teatro</p>
         </div>
 
         <div className="mt-6 space-y-5">
@@ -92,21 +92,21 @@ function RoleOverviewCard({ RoleIcon, userRole, level, xp, xpToNextLevel }: {
   RoleIcon: React.ElementType; userRole: string; level: number; xp: number; xpToNextLevel: number;
 }) {
   return (
-    <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20]">
+    <Card className="bg-gradient-to-br from-[--color-bg-surface] to-[--color-bg-surface-elevated]">
       <div className="flex items-center gap-4 mb-6">
-        <div className="flex-shrink-0 w-16 h-16 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-2xl flex items-center justify-center">
-          <RoleIcon className="text-[#f4bf4f]" size={32} />
+        <div className="flex-shrink-0 w-16 h-16 bg-gradient-to-br from-[--color-burgundy-600] to-[--color-burgundy-800] rounded-2xl flex items-center justify-center">
+          <RoleIcon className="text-[--color-gold-400]" size={32} />
         </div>
         <div className="flex-1">
           <h3 className="text-white mb-1">{userRole}</h3>
           <div className="flex items-center gap-2">
             <Badge variant="gold" size="md">Livello {level}</Badge>
-            <span className="text-[#b8b2b3]">{xp} XP</span>
+            <span className="text-[--color-text-secondary]">{xp} XP</span>
           </div>
         </div>
       </div>
       <div>
-        <div className="flex justify-between text-sm text-[#b8b2b3] mb-2">
+        <div className="flex justify-between text-sm text-[--color-text-secondary] mb-2">
           <span>Progressione livello</span>
           <span>{xpToNextLevel - xp} XP al prossimo</span>
         </div>
@@ -126,7 +126,7 @@ function RoleStatsCard({ roleStats }: { roleStats: Role['stats'] }) {
           return (
             <div key={key}>
               <div className="flex justify-between mb-2">
-                <span className="text-[#b8b2b3]">{ROLE_STAT_LABELS[key]}</span>
+                <span className="text-[--color-text-secondary]">{ROLE_STAT_LABELS[key]}</span>
                 <span className="text-white">{value}/100</span>
               </div>
               <ProgressBar value={value} max={100} color="burgundy" size="sm" />
@@ -145,31 +145,31 @@ function ExperienceCard({ xpTotal, xpSulCampo, tokenAtcl }: { xpTotal: number; x
       <h4 className="text-white mb-4">Esperienza accumulata</h4>
       <div className="space-y-4">
         <XpRow icon={TrendingUp} label="XP totale" sub="Tutte le fonti" value={xpTotal}
-          iconBg="bg-gradient-to-br from-[#e6a23c] to-[#f4bf4f]" valueColor="text-white" />
+          iconBg="bg-gradient-to-br from-[--color-gold-500] to-[--color-gold-400]" valueColor="text-white" />
         <XpRow icon={Theater} label="XP sul campo" sub="Eventi ATCL reali" value={xpSulCampo}
-          iconBg="bg-gradient-to-br from-[#a82847] to-[#6b1529]" valueColor="text-[#f4bf4f]" />
+          iconBg="bg-gradient-to-br from-[--color-burgundy-600] to-[--color-burgundy-800]" valueColor="text-[--color-gold-400]" />
         <XpRow icon={TrendingUp} label="XP da attività" sub="Simulazioni" value={xpTotal - xpSulCampo}
-          iconBg="bg-[#241f20] border-2 border-[#9a9697]" valueColor="text-white" iconColor="text-[#9a9697]" />
+          iconBg="bg-[--color-bg-surface-elevated] border-2 border-[--color-text-tertiary]" valueColor="text-white" iconColor="text-[--color-text-tertiary]" />
         <XpRow icon={Zap} label="Token ATCL" sub="Da turni certificati" value={tokenAtcl}
-          iconBg="bg-gradient-to-br from-[#a82847] to-[#6b1529]" valueColor={tokenAtcl === 0 ? 'text-[#9a9697]' : 'text-[#f4bf4f]'} iconColor="text-[#f4bf4f]" />
+          iconBg="bg-gradient-to-br from-[--color-burgundy-600] to-[--color-burgundy-800]" valueColor={tokenAtcl === 0 ? 'text-[--color-text-tertiary]' : 'text-[--color-gold-400]'} iconColor="text-[--color-gold-400]" />
       </div>
     </Card>
   );
 }
 
-function XpRow({ icon: Icon, label, sub, value, iconBg, valueColor, iconColor = 'text-[#0f0d0e]' }: {
+function XpRow({ icon: Icon, label, sub, value, iconBg, valueColor, iconColor = 'text-[--color-bg-primary]' }: {
   icon: LucideIcon; label: string; sub: string; value: number;
   iconBg: string; valueColor: string; iconColor?: string;
 }) {
   return (
-    <div className="flex items-center justify-between p-4 bg-[#241f20] rounded-lg">
+    <div className="flex items-center justify-between p-4 bg-[--color-bg-surface-elevated] rounded-lg">
       <div className="flex items-center gap-3">
         <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${iconBg}`}>
           <Icon className={iconColor} size={20} />
         </div>
         <div>
           <p className="text-white">{label}</p>
-          <p className="text-xs text-[#b8b2b3]">{sub}</p>
+          <p className="text-xs text-[--color-text-secondary]">{sub}</p>
         </div>
       </div>
       <p className={`text-2xl ${valueColor}`}>{value}</p>
@@ -181,19 +181,19 @@ function ReputationCard({ reputationGlobal }: { reputationGlobal: number }) {
   return (
     <Card>
       <h4 className="text-white mb-4">Reputazione</h4>
-      <div className="flex items-center justify-between p-4 bg-gradient-to-br from-[#241f20] to-[#1a1617] rounded-lg mb-4">
+      <div className="flex items-center justify-between p-4 bg-gradient-to-br from-[--color-bg-surface-elevated] to-[--color-bg-surface] rounded-lg mb-4">
         <div className="flex items-center gap-3">
-          <div className="w-12 h-12 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-xl flex items-center justify-center">
-            <Award className="text-[#f4bf4f]" size={24} />
+          <div className="w-12 h-12 bg-gradient-to-br from-[--color-burgundy-600] to-[--color-burgundy-800] rounded-xl flex items-center justify-center">
+            <Award className="text-[--color-gold-400]" size={24} />
           </div>
           <div>
             <p className="text-white">Reputazione ATCL</p>
-            <p className="text-xs text-[#b8b2b3]">Globale</p>
+            <p className="text-xs text-[--color-text-secondary]">Globale</p>
           </div>
         </div>
         <div className="text-right">
           <p className="text-3xl text-white">{reputationGlobal}</p>
-          <p className="text-xs text-[#b8b2b3]">/ 100</p>
+          <p className="text-xs text-[--color-text-secondary]">/ 100</p>
         </div>
       </div>
       <ProgressBar value={reputationGlobal} max={100} color="burgundy" />
@@ -209,7 +209,7 @@ function MilestonesCard({ milestones, turnStats }: { milestones: GameBadge[]; tu
         {milestones.length ? milestones.map(m => (
           <MilestoneRow key={m.id} milestone={m} turnStats={turnStats} />
         )) : (
-          <p className="text-sm text-[#b8b2b3]">Nessun traguardo disponibile</p>
+          <p className="text-sm text-[--color-text-secondary]">Nessun traguardo disponibile</p>
         )}
       </div>
     </Card>
@@ -223,10 +223,10 @@ function MilestoneRow({ milestone, turnStats }: { milestone: GameBadge; turnStat
 
   return (
     <div className={`flex items-center gap-3 p-3 rounded-lg ${
-      unlocked ? 'bg-[#52c41a]/10 border border-[#52c41a]/30' : 'bg-[#241f20] border border-[#2d2728] opacity-60'
+      unlocked ? 'bg-[--color-success]/10 border border-[--color-success]/30' : 'bg-[--color-bg-surface-elevated] border border-[--color-bg-surface-hover] opacity-60'
     } ${milestone.isHidden ? 'secret-badge-frame' : ''}`}>
       <div className={`w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 ${
-        unlocked ? 'bg-[#52c41a]' : 'bg-[#9a9697]'
+        unlocked ? 'bg-[--color-success]' : 'bg-[--color-text-tertiary]'
       } ${milestone.isHidden ? 'secret-badge-shimmer' : ''}`}>
         {glyph ? (
           <span className="font-mono text-[10px] leading-none font-bold tracking-[-0.08em] text-white relative z-[1]">{glyph}</span>
@@ -237,10 +237,10 @@ function MilestoneRow({ milestone, turnStats }: { milestone: GameBadge; turnStat
       <div className="flex-1">
         <p className="text-white text-sm">{milestone.title}</p>
         {milestone.isHidden && (
-          <p className="secret-badge-label text-[10px] font-medium uppercase tracking-[0.14em] text-[#f4bf4f]">Traguardo segreto</p>
+          <p className="secret-badge-label text-[10px] font-medium uppercase tracking-[0.14em] text-[--color-gold-400]">Traguardo segreto</p>
         )}
-        {milestone.description && <p className="text-xs text-[#9b9496]">{milestone.description}</p>}
-        <p className="text-xs text-[#b8b2b3]">{getBadgeProgressText(milestone, turnStats)}</p>
+        {milestone.description && <p className="text-xs text-[--color-text-tertiary]">{milestone.description}</p>}
+        <p className="text-xs text-[--color-text-secondary]">{getBadgeProgressText(milestone, turnStats)}</p>
       </div>
     </div>
   );
@@ -256,15 +256,15 @@ function TurnHistoryCard({ sortedTurns, resolveRoleName }: {
         <div className="space-y-3">
           {sortedTurns.map(turno => (
             <div key={turno.id} className="flex items-start gap-4">
-              <div className="flex-shrink-0 w-12 h-12 bg-[#241f20] rounded-lg flex items-center justify-center">
-                <Theater className="text-[#f4bf4f]" size={24} />
+              <div className="flex-shrink-0 w-12 h-12 bg-[--color-bg-surface-elevated] rounded-lg flex items-center justify-center">
+                <Theater className="text-[--color-gold-400]" size={24} />
               </div>
               <div className="flex-1 min-w-0">
                 <h4 className="text-white mb-1">{turno.eventName}</h4>
-                <div className="flex items-center gap-2 text-sm text-[#b8b2b3] mb-2">
+                <div className="flex items-center gap-2 text-sm text-[--color-text-secondary] mb-2">
                   <MapPin size={14} /><span>{turno.theatre}</span>
                 </div>
-                <div className="flex items-center gap-2 text-sm text-[#b8b2b3] mb-3">
+                <div className="flex items-center gap-2 text-sm text-[--color-text-secondary] mb-3">
                   <Calendar size={14} /><span>{turno.date} · {turno.time}</span>
                 </div>
                 <div className="flex flex-wrap gap-2">
@@ -277,7 +277,7 @@ function TurnHistoryCard({ sortedTurns, resolveRoleName }: {
           ))}
         </div>
       ) : (
-        <p className="text-sm text-[#b8b2b3]">Nessun turno registrato</p>
+        <p className="text-sm text-[--color-text-secondary]">Nessun turno registrato</p>
       )}
     </Card>
   );

--- a/apps/mobile/src/components/screens/ChangePassword.tsx
+++ b/apps/mobile/src/components/screens/ChangePassword.tsx
@@ -100,21 +100,21 @@ export function ChangePassword({
         <button
           type="button"
           onClick={onBack}
-          className="flex items-center justify-center size-[44px] text-[#f4bf4f]"
+          className="flex items-center justify-center size-[44px] text-[--color-gold-400]"
           aria-label="Indietro"
         >
           <ArrowLeft size={24} />
         </button>
 
         <div className="mt-4 flex flex-col items-start gap-1">
-          <p className="text-[24px] leading-[31.2px] font-bold tracking-[-0.24px] text-[#f5f5f5]">
+          <p className="text-[24px] leading-[31.2px] font-bold tracking-[-0.24px] text-[--color-text-primary]">
             Cambia password
           </p>
-          <p className="text-[16px] leading-[25.6px] text-[#b8b2b3]">
+          <p className="text-[16px] leading-[25.6px] text-[--color-text-secondary]">
             Account: <span className="text-white">{email || '—'}</span>
           </p>
           {isRecovery ? (
-            <p className="text-[14px] leading-[20px] text-[#9a9697] !m-0 mt-2">
+            <p className="text-[14px] leading-[20px] text-[--color-text-tertiary] !m-0 mt-2">
               Hai richiesto una reimpostazione: imposta una nuova password per completare.
             </p>
           ) : null}
@@ -124,13 +124,13 @@ export function ChangePassword({
           <div className="flex flex-col gap-4 w-full">
             {!isRecovery ? (
               <div className="flex flex-col gap-2 w-full">
-                <label htmlFor="current-password" className="text-[16px] leading-[24px] text-[#b8b2b3]">
+                <label htmlFor="current-password" className="text-[16px] leading-[24px] text-[--color-text-secondary]">
                   Password attuale
                 </label>
                 <div
-                  className={`bg-[#241f20] border-2 ${
-                    errors.currentPassword ? 'border-[#ff4d4f]' : 'border-[#2d2728]'
-                  } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
+                  className={`bg-[--color-bg-surface-elevated] border-2 ${
+                    errors.currentPassword ? 'border-[--color-error]' : 'border-[--color-bg-surface-hover]'
+                  } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[--color-gold-400]`}
                 >
                   <input
                     id="current-password"
@@ -140,12 +140,12 @@ export function ChangePassword({
                     autoComplete="current-password"
                     aria-invalid={Boolean(errors.currentPassword)}
                     placeholder="••••••••"
-                    className="w-full h-full bg-transparent px-[10px] py-0 text-[16px] leading-[28px] text-[#f5f5f5] placeholder:text-[#9a9697] focus:outline-none"
+                    className="w-full h-full bg-transparent px-[10px] py-0 text-[16px] leading-[28px] text-[--color-text-primary] placeholder:text-[--color-text-tertiary] focus:outline-none"
                     disabled={isSubmitting}
                   />
                 </div>
                 {errors.currentPassword ? (
-                  <p className="text-[14px] leading-[20px] text-[#ff4d4f] !m-0">
+                  <p className="text-[14px] leading-[20px] text-[--color-error] !m-0">
                     {errors.currentPassword}
                   </p>
                 ) : null}
@@ -154,7 +154,7 @@ export function ChangePassword({
                   type="button"
                   onClick={handleSendResetEmail}
                   disabled={isSubmitting || resetEmailStatus === 'sending'}
-                  className="self-end text-[14px] leading-[20px] text-[#f4bf4f] underline underline-offset-2 disabled:opacity-60 disabled:cursor-not-allowed"
+                  className="self-end text-[14px] leading-[20px] text-[--color-gold-400] underline underline-offset-2 disabled:opacity-60 disabled:cursor-not-allowed"
                 >
                   {resetEmailStatus === 'sending'
                     ? 'Invio email...'
@@ -164,9 +164,9 @@ export function ChangePassword({
                 </button>
 
                 {resetEmailError ? (
-                  <p className="text-[14px] leading-[20px] text-[#ff4d4f] !m-0">{resetEmailError}</p>
+                  <p className="text-[14px] leading-[20px] text-[--color-error] !m-0">{resetEmailError}</p>
                 ) : resetEmailStatus === 'sent' ? (
-                  <p className="text-[14px] leading-[20px] text-[#9a9697] !m-0">
+                  <p className="text-[14px] leading-[20px] text-[--color-text-tertiary] !m-0">
                     Controlla la posta e segui il link per reimpostare la password.
                   </p>
                 ) : null}
@@ -174,13 +174,13 @@ export function ChangePassword({
             ) : null}
 
             <div className="flex flex-col gap-2 w-full">
-              <label htmlFor="new-password" className="text-[16px] leading-[24px] text-[#b8b2b3]">
+              <label htmlFor="new-password" className="text-[16px] leading-[24px] text-[--color-text-secondary]">
                 Nuova password
               </label>
               <div
-                className={`bg-[#241f20] border-2 ${
-                  errors.password ? 'border-[#ff4d4f]' : 'border-[#2d2728]'
-                } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
+                className={`bg-[--color-bg-surface-elevated] border-2 ${
+                  errors.password ? 'border-[--color-error]' : 'border-[--color-bg-surface-hover]'
+                } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[--color-gold-400]`}
               >
                 <input
                   id="new-password"
@@ -190,27 +190,27 @@ export function ChangePassword({
                   autoComplete="new-password"
                   aria-invalid={Boolean(errors.password)}
                   placeholder="••••••••"
-                  className="w-full h-full bg-transparent px-[10px] py-0 text-[16px] leading-[28px] text-[#f5f5f5] placeholder:text-[#9a9697] focus:outline-none"
+                  className="w-full h-full bg-transparent px-[10px] py-0 text-[16px] leading-[28px] text-[--color-text-primary] placeholder:text-[--color-text-tertiary] focus:outline-none"
                   disabled={isSubmitting}
                 />
               </div>
               {errors.password ? (
-                <p className="text-[14px] leading-[20px] text-[#ff4d4f] !m-0">
+                <p className="text-[14px] leading-[20px] text-[--color-error] !m-0">
                   {errors.password}
                 </p>
               ) : (
-                <p className="text-[14px] leading-[20px] text-[#9a9697] !m-0">Almeno 8 caratteri</p>
+                <p className="text-[14px] leading-[20px] text-[--color-text-tertiary] !m-0">Almeno 8 caratteri</p>
               )}
             </div>
 
             <div className="flex flex-col gap-2 w-full">
-              <label htmlFor="confirm-password" className="text-[16px] leading-[24px] text-[#b8b2b3]">
+              <label htmlFor="confirm-password" className="text-[16px] leading-[24px] text-[--color-text-secondary]">
                 Conferma password
               </label>
               <div
-                className={`bg-[#241f20] border-2 ${
-                  errors.confirmPassword ? 'border-[#ff4d4f]' : 'border-[#2d2728]'
-                } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]`}
+                className={`bg-[--color-bg-surface-elevated] border-2 ${
+                  errors.confirmPassword ? 'border-[--color-error]' : 'border-[--color-bg-surface-hover]'
+                } rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[--color-gold-400]`}
               >
                 <input
                   id="confirm-password"
@@ -220,12 +220,12 @@ export function ChangePassword({
                   autoComplete="new-password"
                   aria-invalid={Boolean(errors.confirmPassword)}
                   placeholder="••••••••"
-                  className="w-full h-full bg-transparent px-[10px] py-0 text-[16px] leading-[28px] text-[#f5f5f5] placeholder:text-[#9a9697] focus:outline-none"
+                  className="w-full h-full bg-transparent px-[10px] py-0 text-[16px] leading-[28px] text-[--color-text-primary] placeholder:text-[--color-text-tertiary] focus:outline-none"
                   disabled={isSubmitting}
                 />
               </div>
               {errors.confirmPassword ? (
-                <p className="text-[14px] leading-[20px] text-[#ff4d4f] !m-0">
+                <p className="text-[14px] leading-[20px] text-[--color-error] !m-0">
                   {errors.confirmPassword}
                 </p>
               ) : null}
@@ -233,7 +233,7 @@ export function ChangePassword({
           </div>
 
           {errorMessage ? (
-            <p className="text-[14px] leading-[20px] text-[#ff4d4f] text-center">
+            <p className="text-[14px] leading-[20px] text-[--color-error] text-center">
               {errorMessage}
             </p>
           ) : null}
@@ -247,7 +247,7 @@ export function ChangePassword({
           <button
             type="submit"
             disabled={isSubmitting}
-            className="bg-gradient-to-b from-[#8c1c38] to-[#a82847] h-[44px] w-full rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] disabled:opacity-60 disabled:cursor-not-allowed"
+            className="bg-gradient-to-b from-[--color-burgundy-700] to-[--color-burgundy-600] h-[44px] w-full rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] disabled:opacity-60 disabled:cursor-not-allowed"
           >
             <span className="block text-[18px] leading-[28px] text-center text-white">
               {isSubmitting ? 'Aggiornamento...' : 'Aggiorna password'}

--- a/apps/mobile/src/components/screens/CookieConsent.tsx
+++ b/apps/mobile/src/components/screens/CookieConsent.tsx
@@ -62,7 +62,7 @@ export function CookieConsent({ onAccept, onViewPrivacy }: CookieConsentProps) {
       >
         {/* Logo e titolo */}
         <div className="flex flex-col items-center gap-5 pt-3">
-          <div className="bg-gradient-to-b from-[#a82847] to-[#6b1529] rounded-[28px] size-[96px] flex items-center justify-center ring-1 ring-[#a82847]/30">
+          <div className="bg-gradient-to-b from-[--color-burgundy-600] to-[--color-burgundy-800] rounded-[28px] size-[96px] flex items-center justify-center ring-1 ring-[--color-burgundy-600]/30">
             <img alt="" className="size-[48px]" src={welcomeLogo} />
           </div>
           <div className="flex flex-col items-center gap-1">
@@ -76,7 +76,7 @@ export function CookieConsent({ onAccept, onViewPrivacy }: CookieConsentProps) {
             >
               Cookie e Privacy
             </p>
-            <p className="text-[12px] leading-none text-[#9a9697] tracking-[0.10em] uppercase font-semibold">
+            <p className="text-[12px] leading-none text-[--color-text-tertiary] tracking-[0.10em] uppercase font-semibold">
               Prima di iniziare
             </p>
           </div>
@@ -85,24 +85,24 @@ export function CookieConsent({ onAccept, onViewPrivacy }: CookieConsentProps) {
         {/* Card informativa */}
         <div
           id="cookie-dialog-description"
-          className="mt-6 w-full bg-[#1a1617] border border-[#2d2728] rounded-2xl p-4"
+          className="mt-6 w-full bg-[--color-bg-surface] border border-[--color-bg-surface-hover] rounded-2xl p-4"
         >
           <div className="grid grid-cols-2 gap-2" role="list">
             {bullets.map(({ icon: Icon, title, desc }) => (
               <div
                 key={title}
                 role="listitem"
-                className="flex flex-col gap-2 rounded-[14px] bg-[#0f0d0e] p-3"
+                className="flex flex-col gap-2 rounded-[14px] bg-[--color-bg-primary] p-3"
               >
                 <div
                   aria-hidden="true"
-                  className="flex items-center justify-center size-[32px] rounded-[9px] bg-[#f4bf4f]/10 self-start"
+                  className="flex items-center justify-center size-[32px] rounded-[9px] bg-[--color-gold-400]/10 self-start"
                 >
-                  <Icon size={15} className="text-[#f4bf4f]" />
+                  <Icon size={15} className="text-[--color-gold-400]" />
                 </div>
                 <div className="text-left">
-                  <p className="text-[12px] font-semibold text-[#f5f5f5] leading-[17px]">{title}</p>
-                  <p className="text-[11px] leading-[16px] text-[#9a9697] mt-0.5">{desc}</p>
+                  <p className="text-[12px] font-semibold text-[--color-text-primary] leading-[17px]">{title}</p>
+                  <p className="text-[11px] leading-[16px] text-[--color-text-tertiary] mt-0.5">{desc}</p>
                 </div>
               </div>
             ))}
@@ -115,7 +115,7 @@ export function CookieConsent({ onAccept, onViewPrivacy }: CookieConsentProps) {
             type="button"
             onClick={handleAccept}
             aria-label="Accetta i cookie tecnici e continua"
-            className="h-[50px] w-full max-w-[300px] rounded-2xl bg-gradient-to-b from-[#f4bf4f] to-[#e6a23c] shadow-[0_4px_20px_rgba(244,191,79,0.25)] active:shadow-none active:scale-[0.98] transition-all duration-150 text-[#0f0d0e]"
+            className="h-[50px] w-full max-w-[300px] rounded-2xl bg-gradient-to-b from-[--color-gold-400] to-[--color-gold-500] shadow-[0_4px_20px_rgba(244,191,79,0.25)] active:shadow-none active:scale-[0.98] transition-all duration-150 text-[--color-bg-primary]"
           >
             <span className="block text-[17px] font-semibold leading-none">Accetta e continua</span>
           </button>
@@ -124,7 +124,7 @@ export function CookieConsent({ onAccept, onViewPrivacy }: CookieConsentProps) {
             type="button"
             onClick={() => setRejected(true)}
             aria-label="Rifiuta i cookie"
-            className="text-[#8a7a7b] text-sm underline"
+            className="text-[--color-text-tertiary] text-sm underline"
           >
             Rifiuta
           </button>
@@ -133,7 +133,7 @@ export function CookieConsent({ onAccept, onViewPrivacy }: CookieConsentProps) {
             <p
               role="alert"
               aria-live="assertive"
-              className="text-[12px] leading-[16px] text-[#a82847] max-w-[280px]"
+              className="text-[12px] leading-[16px] text-[--color-burgundy-600] max-w-[280px]"
             >
               Per utilizzare l'app è necessario accettare i cookie tecnici.
             </p>
@@ -145,12 +145,12 @@ export function CookieConsent({ onAccept, onViewPrivacy }: CookieConsentProps) {
             aria-label="Leggi la Privacy Policy"
             className="h-[44px] w-full max-w-[300px] flex items-center justify-center"
           >
-            <span className="text-[14px] text-[#b8b2b3] underline underline-offset-2">
+            <span className="text-[14px] text-[--color-text-secondary] underline underline-offset-2">
               Leggi la Privacy Policy
             </span>
           </button>
 
-          <p className="text-[11px] leading-[16px] text-[#9a9697] max-w-[280px]">
+          <p className="text-[11px] leading-[16px] text-[--color-text-tertiary] max-w-[280px]">
             Cliccando "Accetta e continua" acconsenti all'uso dei cookie tecnici necessari al funzionamento dell'app.
           </p>
 

--- a/apps/mobile/src/components/screens/CookieConsent.tsx
+++ b/apps/mobile/src/components/screens/CookieConsent.tsx
@@ -53,7 +53,13 @@ export function CookieConsent({ onAccept, onViewPrivacy }: CookieConsentProps) {
       className="relative items-start justify-start h-[100dvh] overflow-hidden"
       contentClassName="relative w-full flex-1 px-6 pt-8 pb-[calc(env(safe-area-inset-bottom,_0px)+32px)] space-y-0 box-border"
     >
-      <div className="relative flex h-full flex-col items-center text-center">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cookie-dialog-title"
+        aria-describedby="cookie-dialog-description"
+        className="relative flex h-full flex-col items-center text-center"
+      >
         {/* Logo e titolo */}
         <div className="flex flex-col items-center gap-5 pt-3">
           <div className="bg-gradient-to-b from-[#a82847] to-[#6b1529] rounded-[28px] size-[96px] flex items-center justify-center ring-1 ring-[#a82847]/30">
@@ -61,6 +67,7 @@ export function CookieConsent({ onAccept, onViewPrivacy }: CookieConsentProps) {
           </div>
           <div className="flex flex-col items-center gap-1">
             <p
+              id="cookie-dialog-title"
               className="text-[22px] leading-[1.2] font-bold tracking-[-0.02em] text-transparent bg-clip-text"
               style={{
                 WebkitTextFillColor: 'transparent',
@@ -76,14 +83,21 @@ export function CookieConsent({ onAccept, onViewPrivacy }: CookieConsentProps) {
         </div>
 
         {/* Card informativa */}
-        <div className="mt-6 w-full bg-[#1a1617] border border-[#2d2728] rounded-2xl p-4">
-          <div className="grid grid-cols-2 gap-2">
+        <div
+          id="cookie-dialog-description"
+          className="mt-6 w-full bg-[#1a1617] border border-[#2d2728] rounded-2xl p-4"
+        >
+          <div className="grid grid-cols-2 gap-2" role="list">
             {bullets.map(({ icon: Icon, title, desc }) => (
               <div
                 key={title}
+                role="listitem"
                 className="flex flex-col gap-2 rounded-[14px] bg-[#0f0d0e] p-3"
               >
-                <div className="flex items-center justify-center size-[32px] rounded-[9px] bg-[#f4bf4f]/10 self-start">
+                <div
+                  aria-hidden="true"
+                  className="flex items-center justify-center size-[32px] rounded-[9px] bg-[#f4bf4f]/10 self-start"
+                >
                   <Icon size={15} className="text-[#f4bf4f]" />
                 </div>
                 <div className="text-left">
@@ -100,6 +114,7 @@ export function CookieConsent({ onAccept, onViewPrivacy }: CookieConsentProps) {
           <button
             type="button"
             onClick={handleAccept}
+            aria-label="Accetta i cookie tecnici e continua"
             className="h-[50px] w-full max-w-[300px] rounded-2xl bg-gradient-to-b from-[#f4bf4f] to-[#e6a23c] shadow-[0_4px_20px_rgba(244,191,79,0.25)] active:shadow-none active:scale-[0.98] transition-all duration-150 text-[#0f0d0e]"
           >
             <span className="block text-[17px] font-semibold leading-none">Accetta e continua</span>
@@ -108,13 +123,18 @@ export function CookieConsent({ onAccept, onViewPrivacy }: CookieConsentProps) {
           <button
             type="button"
             onClick={() => setRejected(true)}
+            aria-label="Rifiuta i cookie"
             className="text-[#8a7a7b] text-sm underline"
           >
             Rifiuta
           </button>
 
           {rejected && (
-            <p className="text-[12px] leading-[16px] text-[#a82847] max-w-[280px]">
+            <p
+              role="alert"
+              aria-live="assertive"
+              className="text-[12px] leading-[16px] text-[#a82847] max-w-[280px]"
+            >
               Per utilizzare l'app è necessario accettare i cookie tecnici.
             </p>
           )}
@@ -122,6 +142,7 @@ export function CookieConsent({ onAccept, onViewPrivacy }: CookieConsentProps) {
           <button
             type="button"
             onClick={onViewPrivacy}
+            aria-label="Leggi la Privacy Policy"
             className="h-[44px] w-full max-w-[300px] flex items-center justify-center"
           >
             <span className="text-[14px] text-[#b8b2b3] underline underline-offset-2">

--- a/apps/mobile/src/components/screens/CookieConsent.tsx
+++ b/apps/mobile/src/components/screens/CookieConsent.tsx
@@ -124,7 +124,7 @@ export function CookieConsent({ onAccept, onViewPrivacy }: CookieConsentProps) {
             type="button"
             onClick={() => setRejected(true)}
             aria-label="Rifiuta i cookie"
-            className="text-[--color-text-tertiary] text-sm underline"
+            className="h-[44px] w-full max-w-[300px] rounded-2xl border border-[--color-bg-surface-hover] bg-transparent text-[--color-text-secondary] text-[15px] font-medium active:scale-[0.98] active:bg-[--color-bg-surface-elevated] transition-all duration-150"
           >
             Rifiuta
           </button>

--- a/apps/mobile/src/components/screens/EarnedTitles.tsx
+++ b/apps/mobile/src/components/screens/EarnedTitles.tsx
@@ -76,7 +76,7 @@ export function EarnedTitles({ badges, turnStats, onBack, onViewed }: EarnedTitl
         <button
           type="button"
           onClick={onBack}
-          className="flex items-center justify-center size-[44px] text-[#f4bf4f]"
+          className="flex items-center justify-center size-[44px] text-[--color-gold-400]"
           aria-label="Indietro"
         >
           <ArrowLeft size={24} />
@@ -95,37 +95,37 @@ export function EarnedTitles({ badges, turnStats, onBack, onViewed }: EarnedTitl
               <Card
                 key={badge.id}
                 className={`flex items-start gap-4 border ${
-                  badge.unlocked ? 'border-[#f4bf4f]/20' : 'border-[#3d3a3b] opacity-80'
+                  badge.unlocked ? 'border-[--color-gold-400]/20' : 'border-[--color-border-subtle] opacity-80'
                 } ${badge.isHidden ? 'secret-badge-frame' : ''}`}
-                style={badge.unlocked ? undefined : { backgroundColor: '#161314' }}
+                style={badge.unlocked ? undefined : { backgroundColor: 'var(--color-bg-primary)' }}
               >
                 <div
                   className={`w-14 h-14 rounded-2xl flex items-center justify-center ${
                     badge.unlocked
-                      ? 'bg-[#f4bf4f]'
-                      : 'bg-[#2a2526]'
+                      ? 'bg-[--color-gold-400]'
+                      : 'bg-[--color-bg-surface-elevated]'
                   } ${badge.isHidden ? 'secret-badge-shimmer' : ''}`}
                 >
                   {glyph ? (
                     <span
                       className={`font-mono text-[16px] leading-none font-bold tracking-[-0.08em] ${
-                        badge.unlocked ? 'text-[#0f0d0e]' : 'text-[#9a9697]'
+                        badge.unlocked ? 'text-[--color-bg-primary]' : 'text-[--color-text-tertiary]'
                       } relative z-[1]`}
                     >
                       {glyph}
                     </span>
                   ) : Icon ? (
-                    <Icon className={`${badge.unlocked ? 'text-[#0f0d0e]' : 'text-[#9a9697]'} relative z-[1]`} size={24} />
+                    <Icon className={`${badge.unlocked ? 'text-[--color-bg-primary]' : 'text-[--color-text-tertiary]'} relative z-[1]`} size={24} />
                   ) : null}
                 </div>
                 <div className="min-w-0 flex-1 space-y-1">
-                  <p className={`text-sm leading-snug ${badge.unlocked ? 'text-[#f7f3f4]' : 'text-[#b8b2b3]'}`}>
+                  <p className={`text-sm leading-snug ${badge.unlocked ? 'text-[--color-text-primary]' : 'text-[--color-text-secondary]'}`}>
                     {badge.title}
                   </p>
                   {badge.description ? (
-                    <p className="text-xs leading-snug text-[#9b9496]">{badge.description}</p>
+                    <p className="text-xs leading-snug text-[--color-text-tertiary]">{badge.description}</p>
                   ) : null}
-                  <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-[#9a9697]">
+                  <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-[--color-text-tertiary]">
                     {badge.unlocked ? 'Sbloccato' : (
                       <span className="inline-flex items-center gap-1">
                         <Lock size={10} />
@@ -134,15 +134,15 @@ export function EarnedTitles({ badges, turnStats, onBack, onViewed }: EarnedTitl
                     )}
                   </p>
                   {badge.isHidden ? (
-                    <p className="secret-badge-label text-[10px] font-medium uppercase tracking-[0.14em] text-[#f4bf4f]">
+                    <p className="secret-badge-label text-[10px] font-medium uppercase tracking-[0.14em] text-[--color-gold-400]">
                       Badge segreto
                     </p>
                   ) : null}
                   {progress && !badge.unlocked ? (
                     <div className="pt-1 space-y-2">
-                      <div className="flex items-center justify-between gap-3 text-[11px] text-[#b8b2b3]">
+                      <div className="flex items-center justify-between gap-3 text-[11px] text-[--color-text-secondary]">
                         <span>In corso</span>
-                        <span className="text-[#9b9496]">
+                        <span className="text-[--color-text-tertiary]">
                           {progress.label}
                         </span>
                       </div>
@@ -154,7 +154,7 @@ export function EarnedTitles({ badges, turnStats, onBack, onViewed }: EarnedTitl
                       />
                     </div>
                   ) : (
-                    <p className="text-[11px] text-[#b8b2b3]">
+                    <p className="text-[11px] text-[--color-text-secondary]">
                       {badge.unlocked ? 'Obiettivo completato' : 'Obiettivo in arrivo'}
                     </p>
                   )}
@@ -165,7 +165,7 @@ export function EarnedTitles({ badges, turnStats, onBack, onViewed }: EarnedTitl
         </div>
 
         {!visibleBadges.length ? (
-          <p className="mt-6 text-sm text-[#9a9697]">Nessun badge disponibile in questo momento.</p>
+          <p className="mt-6 text-sm text-[--color-text-tertiary]">Nessun badge disponibile in questo momento.</p>
         ) : null}
       </div>
     </Screen>

--- a/apps/mobile/src/components/screens/EventConfirmation.tsx
+++ b/apps/mobile/src/components/screens/EventConfirmation.tsx
@@ -136,9 +136,14 @@ function SuccessView({ feedbackTitle, feedbackMessage, rewards }: {
   feedbackTitle: string; feedbackMessage: string; rewards: Rewards;
 }) {
   return (
-    <div className="min-h-screen flex items-center justify-center p-6">
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="min-h-screen flex items-center justify-center p-6"
+    >
       <div className="app-content w-full text-center animate-fade-in">
-        <div className="w-24 h-24 bg-gradient-to-br from-[#52c41a] to-[#389e0d] rounded-full flex items-center justify-center mx-auto mb-6 animate-pulse">
+        <div aria-hidden="true" className="w-24 h-24 bg-gradient-to-br from-[#52c41a] to-[#389e0d] rounded-full flex items-center justify-center mx-auto mb-6 animate-pulse">
           <CheckCircle2 className="text-white" size={48} />
         </div>
         <h2 className="text-white mb-3">{feedbackTitle}</h2>
@@ -214,10 +219,16 @@ function BoostCard({ cachet, tokenAtcl, boostRequested, allowBoost, isOffline, o
           <p className="text-sm text-[#b8b2b3]">Costo 1 token. Effetto: +10% XP e +10% Cachet.</p>
           <p className="text-xs text-[#b8b2b3] mt-2">Saldo economico: Cachet {cachet} - Token {tokenAtcl}</p>
         </div>
-        <button type="button" onClick={onToggleBoost} disabled={!allowBoost}
+        <button
+          type="button"
+          onClick={onToggleBoost}
+          disabled={!allowBoost}
+          aria-pressed={boostRequested}
+          aria-label={boostRequested ? 'Disattiva boost token ATCL' : 'Attiva boost token ATCL'}
           className={`rounded-full px-4 py-2 text-sm transition-colors ${
             boostRequested ? 'bg-[#f4bf4f] text-[#0f0d0e]' : 'bg-[#241f20] text-[#b8b2b3]'
-          }`}>
+          }`}
+        >
           {boostRequested ? 'Boost ON' : 'Boost OFF'}
         </button>
       </div>

--- a/apps/mobile/src/components/screens/EventConfirmation.tsx
+++ b/apps/mobile/src/components/screens/EventConfirmation.tsx
@@ -96,8 +96,8 @@ export function EventConfirmation({
         />
 
         {pendingBoostRequests > 0 && (
-          <Card className="bg-[#2a1f14] border border-[#f4bf4f]/30">
-            <div className="flex items-center gap-2 text-[#f4bf4f]">
+          <Card className="bg-[--color-warning-soft-bg] border border-[--color-gold-400]/30">
+            <div className="flex items-center gap-2 text-[--color-gold-400]">
               <AlertTriangle size={16} />
               <p className="text-sm">{pendingBoostRequests} richiesta/e boost in verifica in coda offline.</p>
             </div>
@@ -143,20 +143,20 @@ function SuccessView({ feedbackTitle, feedbackMessage, rewards }: {
       className="min-h-screen flex items-center justify-center p-6"
     >
       <div className="app-content w-full text-center animate-fade-in">
-        <div aria-hidden="true" className="w-24 h-24 bg-gradient-to-br from-[#52c41a] to-[#389e0d] rounded-full flex items-center justify-center mx-auto mb-6 animate-pulse">
+        <div aria-hidden="true" className="w-24 h-24 bg-gradient-to-br from-[--color-success] to-[--color-success] rounded-full flex items-center justify-center mx-auto mb-6 animate-pulse">
           <CheckCircle2 className="text-white" size={48} />
         </div>
         <h2 className="text-white mb-3">{feedbackTitle}</h2>
-        <p className="text-[#b8b2b3] mb-8">{feedbackMessage}</p>
-        <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20] mb-6">
-          <h4 className="text-[#f4bf4f] mb-4">Ricompense registrate</h4>
+        <p className="text-[--color-text-secondary] mb-8">{feedbackMessage}</p>
+        <Card className="bg-gradient-to-br from-[--color-bg-surface] to-[--color-bg-surface-elevated] mb-6">
+          <h4 className="text-[--color-gold-400] mb-4">Ricompense registrate</h4>
           <div className="grid grid-cols-3 gap-4">
-            <RewardCell icon={TrendingUp} value={rewards.xp} label="XP" iconBg="from-[#e6a23c] to-[#f4bf4f]" />
-            <RewardCell icon={Award} value={rewards.reputation} label="Reputazione" iconBg="from-[#a82847] to-[#6b1529]" />
+            <RewardCell icon={TrendingUp} value={rewards.xp} label="XP" iconBg="from-[--color-gold-500] to-[--color-gold-400]" />
+            <RewardCell icon={Award} value={rewards.reputation} label="Reputazione" iconBg="from-[--color-burgundy-600] to-[--color-burgundy-800]" />
             <RewardCell icon={Coins} value={rewards.cachet} label="Cachet" iconBg="" plain />
           </div>
         </Card>
-        <p className="text-sm text-[#b8b2b3]">Reindirizzamento alla home...</p>
+        <p className="text-sm text-[--color-text-secondary]">Reindirizzamento alla home...</p>
       </div>
     </div>
   );
@@ -168,12 +168,12 @@ function RewardCell({ icon: Icon, value, label, iconBg, plain }: {
   return (
     <div className="text-center">
       <div className={`w-12 h-12 rounded-lg flex items-center justify-center mx-auto mb-2 ${
-        plain ? 'bg-[#241f20]' : `bg-gradient-to-br ${iconBg}`
+        plain ? 'bg-[--color-bg-surface-elevated]' : `bg-gradient-to-br ${iconBg}`
       }`}>
-        <Icon className={plain ? 'text-[#f4bf4f]' : 'text-[#0f0d0e]'} size={24} />
+        <Icon className={plain ? 'text-[--color-gold-400]' : 'text-[--color-bg-primary]'} size={24} />
       </div>
       <p className="text-2xl text-white mb-1">+{value}</p>
-      <p className="text-xs text-[#b8b2b3]">{label}</p>
+      <p className="text-xs text-[--color-text-secondary]">{label}</p>
     </div>
   );
 }
@@ -186,9 +186,9 @@ function EventInfoCard({ event }: { event: { name: string; theatre: string; date
         {event.genre && <Badge variant="default" size="sm">{event.genre}</Badge>}
       </div>
       <div className="space-y-3">
-        <div className="flex items-center gap-3 text-[#b8b2b3]"><MapPin size={18} className="text-[#f4bf4f]" /><span>{event.theatre}</span></div>
-        <div className="flex items-center gap-3 text-[#b8b2b3]"><Calendar size={18} className="text-[#f4bf4f]" /><span>{event.date}</span></div>
-        <div className="flex items-center gap-3 text-[#b8b2b3]"><Clock size={18} className="text-[#f4bf4f]" /><span>{event.time}</span></div>
+        <div className="flex items-center gap-3 text-[--color-text-secondary]"><MapPin size={18} className="text-[--color-gold-400]" /><span>{event.theatre}</span></div>
+        <div className="flex items-center gap-3 text-[--color-text-secondary]"><Calendar size={18} className="text-[--color-gold-400]" /><span>{event.date}</span></div>
+        <div className="flex items-center gap-3 text-[--color-text-secondary]"><Clock size={18} className="text-[--color-gold-400]" /><span>{event.time}</span></div>
       </div>
     </Card>
   );
@@ -196,11 +196,11 @@ function EventInfoCard({ event }: { event: { name: string; theatre: string; date
 
 function RoleCard({ role }: { role?: Role }) {
   return (
-    <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20]">
+    <Card className="bg-gradient-to-br from-[--color-bg-surface] to-[--color-bg-surface-elevated]">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h4 className="text-white mb-1">Ruolo registrato</h4>
-          <p className="text-sm text-[#b8b2b3]">{role?.focus ?? 'Selezionato in fase di registrazione'}</p>
+          <p className="text-sm text-[--color-text-secondary]">{role?.focus ?? 'Selezionato in fase di registrazione'}</p>
         </div>
         <Badge variant="outline" size="md">{role?.name ?? 'Ruolo'}</Badge>
       </div>
@@ -212,12 +212,12 @@ function BoostCard({ cachet, tokenAtcl, boostRequested, allowBoost, isOffline, o
   cachet: number; tokenAtcl: number; boostRequested: boolean; allowBoost: boolean; isOffline: boolean; onToggleBoost: () => void;
 }) {
   return (
-    <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20]">
+    <Card className="bg-gradient-to-br from-[--color-bg-surface] to-[--color-bg-surface-elevated]">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h4 className="text-[#f4bf4f] mb-1">Boost token ATCL</h4>
-          <p className="text-sm text-[#b8b2b3]">Costo 1 token. Effetto: +10% XP e +10% Cachet.</p>
-          <p className="text-xs text-[#b8b2b3] mt-2">Saldo economico: Cachet {cachet} - Token {tokenAtcl}</p>
+          <h4 className="text-[--color-gold-400] mb-1">Boost token ATCL</h4>
+          <p className="text-sm text-[--color-text-secondary]">Costo 1 token. Effetto: +10% XP e +10% Cachet.</p>
+          <p className="text-xs text-[--color-text-secondary] mt-2">Saldo economico: Cachet {cachet} - Token {tokenAtcl}</p>
         </div>
         <button
           type="button"
@@ -226,13 +226,13 @@ function BoostCard({ cachet, tokenAtcl, boostRequested, allowBoost, isOffline, o
           aria-pressed={boostRequested}
           aria-label={boostRequested ? 'Disattiva boost token ATCL' : 'Attiva boost token ATCL'}
           className={`rounded-full px-4 py-2 text-sm transition-colors ${
-            boostRequested ? 'bg-[#f4bf4f] text-[#0f0d0e]' : 'bg-[#241f20] text-[#b8b2b3]'
+            boostRequested ? 'bg-[--color-gold-400] text-[--color-bg-primary]' : 'bg-[--color-bg-surface-elevated] text-[--color-text-secondary]'
           }`}
         >
           {boostRequested ? 'Boost ON' : 'Boost OFF'}
         </button>
       </div>
-      <div className="mt-3 rounded-lg bg-[#241f20] px-3 py-2 text-xs text-[#b8b2b3]">
+      <div className="mt-3 rounded-lg bg-[--color-bg-surface-elevated] px-3 py-2 text-xs text-[--color-text-secondary]">
         {!allowBoost ? 'Boost temporaneamente disattivato da configurazione.'
           : isOffline ? 'Offline: richiesta boost in coda, verifica solo online.'
           : boostRequested ? 'Online: la verifica token avviene lato server al momento della registrazione.'
@@ -247,27 +247,27 @@ function RewardsPreviewCard({ resolvedRewards, boostedRewards, boostRequested, a
 }) {
   const showBoosted = boostRequested && allowBoost;
   return (
-    <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20]">
-      <h4 className="text-[#f4bf4f] mb-4">Ricompense previste</h4>
+    <Card className="bg-gradient-to-br from-[--color-bg-surface] to-[--color-bg-surface-elevated]">
+      <h4 className="text-[--color-gold-400] mb-4">Ricompense previste</h4>
       <div className="flex items-center justify-around">
         <div className="text-center">
-          <TrendingUp className="text-[#f4bf4f] mx-auto mb-2" size={24} />
+          <TrendingUp className="text-[--color-gold-400] mx-auto mb-2" size={24} />
           <p className="text-white mb-1">+{showBoosted ? boostedRewards.xp : resolvedRewards.xp}</p>
-          <p className="text-xs text-[#b8b2b3]">XP</p>
+          <p className="text-xs text-[--color-text-secondary]">XP</p>
         </div>
         <div className="text-center">
-          <Award className="text-[#f4bf4f] mx-auto mb-2" size={24} />
+          <Award className="text-[--color-gold-400] mx-auto mb-2" size={24} />
           <p className="text-white mb-1">+{resolvedRewards.reputation}</p>
-          <p className="text-xs text-[#b8b2b3]">Reputazione</p>
+          <p className="text-xs text-[--color-text-secondary]">Reputazione</p>
         </div>
         <div className="text-center">
-          <Coins className="text-[#f4bf4f] mx-auto mb-2" size={24} />
+          <Coins className="text-[--color-gold-400] mx-auto mb-2" size={24} />
           <p className="text-white mb-1">+{showBoosted ? boostedRewards.cachet : resolvedRewards.cachet}</p>
-          <p className="text-xs text-[#b8b2b3]">Cachet</p>
+          <p className="text-xs text-[--color-text-secondary]">Cachet</p>
         </div>
       </div>
       {showBoosted && (
-        <div className="mt-3 text-xs text-[#f4bf4f] flex items-center gap-2">
+        <div className="mt-3 text-xs text-[--color-gold-400] flex items-center gap-2">
           <Zap size={14} /> Richiesta boost attiva (conferma finale solo lato server).
         </div>
       )}

--- a/apps/mobile/src/components/screens/EventDetails.tsx
+++ b/apps/mobile/src/components/screens/EventDetails.tsx
@@ -54,7 +54,7 @@ export function EventDetails({
   const planningStatusLabel = planning ? getPlanningStatusLabel(planning.status) : 'Da pianificare';
   const planningStatusClassName = planning
     ? getPlanningStatusClassName(planning.status)
-    : 'border-white/10 bg-white/5 text-[#b8b2b3]';
+    : 'border-white/10 bg-white/5 text-[--color-text-secondary]';
 
   if (!event) {
     return (
@@ -62,7 +62,7 @@ export function EventDetails({
         <div className="app-content px-6 space-y-6 pt-6">
           <div>
             <h2 className="text-white mb-2">Dettagli evento</h2>
-            <p className="text-[#b8b2b3]">Nessun evento disponibile.</p>
+            <p className="text-[--color-text-secondary]">Nessun evento disponibile.</p>
           </div>
           <Button variant="ghost" size="lg" fullWidth onClick={onBack}>
             Torna indietro
@@ -139,7 +139,7 @@ export function EventDetails({
       <div className="app-content px-6 space-y-6 pt-6">
         <div>
           <h2 className="text-white mb-2">Dettagli evento</h2>
-          <p className="text-[#b8b2b3]">Informazioni sull'evento selezionato</p>
+          <p className="text-[--color-text-secondary]">Informazioni sull'evento selezionato</p>
         </div>
 
         <Card>
@@ -148,47 +148,47 @@ export function EventDetails({
               <h3 id="event-info-heading" className="text-white text-lg leading-tight">{event.name}</h3>
               {event.genre ? <Badge variant="default" size="sm">{event.genre}</Badge> : null}
             </div>
-            <div className="flex items-center gap-3 text-[#b8b2b3]">
-              <MapPin aria-hidden="true" size={18} className="text-[#f4bf4f]" />
+            <div className="flex items-center gap-3 text-[--color-text-secondary]">
+              <MapPin aria-hidden="true" size={18} className="text-[--color-gold-400]" />
               <span aria-label={`Teatro: ${event.theatre}`}>{event.theatre}</span>
             </div>
-            <div className="flex items-center gap-3 text-[#b8b2b3]">
-              <Calendar aria-hidden="true" size={18} className="text-[#f4bf4f]" />
+            <div className="flex items-center gap-3 text-[--color-text-secondary]">
+              <Calendar aria-hidden="true" size={18} className="text-[--color-gold-400]" />
               <span aria-label={`Data: ${event.date}`}>{event.date}</span>
             </div>
-            <div className="flex items-center gap-3 text-[#b8b2b3]">
-              <Clock aria-hidden="true" size={18} className="text-[#f4bf4f]" />
+            <div className="flex items-center gap-3 text-[--color-text-secondary]">
+              <Clock aria-hidden="true" size={18} className="text-[--color-gold-400]" />
               <span aria-label={`Orario: ${event.time}`}>{event.time}</span>
             </div>
           </section>
         </Card>
 
-        <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20]">
+        <Card className="bg-gradient-to-br from-[--color-bg-surface] to-[--color-bg-surface-elevated]">
           <section aria-labelledby="event-base-rewards-heading">
-            <h4 id="event-base-rewards-heading" className="text-[#f4bf4f] mb-4">Ricompense base</h4>
+            <h4 id="event-base-rewards-heading" className="text-[--color-gold-400] mb-4">Ricompense base</h4>
             <div className="grid grid-cols-3 gap-3 text-center">
               <div aria-label={`Esperienza: ${event.baseRewards.xp} XP`}>
                 <p className="text-white text-lg">+{event.baseRewards.xp}</p>
-                <p className="text-xs text-[#b8b2b3]">XP</p>
+                <p className="text-xs text-[--color-text-secondary]">XP</p>
               </div>
               <div aria-label={`Reputazione: ${event.baseRewards.reputation}`}>
                 <p className="text-white text-lg">+{event.baseRewards.reputation}</p>
-                <p className="text-xs text-[#b8b2b3]">Reputazione</p>
+                <p className="text-xs text-[--color-text-secondary]">Reputazione</p>
               </div>
               <div aria-label={`Cachet: ${event.baseRewards.cachet}`}>
                 <p className="text-white text-lg">+{event.baseRewards.cachet}</p>
-                <p className="text-xs text-[#b8b2b3]">Cachet</p>
+                <p className="text-xs text-[--color-text-secondary]">Cachet</p>
               </div>
             </div>
           </section>
         </Card>
 
-        <Card className="border border-[#f4bf4f]/10 bg-[#151112]">
+        <Card className="border border-[--color-gold-400]/10 bg-[--color-bg-primary]">
           <section aria-labelledby="event-planning-heading">
           <div className="flex items-start justify-between gap-4">
             <div>
               <h4 id="event-planning-heading" className="text-white">Pianificazione partecipazione</h4>
-              <p className="text-sm text-[#b8b2b3] mt-1">
+              <p className="text-sm text-[--color-text-secondary] mt-1">
                 Salva il ruolo che intendi coprire per questo evento e mantieni lo stato visibile nella lista.
               </p>
             </div>
@@ -201,7 +201,7 @@ export function EventDetails({
           </div>
 
           <div className="mt-5 space-y-3">
-            <label className="block text-sm text-[#b8b2b3]" htmlFor="event-role-select">
+            <label className="block text-sm text-[--color-text-secondary]" htmlFor="event-role-select">
               Ruolo previsto
             </label>
             <Select
@@ -210,7 +210,7 @@ export function EventDetails({
             >
               <SelectTrigger
                 id="event-role-select"
-                className="w-full border-[#2d2728] bg-[#241f20] text-white"
+                className="w-full border-[--color-bg-surface-hover] bg-[--color-bg-surface-elevated] text-white"
               >
                 <SelectValue placeholder="Scegli un ruolo" />
               </SelectTrigger>
@@ -222,13 +222,13 @@ export function EventDetails({
                 ))}
               </SelectContent>
             </Select>
-            <p className="text-sm text-[#b8b2b3]">
+            <p className="text-sm text-[--color-text-secondary]">
               {planning
                 ? `Stato attuale: ${planningStatusLabel.toLowerCase()} come ${savedRoleName}.`
                 : 'Nessuna pianificazione salvata per questo evento.'}
             </p>
             {planning && planning.roleId !== selectedRoleId ? (
-              <p className="text-sm text-[#f4bf4f]">
+              <p className="text-sm text-[--color-gold-400]">
                 Modifica pronta da salvare: {selectedRoleName}.
               </p>
             ) : null}
@@ -308,9 +308,9 @@ function getPlanningStatusClassName(status: EventPlanning['status']) {
     case 'confirmed':
       return 'border-emerald-400/40 bg-emerald-400/10 text-emerald-300';
     case 'cancelled':
-      return 'border-white/10 bg-white/5 text-[#b8b2b3]';
+      return 'border-white/10 bg-white/5 text-[--color-text-secondary]';
     default:
-      return 'border-[#f4bf4f]/40 bg-[#f4bf4f]/10 text-[#f4bf4f]';
+      return 'border-[--color-gold-400]/40 bg-[--color-gold-400]/10 text-[--color-gold-400]';
   }
 }
 

--- a/apps/mobile/src/components/screens/EventDetails.tsx
+++ b/apps/mobile/src/components/screens/EventDetails.tsx
@@ -143,53 +143,57 @@ export function EventDetails({
         </div>
 
         <Card>
-          <div className="space-y-3">
+          <section aria-labelledby="event-info-heading" className="space-y-3">
             <div className="flex items-start justify-between gap-3">
-              <h3 className="text-white text-lg leading-tight">{event.name}</h3>
+              <h3 id="event-info-heading" className="text-white text-lg leading-tight">{event.name}</h3>
               {event.genre ? <Badge variant="default" size="sm">{event.genre}</Badge> : null}
             </div>
             <div className="flex items-center gap-3 text-[#b8b2b3]">
-              <MapPin size={18} className="text-[#f4bf4f]" />
-              <span>{event.theatre}</span>
+              <MapPin aria-hidden="true" size={18} className="text-[#f4bf4f]" />
+              <span aria-label={`Teatro: ${event.theatre}`}>{event.theatre}</span>
             </div>
             <div className="flex items-center gap-3 text-[#b8b2b3]">
-              <Calendar size={18} className="text-[#f4bf4f]" />
-              <span>{event.date}</span>
+              <Calendar aria-hidden="true" size={18} className="text-[#f4bf4f]" />
+              <span aria-label={`Data: ${event.date}`}>{event.date}</span>
             </div>
             <div className="flex items-center gap-3 text-[#b8b2b3]">
-              <Clock size={18} className="text-[#f4bf4f]" />
-              <span>{event.time}</span>
+              <Clock aria-hidden="true" size={18} className="text-[#f4bf4f]" />
+              <span aria-label={`Orario: ${event.time}`}>{event.time}</span>
             </div>
-          </div>
+          </section>
         </Card>
 
         <Card className="bg-gradient-to-br from-[#1a1617] to-[#241f20]">
-          <h4 className="text-[#f4bf4f] mb-4">Ricompense base</h4>
-          <div className="grid grid-cols-3 gap-3 text-center">
-            <div>
-              <p className="text-white text-lg">+{event.baseRewards.xp}</p>
-              <p className="text-xs text-[#b8b2b3]">XP</p>
+          <section aria-labelledby="event-base-rewards-heading">
+            <h4 id="event-base-rewards-heading" className="text-[#f4bf4f] mb-4">Ricompense base</h4>
+            <div className="grid grid-cols-3 gap-3 text-center">
+              <div aria-label={`Esperienza: ${event.baseRewards.xp} XP`}>
+                <p className="text-white text-lg">+{event.baseRewards.xp}</p>
+                <p className="text-xs text-[#b8b2b3]">XP</p>
+              </div>
+              <div aria-label={`Reputazione: ${event.baseRewards.reputation}`}>
+                <p className="text-white text-lg">+{event.baseRewards.reputation}</p>
+                <p className="text-xs text-[#b8b2b3]">Reputazione</p>
+              </div>
+              <div aria-label={`Cachet: ${event.baseRewards.cachet}`}>
+                <p className="text-white text-lg">+{event.baseRewards.cachet}</p>
+                <p className="text-xs text-[#b8b2b3]">Cachet</p>
+              </div>
             </div>
-            <div>
-              <p className="text-white text-lg">+{event.baseRewards.reputation}</p>
-              <p className="text-xs text-[#b8b2b3]">Reputazione</p>
-            </div>
-            <div>
-              <p className="text-white text-lg">+{event.baseRewards.cachet}</p>
-              <p className="text-xs text-[#b8b2b3]">Cachet</p>
-            </div>
-          </div>
+          </section>
         </Card>
 
         <Card className="border border-[#f4bf4f]/10 bg-[#151112]">
+          <section aria-labelledby="event-planning-heading">
           <div className="flex items-start justify-between gap-4">
             <div>
-              <h4 className="text-white">Pianificazione partecipazione</h4>
+              <h4 id="event-planning-heading" className="text-white">Pianificazione partecipazione</h4>
               <p className="text-sm text-[#b8b2b3] mt-1">
                 Salva il ruolo che intendi coprire per questo evento e mantieni lo stato visibile nella lista.
               </p>
             </div>
             <span
+              aria-label={`Stato pianificazione: ${planningStatusLabel}`}
               className={`inline-flex shrink-0 items-center rounded-full border px-3 py-1 text-xs font-medium ${planningStatusClassName}`}
             >
               {planningStatusLabel}
@@ -259,6 +263,7 @@ export function EventDetails({
               </Button>
             ) : null}
           </div>
+          </section>
         </Card>
 
         <div className="space-y-3">

--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -139,8 +139,8 @@ export function Home({
       </div>
 
       {pendingBoostRequests > 0 && (
-        <Card className="bg-[#2a1f14] border border-[#f4bf4f]/30">
-          <p className="text-sm text-[#f4bf4f]">
+        <Card className="bg-[--color-warning-soft-bg] border border-[--color-gold-400]/30">
+          <p className="text-sm text-[--color-gold-400]">
             Boost in verifica: {pendingBoostRequests} richiesta/e in coda offline.
           </p>
         </Card>
@@ -278,30 +278,30 @@ function NotificationBell({
     <Popover>
       <PopoverTrigger asChild>
         <button type="button" aria-label="Notifiche"
-          className="relative flex items-center justify-center size-[44px] rounded-lg hover:bg-[#241f20] transition mobile-card-hover">
-          <Bell size={20} className="text-[#f4bf4f]" aria-hidden="true" />
+          className="relative flex items-center justify-center size-[44px] rounded-lg hover:bg-[--color-bg-surface-elevated] transition mobile-card-hover">
+          <Bell size={20} className="text-[--color-gold-400]" aria-hidden="true" />
           {hasNewBadges && (
-            <span className={`absolute -top-1 -right-1 w-3 h-3 bg-[#f4bf4f] rounded-full ${animateBadges ? 'mobile-badge-pop' : ''}`} />
+            <span className={`absolute -top-1 -right-1 w-3 h-3 bg-[--color-gold-400] rounded-full ${animateBadges ? 'mobile-badge-pop' : ''}`} />
           )}
         </button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-80 bg-[#1a1617] border-[#3d3a3b] p-3">
+      <PopoverContent align="end" className="w-80 bg-[--color-bg-surface] border-[--color-border-subtle] p-3">
         {showBadge && hasNewBadges ? (
           <div className={`flex items-start gap-3 ${animateBadges ? 'mobile-badge-pop' : ''}`}>
-            <div className="flex-shrink-0 w-10 h-10 bg-gradient-to-br from-[#f4bf4f] to-[#e6a23c] rounded-lg flex items-center justify-center mobile-pulse-once">
-              <Award className="text-[#0f0d0e]" size={20} />
+            <div className="flex-shrink-0 w-10 h-10 bg-gradient-to-br from-[--color-gold-400] to-[--color-gold-500] rounded-lg flex items-center justify-center mobile-pulse-once">
+              <Award className="text-[--color-bg-primary]" size={20} />
             </div>
             <div className="flex-1">
-              <p className="text-xs text-[#f4bf4f] mb-1 font-semibold">Nuovo titolo ottenuto</p>
+              <p className="text-xs text-[--color-gold-400] mb-1 font-semibold">Nuovo titolo ottenuto</p>
               <p className="text-white text-sm">{newBadgeTitle ?? 'Hai sbloccato un nuovo badge'}</p>
             </div>
             <button type="button" onClick={onDismiss} aria-label="Ignora notifica"
-              className="text-[#9a9697] p-1 hover:text-white flex-shrink-0 transition-colors">
+              className="text-[--color-text-tertiary] p-1 hover:text-white flex-shrink-0 transition-colors">
               <X size={16} aria-hidden="true" />
             </button>
           </div>
         ) : (
-          <p className="text-[#b8b2b3] text-sm text-center py-4">Nessuna notifica</p>
+          <p className="text-[--color-text-secondary] text-sm text-center py-4">Nessuna notifica</p>
         )}
       </PopoverContent>
     </Popover>
@@ -341,12 +341,12 @@ function StatsGrid({
 // closes #470 — tokenAtcl rimosso dalla home, visibile nella schermata Carriera
 function EconomyCard({ cachet }: { cachet: number }) {
   return (
-    <Card className="bg-[#1a1617] border border-[#2d2728]">
+    <Card className="bg-[--color-bg-surface] border border-[--color-bg-surface-hover]">
       <h4 className="text-white text-sm font-semibold mb-3">Economia</h4>
-      <div className="rounded-xl bg-[#241f20] border border-[#3d3a3b] p-3">
+      <div className="rounded-xl bg-[--color-bg-surface-elevated] border border-[--color-border-subtle] p-3">
         <div className="flex items-center justify-between gap-2">
-          <p className="text-xs text-[#b8b2b3]">Cachet</p>
-          <Coins size={14} className="text-[#f4bf4f]" />
+          <p className="text-xs text-[--color-text-secondary]">Cachet</p>
+          <Coins size={14} className="text-[--color-gold-400]" />
         </div>
         <p className="text-white text-lg font-semibold mt-1">{cachet}</p>
       </div>
@@ -372,19 +372,19 @@ function TurnSyncFeedbackCard({
   const showGeolocationWarning = feedback.geolocationAvailable === false;
 
   return (
-    <Card className="bg-[#241f20] border border-[#3d3a3b]">
+    <Card className="bg-[--color-bg-surface-elevated] border border-[--color-border-subtle]">
       <div className="flex items-start justify-between gap-3">
         <div className="space-y-1">
           <p className="text-sm text-white">{message}</p>
-          <p className="text-xs text-[#b8b2b3]">{feedback.eventName}</p>
+          <p className="text-xs text-[--color-text-secondary]">{feedback.eventName}</p>
           {showGeolocationWarning && (
-            <p className="text-xs text-[#f4bf4f] mt-2">
+            <p className="text-xs text-[--color-gold-400] mt-2">
               ⚠️ Turno registrato senza geolocalizzazione. Abilita il GPS per una validazione più accurata in futuro.
             </p>
           )}
         </div>
         {onDismiss && (
-          <button type="button" onClick={onDismiss} className="text-[#9a9697] hover:text-white transition-colors p-1" aria-label="Chiudi notifica boost">
+          <button type="button" onClick={onDismiss} className="text-[--color-text-tertiary] hover:text-white transition-colors p-1" aria-label="Chiudi notifica boost">
             <X size={16} />
           </button>
         )}
@@ -401,15 +401,15 @@ function RoleJourneyCard({
   onOpen: () => void;
 }) {
   return (
-    <Card className="animate-stagger-2 border border-[#f4bf4f]/30 bg-gradient-to-br from-[#201819] via-[#251b1d] to-[#171314]">
+    <Card className="animate-stagger-2 border border-[--color-gold-400]/30 bg-gradient-to-br from-[--color-bg-surface] via-[--color-bg-surface] to-[--color-bg-primary]">
       <div className="space-y-3">
         {journey.eyebrow && (
-          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#f4bf4f]">{journey.eyebrow}</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[--color-gold-400]">{journey.eyebrow}</p>
         )}
         <div className="space-y-1">
           <h3 className="text-white text-lg font-semibold">{journey.headline}</h3>
-          <p className="text-sm text-[#b8b2b3]">{journey.summary}</p>
-          {journey.homeMessage && <p className="text-xs text-[#f4bf4f]">{journey.homeMessage}</p>}
+          <p className="text-sm text-[--color-text-secondary]">{journey.summary}</p>
+          {journey.homeMessage && <p className="text-xs text-[--color-gold-400]">{journey.homeMessage}</p>}
         </div>
         <div className="flex flex-wrap gap-2">
           {journey.recommendedActivityTitle && (
@@ -422,7 +422,7 @@ function RoleJourneyCard({
         {(journey.objectives ?? []).length > 0 && (
           <div className="space-y-2">
             {(journey.objectives ?? []).slice(0, 3).map(objective => (
-              <p key={objective} className="text-sm text-[#f7f3f4]">&bull; {objective}</p>
+              <p key={objective} className="text-sm text-[--color-text-primary]">&bull; {objective}</p>
             ))}
           </div>
         )}
@@ -458,7 +458,7 @@ function UpcomingEventSection({
       <div className="flex items-center justify-between">
         <h3 className="text-white text-base font-semibold tracking-tight">Prossimo evento</h3>
         {eventState === 'ready' && (
-          <button onClick={onViewEventDetails} className="text-sm text-[#f4bf4f] hover:text-[#e6a23c] px-3 py-2 rounded-lg transition-colors">
+          <button onClick={onViewEventDetails} className="text-sm text-[--color-gold-400] hover:text-[--color-gold-500] px-3 py-2 rounded-lg transition-colors">
             Dettagli
           </button>
         )}
@@ -474,13 +474,13 @@ function UpcomingEventSection({
         ) : eventState === 'error' ? (
           <div className="space-y-2">
             <p className="text-white">Errore nel caricamento</p>
-            <p className="text-sm text-[#b8b2b3]">Controlla la connessione e riprova.</p>
+            <p className="text-sm text-[--color-text-secondary]">Controlla la connessione e riprova.</p>
             <Button variant="secondary" size="sm" onClick={onViewTurni}>Riprova</Button>
           </div>
         ) : eventState === 'empty' ? (
           <div className="space-y-3">
             <p className="text-white">Nessun evento in programma</p>
-            <p className="text-sm text-[#b8b2b3]">Aggiungi un evento o registra un biglietto.</p>
+            <p className="text-sm text-[--color-text-secondary]">Aggiungi un evento o registra un biglietto.</p>
             <div className="flex gap-2">
               {allowScanQr && <Button variant="secondary" size="sm" onClick={onScanQR}>Registra Biglietto</Button>}
               <Button variant="ghost" size="sm" onClick={onViewTurni}>Vedi turni</Button>
@@ -513,13 +513,13 @@ function EventCard({
   return (
     <div className="space-y-2">
       <div className="flex items-start gap-3 mb-4">
-        <div className="flex-shrink-0 bg-[#241f20] rounded-lg flex flex-col items-center justify-center w-[70px] h-[70px] gap-1">
-          <Calendar className="text-[#f4bf4f] block" size={50} />
-          <p className="text-xs leading-none text-[#f4bf4f] !m-0">{event.date?.slice(0, 6)}</p>
+        <div className="flex-shrink-0 bg-[--color-bg-surface-elevated] rounded-lg flex flex-col items-center justify-center w-[70px] h-[70px] gap-1">
+          <Calendar className="text-[--color-gold-400] block" size={50} />
+          <p className="text-xs leading-none text-[--color-gold-400] !m-0">{event.date?.slice(0, 6)}</p>
         </div>
         <div className="flex-1 min-w-0">
           <h4 className="text-white text-lg leading-tight line-clamp-2">{event.name}</h4>
-          <p className="text-sm text-[#b8b2b3]">{event.theatre} &middot; {event.time}</p>
+          <p className="text-sm text-[--color-text-secondary]">{event.theatre} &middot; {event.time}</p>
           <div className="flex flex-wrap items-center gap-2 mt-2">
             <Tag size="sm" variant="outline" className="p-1">{event.genre ?? 'ATCL'}</Tag>
             <Badge variant="default" size="sm">Turni {totalTurns}</Badge>
@@ -555,7 +555,7 @@ function TurnStatsSection({
     <section className="animate-stagger-4 space-y-3">
       <div className="flex items-center justify-between">
         <h3 className="text-white text-base font-semibold tracking-tight">Turni ATCL</h3>
-        <button onClick={onViewTurni} className="text-sm text-[#f4bf4f] hover:text-[#e6a23c] px-3 py-2 rounded-lg transition-colors">
+        <button onClick={onViewTurni} className="text-sm text-[--color-gold-400] hover:text-[--color-gold-500] px-3 py-2 rounded-lg transition-colors">
           Vedi tutti
         </button>
       </div>
@@ -590,13 +590,13 @@ function ActivitiesCard({
       <h3 className="text-white text-base font-semibold tracking-tight">Attività simulate</h3>
       <Card hoverable onClick={onViewActivities} className="mb-5">
         <div className="flex items-center gap-4">
-          <div className="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-xl flex items-center justify-center">
-            <Play className="text-[#f4bf4f]" size={24} />
+          <div className="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-[--color-burgundy-600] to-[--color-burgundy-800] rounded-xl flex items-center justify-center">
+            <Play className="text-[--color-gold-400]" size={24} />
           </div>
           <div className="flex-1">
             <h4 className="text-white mb-1">{activitiesCount} attività disponibili</h4>
           </div>
-          <ChevronRight className="text-[#9a9697]" size={20} />
+          <ChevronRight className="text-[--color-text-tertiary]" size={20} />
         </div>
       </Card>
     </section>

--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -8,7 +8,6 @@ import { Button } from '../ui/Button';
 import { Screen } from '../ui/Screen';
 import {
   Play,
-  Calendar,
   TrendingUp,
   Award,
   ChevronRight,
@@ -499,6 +498,24 @@ function UpcomingEventSection({
   );
 }
 
+/** Mini tile che mostra giorno + mese abbreviato in italiano a partire da una data ISO "YYYY-MM-DD". */
+function EventDateTile({ date }: { date: string }) {
+  // Append T00:00:00 to parse as local date (avoid UTC midnight off-by-one).
+  const parsed = date ? new Date(date.length === 10 ? `${date}T00:00:00` : date) : null;
+  const isValid = parsed && !isNaN(parsed.getTime());
+  const day = isValid ? String(parsed!.getDate()) : '—';
+  const month = isValid
+    ? parsed!.toLocaleDateString('it-IT', { month: 'short' }).replace('.', '').toUpperCase()
+    : '';
+
+  return (
+    <div className="flex-shrink-0 bg-[--color-bg-surface-elevated] rounded-xl flex flex-col items-center justify-center w-[60px] h-[70px] gap-0.5 border border-[--color-bg-surface-hover]">
+      <span className="text-[28px] font-bold leading-none text-white tabular-nums">{day}</span>
+      <span className="text-[10px] font-semibold leading-none text-[--color-gold-400] tracking-[0.08em]">{month}</span>
+    </div>
+  );
+}
+
 function EventCard({
   event,
   totalTurns,
@@ -513,10 +530,7 @@ function EventCard({
   return (
     <div className="space-y-2">
       <div className="flex items-start gap-3 mb-4">
-        <div className="flex-shrink-0 bg-[--color-bg-surface-elevated] rounded-lg flex flex-col items-center justify-center w-[70px] h-[70px] gap-1">
-          <Calendar className="text-[--color-gold-400] block" size={50} />
-          <p className="text-xs leading-none text-[--color-gold-400] !m-0">{event.date?.slice(0, 6)}</p>
-        </div>
+        <EventDateTile date={event.date} />
         <div className="flex-1 min-w-0">
           <h4 className="text-white text-lg leading-tight line-clamp-2">{event.name}</h4>
           <p className="text-sm text-[--color-text-secondary]">{event.theatre} &middot; {event.time}</p>

--- a/apps/mobile/src/components/screens/InstallApp.tsx
+++ b/apps/mobile/src/components/screens/InstallApp.tsx
@@ -66,12 +66,12 @@ export function InstallApp({ onContinue, onDismiss }: InstallAppProps) {
 
       <section
         aria-labelledby="install-steps-heading"
-        className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-4 space-y-2"
+        className="bg-[--color-bg-surface] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-4 space-y-2"
       >
         <p id="install-steps-heading" className="text-white font-semibold">
           Installazione ({platform === 'ios' ? 'iOS' : platform === 'android' ? 'Android' : 'Desktop'})
         </p>
-        <ol className="list-decimal pl-5 space-y-1 text-[#b8b2b3]" aria-describedby="install-steps-heading">
+        <ol className="list-decimal pl-5 space-y-1 text-[--color-text-secondary]" aria-describedby="install-steps-heading">
           {steps.map((step) => (
             <li key={step}>{step}</li>
           ))}
@@ -79,7 +79,7 @@ export function InstallApp({ onContinue, onDismiss }: InstallAppProps) {
       </section>
 
       {platform === 'desktop' ? (
-        <div className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-4 flex flex-col items-center gap-3">
+        <div className="bg-[--color-bg-surface] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-4 flex flex-col items-center gap-3">
           <p className="text-white font-semibold">QR</p>
           <img
             src={qrSrc}
@@ -91,7 +91,7 @@ export function InstallApp({ onContinue, onDismiss }: InstallAppProps) {
       ) : null}
 
       {standalone ? (
-        <div className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-4">
+        <div className="bg-[--color-bg-surface] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-4">
           <p className="text-white font-semibold">Gia installata</p>
         </div>
       ) : null}
@@ -101,7 +101,7 @@ export function InstallApp({ onContinue, onDismiss }: InstallAppProps) {
           type="button"
           onClick={onContinue}
           aria-label="Apri Turni di Palco senza installare"
-          className="w-full bg-gradient-to-b from-[#8c1c38] to-[#a82847] rounded-[16.4px] h-[54px] flex items-center justify-center text-white font-semibold active:scale-[0.99] transition-transform"
+          className="w-full bg-gradient-to-b from-[--color-burgundy-700] to-[--color-burgundy-600] rounded-[16.4px] h-[54px] flex items-center justify-center text-white font-semibold active:scale-[0.99] transition-transform"
         >
           Apri l'app
         </button>
@@ -109,7 +109,7 @@ export function InstallApp({ onContinue, onDismiss }: InstallAppProps) {
           type="button"
           onClick={handleDismiss}
           aria-label="Rimanda l'installazione dell'app"
-          className="w-full h-[48px] rounded-[16.4px] border border-[#2d2728] text-[#f4bf4f] font-semibold"
+          className="w-full h-[48px] rounded-[16.4px] border border-[--color-bg-surface-hover] text-[--color-gold-400] font-semibold"
         >
           Non ora
         </button>

--- a/apps/mobile/src/components/screens/InstallApp.tsx
+++ b/apps/mobile/src/components/screens/InstallApp.tsx
@@ -64,14 +64,19 @@ export function InstallApp({ onContinue, onDismiss }: InstallAppProps) {
         <h1 className="text-[22px] leading-[28px] font-semibold text-white">Installa Turni di Palco</h1>
       </div>
 
-      <div className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-4 space-y-2">
-        <p className="text-white font-semibold">Installazione ({platform === 'ios' ? 'iOS' : platform === 'android' ? 'Android' : 'Desktop'})</p>
-        <ol className="list-decimal pl-5 space-y-1 text-[#b8b2b3]">
+      <section
+        aria-labelledby="install-steps-heading"
+        className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-4 space-y-2"
+      >
+        <p id="install-steps-heading" className="text-white font-semibold">
+          Installazione ({platform === 'ios' ? 'iOS' : platform === 'android' ? 'Android' : 'Desktop'})
+        </p>
+        <ol className="list-decimal pl-5 space-y-1 text-[#b8b2b3]" aria-describedby="install-steps-heading">
           {steps.map((step) => (
             <li key={step}>{step}</li>
           ))}
         </ol>
-      </div>
+      </section>
 
       {platform === 'desktop' ? (
         <div className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-4 flex flex-col items-center gap-3">
@@ -95,6 +100,7 @@ export function InstallApp({ onContinue, onDismiss }: InstallAppProps) {
         <button
           type="button"
           onClick={onContinue}
+          aria-label="Apri Turni di Palco senza installare"
           className="w-full bg-gradient-to-b from-[#8c1c38] to-[#a82847] rounded-[16.4px] h-[54px] flex items-center justify-center text-white font-semibold active:scale-[0.99] transition-transform"
         >
           Apri l'app
@@ -102,6 +108,7 @@ export function InstallApp({ onContinue, onDismiss }: InstallAppProps) {
         <button
           type="button"
           onClick={handleDismiss}
+          aria-label="Rimanda l'installazione dell'app"
           className="w-full h-[48px] rounded-[16.4px] border border-[#2d2728] text-[#f4bf4f] font-semibold"
         >
           Non ora

--- a/apps/mobile/src/components/screens/Leaderboard.tsx
+++ b/apps/mobile/src/components/screens/Leaderboard.tsx
@@ -11,7 +11,7 @@ interface LeaderboardProps {
 export function Leaderboard({ onSelectEntry }: LeaderboardProps) {
   const { authUserId, leaderboard, leaderboardLoading, refreshLeaderboard, roles } = useGameState();
   const [hasBootstrapped, setHasBootstrapped] = useState(false);
-  const rowRefs = useRef(new Map<string, HTMLDivElement>());
+  const rowRefs = useRef(new Map<string, HTMLLIElement>());
   const previousRowTops = useRef(new Map<string, number>());
 
   useEffect(() => {
@@ -174,7 +174,7 @@ function getRankClass(position: number) {
 
 function animateRowTransitions(
   sorted: { id: string }[],
-  rowRefs: React.MutableRefObject<Map<string, HTMLDivElement>>,
+  rowRefs: React.MutableRefObject<Map<string, HTMLLIElement>>,
   previousRowTops: React.MutableRefObject<Map<string, number>>,
 ) {
   const nextRowIds = new Set(sorted.map(e => e.id));

--- a/apps/mobile/src/components/screens/Leaderboard.tsx
+++ b/apps/mobile/src/components/screens/Leaderboard.tsx
@@ -48,15 +48,16 @@ export function Leaderboard({ onSelectEntry }: LeaderboardProps) {
       ) : sorted.length === 0 ? (
         <Card><p className="text-[#b8b2b3]">Nessun dato disponibile.</p></Card>
       ) : (
-        <div className="space-y-3">
+        <ol className="space-y-3 list-none p-0 m-0" aria-label="Classifica giocatori per XP">
           {sorted.map((entry, index) => {
             const roleName = roles.find(r => r.id === entry.roleId)?.name ?? 'Ruolo';
             const isMe = Boolean(authUserId) && entry.id === authUserId;
             return (
-              <div
+              <li
                 key={entry.id}
                 ref={node => { if (node) rowRefs.current.set(entry.id, node); else rowRefs.current.delete(entry.id); }}
                 className="transform-gpu"
+                aria-current={isMe ? 'true' : undefined}
               >
                 <LeaderboardRow
                   entry={entry}
@@ -66,10 +67,10 @@ export function Leaderboard({ onSelectEntry }: LeaderboardProps) {
                   onClick={onSelectEntry ? () => onSelectEntry(entry, isMe) : undefined}
                   hoverable={Boolean(onSelectEntry)}
                 />
-              </div>
+              </li>
             );
           })}
-        </div>
+        </ol>
       )}
     </Screen>
   );
@@ -88,17 +89,26 @@ function LeaderboardRow({
   hoverable: boolean;
 }) {
   const initial = (entry.name?.slice(0, 1) ?? 'P').toUpperCase();
+  const rowLabel = `${index + 1}° posto: ${entry.name}, ${roleName}, ${entry.xpTotal} XP${isMe ? ' (tu)' : ''}`;
 
   return (
-    <Card onClick={onClick} hoverable={hoverable} className={getPodiumCardClass(index, isMe)}>
+    <Card
+      onClick={onClick}
+      hoverable={hoverable}
+      aria-label={rowLabel}
+      className={getPodiumCardClass(index, isMe)}
+    >
       <div className="flex items-center gap-3">
         <RankBadge position={index} />
 
-        <div className={`flex items-center justify-center w-12 h-12 rounded-xl bg-[#241f20] overflow-hidden ${
-          isMe ? 'ring-2 ring-[#f4bf4f]/45 shadow-[0_0_16px_rgba(244,191,79,0.16)]' : ''
-        }`}>
+        <div
+          aria-hidden="true"
+          className={`flex items-center justify-center w-12 h-12 rounded-xl bg-[#241f20] overflow-hidden ${
+            isMe ? 'ring-2 ring-[#f4bf4f]/45 shadow-[0_0_16px_rgba(244,191,79,0.16)]' : ''
+          }`}
+        >
           {entry.profileImage ? (
-            <img src={entry.profileImage} alt={entry.name} className="w-full h-full object-cover" />
+            <img src={entry.profileImage} alt="" className="w-full h-full object-cover" />
           ) : (
             <span className="text-white font-semibold">{initial}</span>
           )}
@@ -112,7 +122,7 @@ function LeaderboardRow({
           <p className="text-xs text-[#b8b2b3] truncate">{roleName}</p>
         </div>
 
-        <div className="flex items-center gap-2 text-[#f4bf4f] shrink-0">
+        <div className="flex items-center gap-2 text-[#f4bf4f] shrink-0" aria-hidden="true">
           <Trophy size={18} />
           <span className="text-white font-semibold">{entry.xpTotal}</span>
         </div>

--- a/apps/mobile/src/components/screens/Leaderboard.tsx
+++ b/apps/mobile/src/components/screens/Leaderboard.tsx
@@ -40,13 +40,13 @@ export function Leaderboard({ onSelectEntry }: LeaderboardProps) {
     <Screen contentClassName="px-6 pt-6 pb-8 space-y-6">
       <header className="space-y-2">
         <h2 className="text-2xl text-white font-semibold leading-tight">Classifica</h2>
-        <p className="text-sm text-[#b8b2b3]">Top giocatori per XP</p>
+        <p className="text-sm text-[--color-text-secondary]">Top giocatori per XP</p>
       </header>
 
       {showInitialLoading ? (
-        <p className="text-[#b8b2b3]">Caricamento...</p>
+        <p className="text-[--color-text-secondary]">Caricamento...</p>
       ) : sorted.length === 0 ? (
-        <Card><p className="text-[#b8b2b3]">Nessun dato disponibile.</p></Card>
+        <Card><p className="text-[--color-text-secondary]">Nessun dato disponibile.</p></Card>
       ) : (
         <ol className="space-y-3 list-none p-0 m-0" aria-label="Classifica giocatori per XP">
           {sorted.map((entry, index) => {
@@ -103,8 +103,8 @@ function LeaderboardRow({
 
         <div
           aria-hidden="true"
-          className={`flex items-center justify-center w-12 h-12 rounded-xl bg-[#241f20] overflow-hidden ${
-            isMe ? 'ring-2 ring-[#f4bf4f]/45 shadow-[0_0_16px_rgba(244,191,79,0.16)]' : ''
+          className={`flex items-center justify-center w-12 h-12 rounded-xl bg-[--color-bg-surface-elevated] overflow-hidden ${
+            isMe ? 'ring-2 ring-[--color-gold-400]/45 shadow-[0_0_16px_rgba(244,191,79,0.16)]' : ''
           }`}
         >
           {entry.profileImage ? (
@@ -119,10 +119,10 @@ function LeaderboardRow({
             {isMe && <CurrentUserIndicator />}
             <p className="text-white font-semibold truncate min-w-0" style={{ marginBottom: 0 }}>{entry.name}</p>
           </div>
-          <p className="text-xs text-[#b8b2b3] truncate">{roleName}</p>
+          <p className="text-xs text-[--color-text-secondary] truncate">{roleName}</p>
         </div>
 
-        <div className="flex items-center gap-2 text-[#f4bf4f] shrink-0" aria-hidden="true">
+        <div className="flex items-center gap-2 text-[--color-gold-400] shrink-0" aria-hidden="true">
           <Trophy size={18} />
           <span className="text-white font-semibold">{entry.xpTotal}</span>
         </div>
@@ -142,8 +142,8 @@ function RankBadge({ position }: { position: number }) {
 function CurrentUserIndicator() {
   return (
     <span className="relative inline-flex w-2.5 h-2.5 shrink-0" aria-hidden="true">
-      <span className="absolute inset-0 rounded-full bg-[#f4bf4f]/35 animate-ping" />
-      <span className="relative inline-flex w-2.5 h-2.5 rounded-full bg-[#f4bf4f] shadow-[0_0_10px_rgba(244,191,79,0.28)]" />
+      <span className="absolute inset-0 rounded-full bg-[--color-gold-400]/35 animate-ping" />
+      <span className="relative inline-flex w-2.5 h-2.5 rounded-full bg-[--color-gold-400] shadow-[0_0_10px_rgba(244,191,79,0.28)]" />
     </span>
   );
 }
@@ -158,17 +158,17 @@ const PODIUM_CLASSES = [
 
 function getPodiumCardClass(position: number, isMe: boolean) {
   if (position < 3) {
-    return `${PODIUM_CLASSES[position]}${isMe ? ' ring-1 ring-[#f4bf4f]/18' : ''}`;
+    return `${PODIUM_CLASSES[position]}${isMe ? ' ring-1 ring-[--color-gold-400]/18' : ''}`;
   }
-  return isMe ? 'border border-[#f4bf4f]/25 shadow-[0_0_0_1px_rgba(244,191,79,0.08),0_0_18px_rgba(244,191,79,0.10)]' : '';
+  return isMe ? 'border border-[--color-gold-400]/25 shadow-[0_0_0_1px_rgba(244,191,79,0.08),0_0_18px_rgba(244,191,79,0.10)]' : '';
 }
 
 function getRankClass(position: number) {
   switch (position) {
-    case 0: return 'bg-gradient-to-b from-[#f6c85f] to-[#d89a1f] text-[#0f0d0e] shadow-[0_8px_18px_rgba(244,191,79,0.24)]';
-    case 1: return 'bg-gradient-to-b from-[#e5e7eb] to-[#aeb6c2] text-[#0f0d0e] shadow-[0_8px_18px_rgba(208,213,221,0.18)]';
-    case 2: return 'bg-gradient-to-b from-[#d7996a] to-[#a95e27] text-white shadow-[0_8px_18px_rgba(201,122,61,0.18)]';
-    default: return 'text-[#b8b2b3]';
+    case 0: return 'bg-gradient-to-b from-[--color-podium-gold-top] to-[--color-podium-gold-bottom] text-[--color-bg-primary] shadow-[0_8px_18px_rgba(244,191,79,0.24)]';
+    case 1: return 'bg-gradient-to-b from-[--color-podium-silver-top] to-[--color-podium-silver-bottom] text-[--color-bg-primary] shadow-[0_8px_18px_rgba(208,213,221,0.18)]';
+    case 2: return 'bg-gradient-to-b from-[--color-podium-bronze-top] to-[--color-podium-bronze-bottom] text-white shadow-[0_8px_18px_rgba(201,122,61,0.18)]';
+    default: return 'text-[--color-text-secondary]';
   }
 }
 

--- a/apps/mobile/src/components/screens/Login.tsx
+++ b/apps/mobile/src/components/screens/Login.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { ArrowLeft } from 'lucide-react';
 import { Screen } from '../ui/Screen';
 import { FormField, FormInput, AuthFormLayout } from '../ui/FormField';
+import { PasswordInput } from '../ui/PasswordInput';
 import { Button } from '../ui/Button';
 
 interface LoginProps {
@@ -49,8 +50,8 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword, errorMessag
           <p className="text-base text-[--color-text-secondary]">Inizia la tua carriera teatrale</p>
         </div>
 
-        <form onSubmit={handleSubmit} autoComplete="on"
-          className="mt-8 flex w-full max-w-[300px] flex-col gap-6 mx-auto">
+        <form onSubmit={handleSubmit} method="post" action="/login" autoComplete="on"
+          className="mt-8 flex w-full max-w-[340px] flex-col gap-6 mx-auto">
 
           <FormField label="Email" htmlFor="login-email" error={errors.email}>
             <FormInput
@@ -63,14 +64,14 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword, errorMessag
           </FormField>
 
           <FormField label="Password" htmlFor="login-password" error={errors.password}>
-            <FormInput
-              id="login-password" name="password" type="password"
+            <PasswordInput
+              id="login-password" name="password"
               value={password} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
               autoComplete="current-password" hasError={!!errors.password}
               placeholder="••••••••" enterKeyHint="go"
             />
             <button type="button" onClick={onForgotPassword}
-              className="self-start rounded-md px-2 py-2.5 mt-2 text-base text-[--color-gold-400]">
+              className="self-start rounded-md px-2 py-1 mt-1 text-sm text-[--color-gold-400]">
               Password dimenticata?
             </button>
           </FormField>

--- a/apps/mobile/src/components/screens/Login.tsx
+++ b/apps/mobile/src/components/screens/Login.tsx
@@ -40,13 +40,13 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword, errorMessag
     >
       <AuthFormLayout>
         <button type="button" onClick={onBack}
-          className="flex items-center justify-center size-[44px] text-[#f4bf4f]" aria-label="Indietro">
+          className="flex items-center justify-center size-[44px] text-[--color-gold-400]" aria-label="Indietro">
           <ArrowLeft size={24} />
         </button>
 
         <div className="mt-4 flex flex-col items-start gap-1">
-          <h1 className="text-2xl font-bold tracking-[-0.24px] text-[#f5f5f5]">Accedi</h1>
-          <p className="text-base text-[#b8b2b3]">Inizia la tua carriera teatrale</p>
+          <h1 className="text-2xl font-bold tracking-[-0.24px] text-[--color-text-primary]">Accedi</h1>
+          <p className="text-base text-[--color-text-secondary]">Inizia la tua carriera teatrale</p>
         </div>
 
         <form onSubmit={handleSubmit} autoComplete="on"
@@ -70,13 +70,13 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword, errorMessag
               placeholder="••••••••" enterKeyHint="go"
             />
             <button type="button" onClick={onForgotPassword}
-              className="self-start rounded-md px-2 py-2.5 mt-2 text-base text-[#f4bf4f]">
+              className="self-start rounded-md px-2 py-2.5 mt-2 text-base text-[--color-gold-400]">
               Password dimenticata?
             </button>
           </FormField>
 
           {errorMessage && (
-            <p className="text-sm text-[#ff4d4f] text-center">{errorMessage}</p>
+            <p className="text-sm text-[--color-error] text-center">{errorMessage}</p>
           )}
 
           <Button type="submit" fullWidth disabled={isSubmitting} className={isSubmitting ? 'opacity-50 pointer-events-none' : ''}>
@@ -85,9 +85,9 @@ export function Login({ onBack, onLogin, onSignup, onForgotPassword, errorMessag
         </form>
 
         <div className="mt-auto pt-6 text-center">
-          <p className="text-base text-[#b8b2b3]">Non hai un account?</p>
+          <p className="text-base text-[--color-text-secondary]">Non hai un account?</p>
           <button type="button" onClick={onSignup}
-            className="inline-flex items-center justify-center rounded-md px-2 py-2.5 text-base text-[#f4bf4f]">
+            className="inline-flex items-center justify-center rounded-md px-2 py-2.5 text-base text-[--color-gold-400]">
             Registrati
           </button>
         </div>

--- a/apps/mobile/src/components/screens/PrivacyPolicy.tsx
+++ b/apps/mobile/src/components/screens/PrivacyPolicy.tsx
@@ -57,7 +57,7 @@ export function PrivacyPolicy({ onBack }: PrivacyPolicyProps) {
           <button
             type="button"
             onClick={onBack}
-            className="flex items-center justify-center size-[44px] text-[#f4bf4f] shrink-0"
+            className="flex items-center justify-center size-[44px] text-[--color-gold-400] shrink-0"
             aria-label="Indietro"
           >
             <ArrowLeft size={24} />
@@ -66,14 +66,14 @@ export function PrivacyPolicy({ onBack }: PrivacyPolicyProps) {
 
         {/* Title block */}
         <div className="flex items-start gap-3">
-          <div className="flex items-center justify-center size-[48px] rounded-[14px] bg-[#f4bf4f]/10 shrink-0">
-            <Shield size={24} className="text-[#f4bf4f]" />
+          <div className="flex items-center justify-center size-[48px] rounded-[14px] bg-[--color-gold-400]/10 shrink-0">
+            <Shield size={24} className="text-[--color-gold-400]" />
           </div>
           <div className="flex flex-col gap-0.5">
-            <h1 className="text-[22px] leading-[28px] font-bold tracking-[-0.2px] text-[#f5f5f5]">
+            <h1 className="text-[22px] leading-[28px] font-bold tracking-[-0.2px] text-[--color-text-primary]">
               Privacy Policy
             </h1>
-            <p className="text-[14px] leading-[20px] text-[#b8b2b3]">
+            <p className="text-[14px] leading-[20px] text-[--color-text-secondary]">
               Come trattiamo i tuoi dati
             </p>
           </div>
@@ -81,21 +81,21 @@ export function PrivacyPolicy({ onBack }: PrivacyPolicyProps) {
 
         {/* Highlights */}
         <div className="flex flex-col gap-2">
-          <p className="text-[11px] font-semibold uppercase tracking-widest text-[#b8b2b3]/60 px-1">
+          <p className="text-[11px] font-semibold uppercase tracking-widest text-[--color-text-secondary]/60 px-1">
             In sintesi
           </p>
           <div className="grid grid-cols-2 gap-2">
             {highlights.map(({ icon: Icon, title, desc }) => (
               <div
                 key={title}
-                className="bg-[#1a1617] rounded-[14px] p-3.5 flex flex-col gap-2"
+                className="bg-[--color-bg-surface] rounded-[14px] p-3.5 flex flex-col gap-2"
               >
-                <div className="flex items-center justify-center size-[32px] rounded-[9px] bg-[#f4bf4f]/10">
-                  <Icon size={16} className="text-[#f4bf4f]" />
+                <div className="flex items-center justify-center size-[32px] rounded-[9px] bg-[--color-gold-400]/10">
+                  <Icon size={16} className="text-[--color-gold-400]" />
                 </div>
                 <div>
-                  <p className="text-[13px] font-semibold text-[#f5f5f5] leading-[18px]">{title}</p>
-                  <p className="text-[12px] leading-[17px] text-[#b8b2b3] mt-0.5">{desc}</p>
+                  <p className="text-[13px] font-semibold text-[--color-text-primary] leading-[18px]">{title}</p>
+                  <p className="text-[12px] leading-[17px] text-[--color-text-secondary] mt-0.5">{desc}</p>
                 </div>
               </div>
             ))}
@@ -104,15 +104,15 @@ export function PrivacyPolicy({ onBack }: PrivacyPolicyProps) {
 
         {/* Full document */}
         <div className="flex flex-col gap-3">
-          <p className="text-[11px] font-semibold uppercase tracking-widest text-[#b8b2b3]/60 px-1">
+          <p className="text-[11px] font-semibold uppercase tracking-widest text-[--color-text-secondary]/60 px-1">
             Documento completo
           </p>
-          <div className="bg-[#1a1617] rounded-[16px] overflow-hidden">
+          <div className="bg-[--color-bg-surface] rounded-[16px] overflow-hidden">
             <div className="flex items-center gap-2.5 px-4 py-3 border-b border-white/[0.06]">
-              <FileText size={15} className="text-[#f4bf4f]" />
-              <p className="text-[13px] text-[#b8b2b3]">
+              <FileText size={15} className="text-[--color-gold-400]" />
+              <p className="text-[13px] text-[--color-text-secondary]">
                 Pubblicata e mantenuta tramite{' '}
-                <span className="text-[#f5f5f5] font-medium">Iubenda</span>
+                <span className="text-[--color-text-primary] font-medium">Iubenda</span>
               </p>
             </div>
             {isOnline ? (
@@ -130,15 +130,15 @@ export function PrivacyPolicy({ onBack }: PrivacyPolicyProps) {
                   />
                 </div>
                 <div className="px-4 pb-3">
-                  <p className="text-[11px] leading-[16px] text-[#b8b2b3]/50">
+                  <p className="text-[11px] leading-[16px] text-[--color-text-secondary]/50">
                     Richiesta connessione internet per caricare il documento.
                   </p>
                 </div>
               </>
             ) : (
               <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
-                <WifiOff size={32} className="text-[#b8b2b3]/50" />
-                <p className="text-sm text-[#b8b2b3]">
+                <WifiOff size={32} className="text-[--color-text-secondary]/50" />
+                <p className="text-sm text-[--color-text-secondary]">
                   La privacy policy completa non è disponibile offline. Connettiti a internet per visualizzarla.
                 </p>
               </div>

--- a/apps/mobile/src/components/screens/Profile.tsx
+++ b/apps/mobile/src/components/screens/Profile.tsx
@@ -92,9 +92,13 @@ export function Profile({
             onClick={onSettings}
           />
 
-          <button type="button" onClick={onLogout}
-            className="flex items-center justify-center gap-2 h-11 rounded-xl text-[15px] font-medium text-[#ff4d4f]/80 hover:text-[#ff4d4f] transition-colors">
-            <LogOut size={20} /> Esci
+          <button
+            type="button"
+            onClick={onLogout}
+            aria-label="Disconnetti dal profilo"
+            className="flex items-center justify-center gap-2 h-11 rounded-xl text-[15px] font-medium text-[--color-error]/80 hover:text-[--color-error] transition-colors"
+          >
+            <LogOut aria-hidden="true" size={20} /> Esci
           </button>
         </div>
       </div>
@@ -138,25 +142,36 @@ function ProfileAvatar({
 
   return (
     <div className="relative flex flex-col items-center gap-3 pt-8 pb-5 px-6">
-      <div className="absolute inset-x-0 top-0 h-32 bg-gradient-to-b from-[#1f1719] to-transparent pointer-events-none" />
+      <div className="absolute inset-x-0 top-0 h-32 bg-gradient-to-b from-[--color-bg-surface] to-transparent pointer-events-none" />
       <div className="relative">
-        <div className="bg-gradient-to-b from-[#a82847] to-[#6b1529] rounded-full shadow-[0_8px_24px_rgba(168,40,71,0.35)] size-[88px] flex items-center justify-center overflow-hidden ring-2 ring-[#a82847]/30">
+        <div className="bg-gradient-to-b from-[--color-burgundy-600] to-[--color-burgundy-800] rounded-full shadow-[0_8px_24px_rgba(168,40,71,0.35)] size-[88px] flex items-center justify-center overflow-hidden ring-2 ring-[--color-burgundy-600]/30">
           {profileImage ? (
             <img src={profileImage} alt="Profilo" className="w-full h-full object-cover" />
           ) : (
-            <User className="text-[#f4bf4f]" size={44} />
+            <User className="text-[--color-gold-400]" size={44} />
           )}
         </div>
-        <button type="button" onClick={() => fileInputRef.current?.click()} disabled={isUploading}
-          aria-label="Carica immagine profilo"
-          className="absolute bottom-0 right-0 bg-[#f4bf4f] rounded-full p-1.5 shadow-lg disabled:opacity-50 ring-2 ring-[#0f0d0e]">
-          <Camera className="text-[#0f0d0e]" size={14} aria-hidden="true" />
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={isUploading}
+          aria-label={isUploading ? 'Caricamento immagine in corso' : 'Carica immagine profilo'}
+          className="absolute bottom-0 right-0 bg-[--color-gold-400] rounded-full p-1.5 shadow-lg disabled:opacity-50 ring-2 ring-[--color-bg-primary]"
+        >
+          <Camera aria-hidden="true" className="text-[--color-bg-primary]" size={14} />
         </button>
-        <input ref={fileInputRef} type="file" accept="image/*" onChange={handleFileChange} className="hidden" />
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          onChange={handleFileChange}
+          className="hidden"
+          aria-label="Seleziona immagine profilo"
+        />
       </div>
       <div className="flex flex-col items-center gap-0.5">
         <p className="text-xl font-bold tracking-tight text-white text-center">{userName || 'Utente'}</p>
-        <p className="text-sm text-[#f4bf4f] text-center">{roleLabel}</p>
+        <p className="text-sm text-[--color-gold-400] text-center">{roleLabel}</p>
         {uploadError && (
           <p className="text-xs text-[#ff4d4f] text-center mt-1">{uploadError}</p>
         )}
@@ -174,36 +189,41 @@ function StatsCard({
   const [showTokenInfo, setShowTokenInfo] = useState(false);
 
   return (
-    <div className="bg-[#1a1617] rounded-2xl overflow-hidden border border-[#2d2728]">
+    <div className="bg-[--color-bg-surface] rounded-2xl overflow-hidden border border-[--color-bg-surface-hover]">
       <SectionHeader>Statistiche generali</SectionHeader>
-      <div className="divide-y divide-[#241f20]">
+      <div className="divide-y divide-[--color-bg-surface-elevated]">
         <StatRow label="Livello" value={level} />
         <StatRow label="XP totale" value={xpTotal} />
         <StatRow label="Cachet accumulato" value={cachet} />
         <div className="flex items-center justify-between px-4 py-3">
-          <span className="flex items-center gap-1.5 text-sm text-[#b8b2b3]">
+          <span className="flex items-center gap-1.5 text-sm text-[--color-text-secondary]">
             Token ATCL (premium)
-            <button type="button" onClick={() => setShowTokenInfo(v => !v)}
-              className="text-[#9a9697] hover:text-[#b8b2b3] transition-colors" aria-label="Informazioni valute">
-              <Info size={13} />
+            <button
+              type="button"
+              onClick={() => setShowTokenInfo(v => !v)}
+              className="text-[--color-text-tertiary] hover:text-[--color-text-secondary] transition-colors"
+              aria-label="Mostra informazioni sulle valute di gioco"
+              aria-expanded={showTokenInfo}
+            >
+              <Info aria-hidden="true" size={13} />
             </button>
           </span>
-          <span className="text-sm font-semibold text-[#f4bf4f]">{tokenAtcl}</span>
+          <span className="text-sm font-semibold text-[--color-gold-400]" aria-label={`Token ATCL: ${tokenAtcl}`}>{tokenAtcl}</span>
         </div>
         {showTokenInfo && (
-          <div className="px-4 py-3 bg-[#241f20]">
-            <p className="text-xs text-[#b8b2b3]">Cachet = valuta base di gioco. Token ATCL = boost e futuri riscatti.</p>
+          <div className="px-4 py-3 bg-[--color-bg-surface-elevated]">
+            <p className="text-xs text-[--color-text-secondary]">Cachet = valuta base di gioco. Token ATCL = boost e futuri riscatti.</p>
           </div>
         )}
         <div className="flex flex-col gap-2 px-4 py-3">
-          <div className="flex items-center justify-between text-sm text-[#b8b2b3]">
+          <div className="flex items-center justify-between text-sm text-[--color-text-secondary]">
             <span className="flex items-center gap-2"><Theater size={13} /> XP sul campo (eventi ATCL)</span>
-            <span className="font-semibold text-[#f4bf4f]">{xpSulCampo}</span>
+            <span className="font-semibold text-[--color-gold-400]">{xpSulCampo}</span>
           </div>
           <ProgressBar value={xpSulCampo} max={safeXpTotal} color="gold" size="md" />
         </div>
         <div className="flex flex-col gap-2 px-4 py-3">
-          <div className="flex items-center justify-between text-sm text-[#b8b2b3]">
+          <div className="flex items-center justify-between text-sm text-[--color-text-secondary]">
             <span>Reputazione ATCL globale</span>
             <span className="font-semibold text-white">{reputationGlobal}/100</span>
           </div>
@@ -221,13 +241,13 @@ function TheatreReputationCard({
   loading: boolean;
 }) {
   return (
-    <div className="bg-[#1a1617] rounded-2xl overflow-hidden border border-[#2d2728]">
+    <div className="bg-[--color-bg-surface] rounded-2xl overflow-hidden border border-[--color-bg-surface-hover]">
       <SectionHeader>Reputazione per teatro</SectionHeader>
-      {loading && <p className="px-4 py-3 text-sm text-[#b8b2b3]">Caricamento...</p>}
-      <div className="divide-y divide-[#241f20]">
+      {loading && <p className="px-4 py-3 text-sm text-[--color-text-secondary]">Caricamento...</p>}
+      <div className="divide-y divide-[--color-bg-surface-elevated]">
         {theatreReputation.map(theatre => (
           <div key={theatre.name} className="flex flex-col gap-2 px-4 py-3">
-            <div className="flex items-center justify-between text-sm text-[#b8b2b3]">
+            <div className="flex items-center justify-between text-sm text-[--color-text-secondary]">
               <span>{theatre.name}</span>
               <span className="font-semibold text-white">{theatre.reputation}/100</span>
             </div>
@@ -246,25 +266,36 @@ function BadgesButton({
   newBadgesCount: number;
   onClick: () => void;
 }) {
+  const badgeLabel = newBadgesCount > 0
+    ? `Titoli ottenuti: ${badgesUnlockedCount} badge sbloccati, ${newBadgesCount} nuovi`
+    : `Titoli ottenuti: ${badgesUnlockedCount} badge sbloccati`;
+
   return (
-    <button type="button" onClick={onClick}
-      className="bg-[#1a1617] border border-[#2d2728] rounded-2xl px-4 py-3 flex items-center justify-between active:bg-[#241f20] transition-colors">
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={badgeLabel}
+      className="bg-[--color-bg-surface] border border-[--color-bg-surface-hover] rounded-2xl px-4 py-3 flex items-center justify-between active:bg-[--color-bg-surface-elevated] transition-colors"
+    >
       <div className="flex items-center gap-3">
-        <div className="bg-gradient-to-b from-[#e6a23c] to-[#f4bf4f] rounded-xl size-10 flex items-center justify-center flex-shrink-0">
-          <Award className="text-[#0f0d0e]" size={20} />
+        <div aria-hidden="true" className="bg-gradient-to-b from-[--color-gold-500] to-[--color-gold-400] rounded-xl size-10 flex items-center justify-center flex-shrink-0">
+          <Award className="text-[--color-bg-primary]" size={20} />
         </div>
         <div className="flex flex-col items-start">
           <p className="text-base font-semibold text-white !m-0">Titoli ottenuti</p>
-          <p className="text-[13px] text-[#9a9697] !m-0">{badgesUnlockedCount} badge sbloccati</p>
+          <p className="text-[13px] text-[--color-text-tertiary] !m-0">{badgesUnlockedCount} badge sbloccati</p>
         </div>
       </div>
       <div className="flex items-center gap-2">
         {newBadgesCount > 0 && (
-          <span className="bg-gradient-to-b from-[#e6a23c] to-[#f4bf4f] rounded-full size-[18px] flex items-center justify-center text-[11px] font-bold text-[#0f0d0e]">
+          <span
+            aria-hidden="true"
+            className="bg-gradient-to-b from-[--color-gold-500] to-[--color-gold-400] rounded-full size-[18px] flex items-center justify-center text-[11px] font-bold text-[--color-bg-primary]"
+          >
             {newBadgesCount}
           </span>
         )}
-        <ChevronRight className="text-[#6a6566]" size={18} />
+        <ChevronRight aria-hidden="true" className="text-[--color-text-tertiary]" size={18} />
       </div>
     </button>
   );
@@ -279,19 +310,28 @@ function ProfileMenuButton({
   onClick: () => void;
   gradient?: boolean;
 }) {
+  const buttonLabel = subtitle ? `${label}: ${subtitle}` : label;
+
   return (
-    <button type="button" onClick={onClick}
-      className="w-full bg-[#1a1617] border border-[#2d2728] rounded-2xl flex items-center gap-3 px-4 py-3 active:bg-[#241f20] transition-colors">
-      <div className={`rounded-xl size-10 flex items-center justify-center flex-shrink-0 ${
-        gradient ? 'bg-gradient-to-b from-[#a82847] to-[#6b1529]' : ''
-      }`}>
-        <Icon className="text-[#f4bf4f]" size={gradient ? 20 : 22} />
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={buttonLabel}
+      className="w-full bg-[--color-bg-surface] border border-[--color-bg-surface-hover] rounded-2xl flex items-center gap-3 px-4 py-3 active:bg-[--color-bg-surface-elevated] transition-colors"
+    >
+      <div
+        aria-hidden="true"
+        className={`rounded-xl size-10 flex items-center justify-center flex-shrink-0 ${
+          gradient ? 'bg-gradient-to-b from-[--color-burgundy-600] to-[--color-burgundy-800]' : ''
+        }`}
+      >
+        <Icon className="text-[--color-gold-400]" size={gradient ? 20 : 22} />
       </div>
       <div className="flex-1 text-left">
         <p className="text-base font-medium text-white !m-0">{label}</p>
-        {subtitle && <p className="text-[13px] text-[#9a9697] !m-0">{subtitle}</p>}
+        {subtitle && <p className="text-[13px] text-[--color-text-tertiary] !m-0">{subtitle}</p>}
       </div>
-      <ChevronRight className="text-[#6a6566]" size={18} />
+      <ChevronRight aria-hidden="true" className="text-[--color-text-tertiary]" size={18} />
     </button>
   );
 }
@@ -299,8 +339,8 @@ function ProfileMenuButton({
 // Shared helpers
 function SectionHeader({ children }: { children: React.ReactNode }) {
   return (
-    <div className="px-4 py-3 border-b border-[#2d2728]">
-      <p className="text-sm font-semibold text-[#9a9697] uppercase tracking-[0.1em]">{children}</p>
+    <div className="px-4 py-3 border-b border-[--color-bg-surface-hover]">
+      <p className="text-sm font-semibold text-[--color-text-tertiary] uppercase tracking-[0.1em]">{children}</p>
     </div>
   );
 }

--- a/apps/mobile/src/components/screens/Profile.tsx
+++ b/apps/mobile/src/components/screens/Profile.tsx
@@ -348,7 +348,7 @@ function SectionHeader({ children }: { children: React.ReactNode }) {
 function StatRow({ label, value }: { label: string; value: number | string }) {
   return (
     <div className="flex items-center justify-between px-4 py-3">
-      <span className="text-sm text-[#b8b2b3]">{label}</span>
+      <span className="text-sm text-[--color-text-secondary]">{label}</span>
       <span className="text-sm font-semibold text-white">{value}</span>
     </div>
   );

--- a/apps/mobile/src/components/screens/PublicProfile.tsx
+++ b/apps/mobile/src/components/screens/PublicProfile.tsx
@@ -45,7 +45,7 @@ export function PublicProfile({
             type="button"
             onClick={onBack}
             aria-label="Torna alla classifica"
-            className="inline-flex items-center gap-[8px] text-[14px] leading-[20px] text-[#b8b2b3] hover:text-white"
+            className="inline-flex items-center gap-[8px] text-[14px] leading-[20px] text-[--color-text-secondary] hover:text-white"
           >
             <ArrowLeft aria-hidden="true" size={16} />
             Torna alla classifica
@@ -53,7 +53,7 @@ export function PublicProfile({
         </div>
 
         <div className="flex items-center px-[25px] gap-[16px]">
-          <div className="bg-gradient-to-b from-[#a82847] to-[#6b1529] rounded-full shadow-[0px_10px_15px_-3px_rgba(0,0,0,0.1),0px_4px_6px_-4px_rgba(0,0,0,0.1)] size-[96px] flex items-center justify-center overflow-hidden">
+          <div className="bg-gradient-to-b from-[--color-burgundy-600] to-[--color-burgundy-800] rounded-full shadow-[0px_10px_15px_-3px_rgba(0,0,0,0.1),0px_4px_6px_-4px_rgba(0,0,0,0.1)] size-[96px] flex items-center justify-center overflow-hidden">
             {profileImage ? (
               <img
                 src={profileImage}
@@ -61,14 +61,14 @@ export function PublicProfile({
                 className="w-full h-full object-cover"
               />
             ) : (
-              <span className="text-[#f4bf4f] text-[34px] leading-none font-semibold">{initial}</span>
+              <span className="text-[--color-gold-400] text-[34px] leading-none font-semibold">{initial}</span>
             )}
           </div>
           <div className="min-w-0 flex-1 flex flex-col gap-[6px]">
             <p className="text-[24px] leading-[31.2px] font-bold tracking-[-0.24px] text-white truncate !m-0">
               {userName || 'Utente'}
             </p>
-            <p className="text-[16px] leading-[25.6px] text-[#f4bf4f] truncate !m-0">
+            <p className="text-[16px] leading-[25.6px] text-[--color-gold-400] truncate !m-0">
               {userRole || 'Ruolo'}
             </p>
           </div>
@@ -81,7 +81,7 @@ export function PublicProfile({
                 <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">
                   Progressione
                 </p>
-                <p className="text-[14px] leading-[20px] text-[#b8b2b3] !m-0">
+                <p className="text-[14px] leading-[20px] text-[--color-text-secondary] !m-0">
                   Una panoramica rapida del percorso ATCL.
                 </p>
               </div>
@@ -91,9 +91,9 @@ export function PublicProfile({
             <dl className="grid grid-cols-2 gap-[12px] m-0" aria-label="Statistiche del profilo">
               <div
                 aria-label={`XP totale: ${xpTotal}`}
-                className="rounded-[12px] bg-[#241f20] p-[12px] flex flex-col gap-[8px]"
+                className="rounded-[12px] bg-[--color-bg-surface-elevated] p-[12px] flex flex-col gap-[8px]"
               >
-                <dt className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[#b8b2b3]">
+                <dt className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[--color-text-secondary]">
                   <Trophy aria-hidden="true" size={14} />
                   XP totale
                 </dt>
@@ -101,9 +101,9 @@ export function PublicProfile({
               </div>
               <div
                 aria-label={`Cachet: ${cachet}`}
-                className="rounded-[12px] bg-[#241f20] p-[12px] flex flex-col gap-[8px]"
+                className="rounded-[12px] bg-[--color-bg-surface-elevated] p-[12px] flex flex-col gap-[8px]"
               >
-                <dt className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[#b8b2b3]">
+                <dt className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[--color-text-secondary]">
                   <Coins aria-hidden="true" size={14} />
                   Cachet
                 </dt>
@@ -111,9 +111,9 @@ export function PublicProfile({
               </div>
               <div
                 aria-label={`Reputazione: ${reputation} su 100`}
-                className="rounded-[12px] bg-[#241f20] p-[12px] flex flex-col gap-[8px]"
+                className="rounded-[12px] bg-[--color-bg-surface-elevated] p-[12px] flex flex-col gap-[8px]"
               >
-                <dt className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[#b8b2b3]">
+                <dt className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[--color-text-secondary]">
                   <Shield aria-hidden="true" size={14} />
                   Reputazione
                 </dt>
@@ -121,9 +121,9 @@ export function PublicProfile({
               </div>
               <div
                 aria-label={`Presenze: ${turnsCount} turni`}
-                className="rounded-[12px] bg-[#241f20] p-[12px] flex flex-col gap-[8px]"
+                className="rounded-[12px] bg-[--color-bg-surface-elevated] p-[12px] flex flex-col gap-[8px]"
               >
-                <dt className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[#b8b2b3]">
+                <dt className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[--color-text-secondary]">
                   <Users aria-hidden="true" size={14} />
                   Presenze
                 </dt>
@@ -132,7 +132,7 @@ export function PublicProfile({
             </dl>
 
             <div className="flex flex-col gap-[6px]">
-              <div className="flex items-center justify-between text-[14px] leading-[20px] text-[#b8b2b3]">
+              <div className="flex items-center justify-between text-[14px] leading-[20px] text-[--color-text-secondary]">
                 <span className="inline-flex items-center gap-[8px]">
                   <Sparkles size={14} />
                   Reputazione ATCL
@@ -151,23 +151,23 @@ export function PublicProfile({
                 <p className="text-[18px] leading-[25.2px] font-semibold text-white !m-0">
                   Teatri frequentati
                 </p>
-                <p className="text-[14px] leading-[20px] text-[#b8b2b3] !m-0">
+                <p className="text-[14px] leading-[20px] text-[--color-text-secondary] !m-0">
                   Le venue in cui questo profilo ha gia lavorato.
                 </p>
               </div>
-              <div className="bg-[#241f20] rounded-[12px] size-[40px] flex items-center justify-center">
-                <Theater className="text-[#f4bf4f]" size={18} />
+              <div className="bg-[--color-bg-surface-elevated] rounded-[12px] size-[40px] flex items-center justify-center">
+                <Theater className="text-[--color-gold-400]" size={18} />
               </div>
             </div>
 
             {theatresLoading ? (
-              <p className="text-[14px] leading-[20px] text-[#b8b2b3] !m-0">Caricamento...</p>
+              <p className="text-[14px] leading-[20px] text-[--color-text-secondary] !m-0">Caricamento...</p>
             ) : theatres.length > 0 ? (
               <div className="flex flex-col gap-[10px]">
                 {theatres.map((item) => (
                   <div
                     key={item.theatre}
-                    className="flex items-center justify-between gap-[12px] rounded-[12px] bg-[#241f20] px-[12px] py-[10px]"
+                    className="flex items-center justify-between gap-[12px] rounded-[12px] bg-[--color-bg-surface-elevated] px-[12px] py-[10px]"
                   >
                     <span className="text-[15px] leading-[20px] text-white">{item.theatre}</span>
                     <Tag size="sm">{item.turnsCount} turni</Tag>
@@ -175,7 +175,7 @@ export function PublicProfile({
                 ))}
               </div>
             ) : (
-              <p className="text-[14px] leading-[20px] text-[#b8b2b3] !m-0">
+              <p className="text-[14px] leading-[20px] text-[--color-text-secondary] !m-0">
                 Nessun teatro registrato per questo profilo.
               </p>
             )}

--- a/apps/mobile/src/components/screens/PublicProfile.tsx
+++ b/apps/mobile/src/components/screens/PublicProfile.tsx
@@ -44,9 +44,10 @@ export function PublicProfile({
           <button
             type="button"
             onClick={onBack}
+            aria-label="Torna alla classifica"
             className="inline-flex items-center gap-[8px] text-[14px] leading-[20px] text-[#b8b2b3] hover:text-white"
           >
-            <ArrowLeft size={16} />
+            <ArrowLeft aria-hidden="true" size={16} />
             Torna alla classifica
           </button>
         </div>
@@ -87,36 +88,48 @@ export function PublicProfile({
               <Tag size="sm">{turnsCount} turni</Tag>
             </div>
 
-            <div className="grid grid-cols-2 gap-[12px]">
-              <div className="rounded-[12px] bg-[#241f20] p-[12px] flex flex-col gap-[8px]">
-                <span className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[#b8b2b3]">
-                  <Trophy size={14} />
+            <dl className="grid grid-cols-2 gap-[12px] m-0" aria-label="Statistiche del profilo">
+              <div
+                aria-label={`XP totale: ${xpTotal}`}
+                className="rounded-[12px] bg-[#241f20] p-[12px] flex flex-col gap-[8px]"
+              >
+                <dt className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[#b8b2b3]">
+                  <Trophy aria-hidden="true" size={14} />
                   XP totale
-                </span>
-                <span className="text-[24px] leading-[28px] font-semibold text-white">{xpTotal}</span>
+                </dt>
+                <dd className="text-[24px] leading-[28px] font-semibold text-white m-0">{xpTotal}</dd>
               </div>
-              <div className="rounded-[12px] bg-[#241f20] p-[12px] flex flex-col gap-[8px]">
-                <span className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[#b8b2b3]">
-                  <Coins size={14} />
+              <div
+                aria-label={`Cachet: ${cachet}`}
+                className="rounded-[12px] bg-[#241f20] p-[12px] flex flex-col gap-[8px]"
+              >
+                <dt className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[#b8b2b3]">
+                  <Coins aria-hidden="true" size={14} />
                   Cachet
-                </span>
-                <span className="text-[24px] leading-[28px] font-semibold text-white">{cachet}</span>
+                </dt>
+                <dd className="text-[24px] leading-[28px] font-semibold text-white m-0">{cachet}</dd>
               </div>
-              <div className="rounded-[12px] bg-[#241f20] p-[12px] flex flex-col gap-[8px]">
-                <span className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[#b8b2b3]">
-                  <Shield size={14} />
+              <div
+                aria-label={`Reputazione: ${reputation} su 100`}
+                className="rounded-[12px] bg-[#241f20] p-[12px] flex flex-col gap-[8px]"
+              >
+                <dt className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[#b8b2b3]">
+                  <Shield aria-hidden="true" size={14} />
                   Reputazione
-                </span>
-                <span className="text-[24px] leading-[28px] font-semibold text-white">{reputation}/100</span>
+                </dt>
+                <dd className="text-[24px] leading-[28px] font-semibold text-white m-0">{reputation}/100</dd>
               </div>
-              <div className="rounded-[12px] bg-[#241f20] p-[12px] flex flex-col gap-[8px]">
-                <span className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[#b8b2b3]">
-                  <Users size={14} />
+              <div
+                aria-label={`Presenze: ${turnsCount} turni`}
+                className="rounded-[12px] bg-[#241f20] p-[12px] flex flex-col gap-[8px]"
+              >
+                <dt className="inline-flex items-center gap-[8px] text-[13px] leading-[18px] text-[#b8b2b3]">
+                  <Users aria-hidden="true" size={14} />
                   Presenze
-                </span>
-                <span className="text-[24px] leading-[28px] font-semibold text-white">{turnsCount}</span>
+                </dt>
+                <dd className="text-[24px] leading-[28px] font-semibold text-white m-0">{turnsCount}</dd>
               </div>
-            </div>
+            </dl>
 
             <div className="flex flex-col gap-[6px]">
               <div className="flex items-center justify-between text-[14px] leading-[20px] text-[#b8b2b3]">

--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -185,9 +185,13 @@ function ScannerHeader({ onClose, isScanning }: { onClose: () => void; isScannin
   return (
     <div className="flex items-center justify-between p-4 bg-[color:var(--qrscanner-header-bg)]">
       <h3 className="text-white">{isScanning ? 'Scansiona Biglietto' : 'Registra Biglietto'}</h3>
-      <button onClick={onClose}
-        className="flex items-center justify-center size-[44px] hover:bg-[color:var(--qrscanner-header-hover-bg)] rounded-lg transition-colors">
-        <X className="text-[color:var(--qrscanner-accent)]" size={24} />
+      <button
+        onClick={onClose}
+        type="button"
+        aria-label="Chiudi scanner biglietti"
+        className="flex items-center justify-center size-[44px] hover:bg-[color:var(--qrscanner-header-hover-bg)] rounded-lg transition-colors"
+      >
+        <X aria-hidden="true" className="text-[color:var(--qrscanner-accent)]" size={24} />
       </button>
     </div>
   );
@@ -202,17 +206,28 @@ function CameraView({ videoRef, canvasRef, isStartingCamera, isHandlingScan, sca
 }) {
   return (
     <>
-      <div className="absolute inset-0 bg-black">
-        <video ref={videoRef} className="absolute inset-0 h-full w-full object-cover" playsInline autoPlay muted />
-        <canvas ref={canvasRef} className="hidden" />
-        <div className="absolute inset-0 bg-gradient-to-b from-[#1a1617]/60 to-[#0f0d0e]/80" />
+      <div
+        className="absolute inset-0 bg-black"
+        role="region"
+        aria-label="Area di scansione QR del biglietto"
+      >
+        <video
+          ref={videoRef}
+          className="absolute inset-0 h-full w-full object-cover"
+          playsInline
+          autoPlay
+          muted
+          aria-label="Anteprima fotocamera per scansione biglietto"
+        />
+        <canvas ref={canvasRef} className="hidden" aria-hidden="true" />
+        <div aria-hidden="true" className="absolute inset-0 bg-gradient-to-b from-[#1a1617]/60 to-[#0f0d0e]/80" />
         <ScanningFrame />
         {isStartingCamera && <Overlay text="Avvio fotocamera..." />}
         {isHandlingScan && <Overlay text="Verifica biglietto..." />}
       </div>
 
       <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-[#0f0d0e] to-transparent p-6">
-        <div className="app-content text-center">
+        <div className="app-content text-center" aria-live="polite" aria-atomic="true">
           {scanError && (
             <>
               <p className="text-white mb-2">Biglietto non valido</p>
@@ -243,7 +258,7 @@ function CameraView({ videoRef, canvasRef, isStartingCamera, isHandlingScan, sca
 
 function ScanningFrame() {
   return (
-    <div className="absolute inset-0 flex items-center justify-center">
+    <div aria-hidden="true" className="absolute inset-0 flex items-center justify-center">
       <div className="relative w-64 h-64">
         <div className="absolute top-0 left-0 w-12 h-12 border-t-4 border-l-4 border-[#f4bf4f] rounded-tl-lg" />
         <div className="absolute top-0 right-0 w-12 h-12 border-t-4 border-r-4 border-[#f4bf4f] rounded-tr-lg" />
@@ -259,7 +274,11 @@ function ScanningFrame() {
 
 function Overlay({ text }: { text: string }) {
   return (
-    <div className="absolute inset-0 flex items-center justify-center bg-[#0f0d0e]/60">
+    <div
+      role="status"
+      aria-live="polite"
+      className="absolute inset-0 flex items-center justify-center bg-[#0f0d0e]/60"
+    >
       <p className="text-sm text-[#b8b2b3]">{text}</p>
     </div>
   );
@@ -267,9 +286,13 @@ function Overlay({ text }: { text: string }) {
 
 function ManualSwitchButton({ onClick }: { onClick: () => void }) {
   return (
-    <button onClick={onClick}
-      className="inline-flex items-center justify-center gap-2 rounded-md px-2 py-[10px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors">
-      <Ticket size={16} />
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Inserisci manualmente il numero del biglietto"
+      className="inline-flex items-center justify-center gap-2 rounded-md px-2 py-[10px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
+    >
+      <Ticket aria-hidden="true" size={16} />
       Inserisci numero biglietto
     </button>
   );
@@ -298,30 +321,48 @@ function ManualEntryForm({ manualTicket, manualEventId, events, scanError, isHan
       </div>
 
       {scanError && (
-        <div className="mb-4 rounded-xl border border-[#d32f2f]/30 bg-[#d32f2f]/10 px-4 py-3 text-center">
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="mb-4 rounded-xl border border-[#d32f2f]/30 bg-[#d32f2f]/10 px-4 py-3 text-center"
+        >
           <p className="text-[#ff5252] text-xs">{scanError}</p>
         </div>
       )}
 
-      <form onSubmit={onSubmit} className="space-y-4">
+      <form onSubmit={onSubmit} className="space-y-4" aria-label="Attivazione manuale biglietto">
         <div className="space-y-4">
           <div className="space-y-2">
-            <label className="text-xs text-[#7f797a] ml-1 uppercase font-bold tracking-wider">Seleziona Evento</label>
+            <label htmlFor="qr-manual-event" className="text-xs text-[#7f797a] ml-1 uppercase font-bold tracking-wider">Seleziona Evento</label>
             <div className="relative">
-              <select value={manualEventId} onChange={e => onEventChange(e.target.value)}
-                className="w-full bg-[#1a1617] border border-[#2d2728] rounded-xl px-4 py-3 text-sm text-white appearance-none focus:outline-none focus:border-[#f4bf4f] transition-colors">
+              <select
+                id="qr-manual-event"
+                value={manualEventId}
+                onChange={e => onEventChange(e.target.value)}
+                className="w-full bg-[#1a1617] border border-[#2d2728] rounded-xl px-4 py-3 text-sm text-white appearance-none focus:outline-none focus:border-[#f4bf4f] transition-colors"
+              >
                 <option value="" disabled>Scegli l'evento...</option>
                 {events.map(ev => <option key={ev.id} value={ev.id}>{ev.name} ({ev.date})</option>)}
               </select>
-              <div className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-[#f4bf4f]">
+              <div aria-hidden="true" className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-[#f4bf4f]">
                 <X size={14} className="rotate-45" />
               </div>
             </div>
           </div>
           <div className="space-y-2">
-            <label className="text-xs text-[#7f797a] ml-1 uppercase font-bold tracking-wider">Numero Biglietto</label>
-            <Input type="text" placeholder="es. 12345" value={manualTicket} onChange={e => onTicketChange(e.target.value)} className="text-center" />
-            <p className="text-[10px] text-[#7f797a] text-center px-2 italic">Il biglietto deve essere stato pre-registrato dalla biglietteria autorizzata</p>
+            <label htmlFor="qr-manual-ticket" className="text-xs text-[#7f797a] ml-1 uppercase font-bold tracking-wider">Numero Biglietto</label>
+            <Input
+              id="qr-manual-ticket"
+              type="text"
+              placeholder="es. 12345"
+              value={manualTicket}
+              onChange={e => onTicketChange(e.target.value)}
+              className="text-center"
+              aria-describedby="qr-manual-ticket-help"
+            />
+            <p id="qr-manual-ticket-help" className="text-[10px] text-[#7f797a] text-center px-2 italic">
+              Il biglietto deve essere stato pre-registrato dalla biglietteria autorizzata
+            </p>
           </div>
         </div>
 
@@ -329,9 +370,13 @@ function ManualEntryForm({ manualTicket, manualEventId, events, scanError, isHan
           <Button type="submit" variant="primary" size="lg" fullWidth disabled={isHandlingScan}>
             {isHandlingScan ? 'Verifica in corso...' : 'Attiva biglietto'}
           </Button>
-          <button type="button" onClick={onSwitchToScanner}
-            className="w-full inline-flex items-center justify-center gap-2 rounded-md py-[10px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors">
-            <Camera size={16} />
+          <button
+            type="button"
+            onClick={onSwitchToScanner}
+            aria-label="Passa alla scansione con fotocamera"
+            className="w-full inline-flex items-center justify-center gap-2 rounded-md py-[10px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
+          >
+            <Camera aria-hidden="true" size={16} />
             Usa la fotocamera
           </button>
         </div>

--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -146,7 +146,7 @@ export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
 
   return (
     <div className="fixed inset-0 app-gradient z-50 flex flex-col"
-      style={{ '--qrscanner-header-bg': '#1a1617', '--qrscanner-header-hover-bg': '#241f20', '--qrscanner-accent': '#f4bf4f' } as React.CSSProperties}>
+      style={{ '--qrscanner-header-bg': 'var(--color-bg-surface)', '--qrscanner-header-hover-bg': 'var(--color-bg-surface-elevated)', '--qrscanner-accent': 'var(--color-gold-400)' } as React.CSSProperties}>
       <ScannerHeader onClose={onClose} isScanning={isScanning} />
 
       <div className="flex-1 relative overflow-hidden">
@@ -220,24 +220,24 @@ function CameraView({ videoRef, canvasRef, isStartingCamera, isHandlingScan, sca
           aria-label="Anteprima fotocamera per scansione biglietto"
         />
         <canvas ref={canvasRef} className="hidden" aria-hidden="true" />
-        <div aria-hidden="true" className="absolute inset-0 bg-gradient-to-b from-[#1a1617]/60 to-[#0f0d0e]/80" />
+        <div aria-hidden="true" className="absolute inset-0 bg-gradient-to-b from-[--color-bg-surface]/60 to-[--color-bg-primary]/80" />
         <ScanningFrame />
         {isStartingCamera && <Overlay text="Avvio fotocamera..." />}
         {isHandlingScan && <Overlay text="Verifica biglietto..." />}
       </div>
 
-      <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-[#0f0d0e] to-transparent p-6">
+      <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-[--color-bg-primary] to-transparent p-6">
         <div className="app-content text-center" aria-live="polite" aria-atomic="true">
           {scanError && (
             <>
               <p className="text-white mb-2">Biglietto non valido</p>
-              <p className="text-sm text-[#b8b2b3] mb-6">{scanError}</p>
+              <p className="text-sm text-[--color-text-secondary] mb-6">{scanError}</p>
             </>
           )}
           {cameraError ? (
             <>
               <p className="text-white mb-2">Impossibile avviare la fotocamera</p>
-              <p className="text-sm text-[#b8b2b3] mb-6">{cameraError}</p>
+              <p className="text-sm text-[--color-text-secondary] mb-6">{cameraError}</p>
               <div className="flex flex-col items-center gap-3">
                 <Button variant="primary" onClick={onRetryCamera} className="w-full max-w-xs">Riprova</Button>
                 <ManualSwitchButton onClick={onSwitchToManual} />
@@ -246,7 +246,7 @@ function CameraView({ videoRef, canvasRef, isStartingCamera, isHandlingScan, sca
           ) : (
             <>
               <p className="text-white mb-2">Inquadra il codice sul tuo biglietto ATCL</p>
-              <p className="text-sm text-[#b8b2b3] mb-6">Posiziona il codice al centro del riquadro</p>
+              <p className="text-sm text-[--color-text-secondary] mb-6">Posiziona il codice al centro del riquadro</p>
               <ManualSwitchButton onClick={onSwitchToManual} />
             </>
           )}
@@ -260,12 +260,12 @@ function ScanningFrame() {
   return (
     <div aria-hidden="true" className="absolute inset-0 flex items-center justify-center">
       <div className="relative w-64 h-64">
-        <div className="absolute top-0 left-0 w-12 h-12 border-t-4 border-l-4 border-[#f4bf4f] rounded-tl-lg" />
-        <div className="absolute top-0 right-0 w-12 h-12 border-t-4 border-r-4 border-[#f4bf4f] rounded-tr-lg" />
-        <div className="absolute bottom-0 left-0 w-12 h-12 border-b-4 border-l-4 border-[#f4bf4f] rounded-bl-lg" />
-        <div className="absolute bottom-0 right-0 w-12 h-12 border-b-4 border-r-4 border-[#f4bf4f] rounded-br-lg" />
+        <div className="absolute top-0 left-0 w-12 h-12 border-t-4 border-l-4 border-[--color-gold-400] rounded-tl-lg" />
+        <div className="absolute top-0 right-0 w-12 h-12 border-t-4 border-r-4 border-[--color-gold-400] rounded-tr-lg" />
+        <div className="absolute bottom-0 left-0 w-12 h-12 border-b-4 border-l-4 border-[--color-gold-400] rounded-bl-lg" />
+        <div className="absolute bottom-0 right-0 w-12 h-12 border-b-4 border-r-4 border-[--color-gold-400] rounded-br-lg" />
         <div className="absolute inset-0 flex items-center justify-center">
-          <div className="w-full h-1 bg-[#f4bf4f] animate-pulse" />
+          <div className="w-full h-1 bg-[--color-gold-400] animate-pulse" />
         </div>
       </div>
     </div>
@@ -277,9 +277,9 @@ function Overlay({ text }: { text: string }) {
     <div
       role="status"
       aria-live="polite"
-      className="absolute inset-0 flex items-center justify-center bg-[#0f0d0e]/60"
+      className="absolute inset-0 flex items-center justify-center bg-[--color-bg-primary]/60"
     >
-      <p className="text-sm text-[#b8b2b3]">{text}</p>
+      <p className="text-sm text-[--color-text-secondary]">{text}</p>
     </div>
   );
 }
@@ -290,7 +290,7 @@ function ManualSwitchButton({ onClick }: { onClick: () => void }) {
       type="button"
       onClick={onClick}
       aria-label="Inserisci manualmente il numero del biglietto"
-      className="inline-flex items-center justify-center gap-2 rounded-md px-2 py-[10px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
+      className="inline-flex items-center justify-center gap-2 rounded-md px-2 py-[10px] text-[--color-gold-400] hover:text-[--color-gold-500] transition-colors"
     >
       <Ticket aria-hidden="true" size={16} />
       Inserisci numero biglietto
@@ -307,15 +307,15 @@ function ManualEntryForm({ manualTicket, manualEventId, events, scanError, isHan
   return (
     <div className="p-6 app-content h-full overflow-y-auto pb-20">
       <div className="mb-6 text-center">
-        <div className="w-16 h-16 bg-[#241f20] rounded-full flex items-center justify-center mx-auto mb-4">
-          <Ticket className="text-[#f4bf4f]" size={32} />
+        <div className="w-16 h-16 bg-[--color-bg-surface-elevated] rounded-full flex items-center justify-center mx-auto mb-4">
+          <Ticket className="text-[--color-gold-400]" size={32} />
         </div>
         <h3 className="text-white mb-2">Attiva il tuo Biglietto</h3>
-        <p className="text-sm text-[#b8b2b3]">Inserisci il numero di biglietto pre-registrato</p>
+        <p className="text-sm text-[--color-text-secondary]">Inserisci il numero di biglietto pre-registrato</p>
       </div>
 
       <div className="mb-6 text-center">
-        <div className="inline-block px-3 py-1 bg-[#241f20] rounded-full text-[10px] text-[#f4bf4f] font-bold uppercase tracking-wider">
+        <div className="inline-block px-3 py-1 bg-[--color-bg-surface-elevated] rounded-full text-[10px] text-[--color-gold-400] font-bold uppercase tracking-wider">
           Attivazione Biglietto
         </div>
       </div>
@@ -324,33 +324,33 @@ function ManualEntryForm({ manualTicket, manualEventId, events, scanError, isHan
         <div
           role="alert"
           aria-live="assertive"
-          className="mb-4 rounded-xl border border-[#d32f2f]/30 bg-[#d32f2f]/10 px-4 py-3 text-center"
+          className="mb-4 rounded-xl border border-[--color-error]/30 bg-[--color-error]/10 px-4 py-3 text-center"
         >
-          <p className="text-[#ff5252] text-xs">{scanError}</p>
+          <p className="text-[--color-error] text-xs">{scanError}</p>
         </div>
       )}
 
       <form onSubmit={onSubmit} className="space-y-4" aria-label="Attivazione manuale biglietto">
         <div className="space-y-4">
           <div className="space-y-2">
-            <label htmlFor="qr-manual-event" className="text-xs text-[#7f797a] ml-1 uppercase font-bold tracking-wider">Seleziona Evento</label>
+            <label htmlFor="qr-manual-event" className="text-xs text-[--color-text-tertiary] ml-1 uppercase font-bold tracking-wider">Seleziona Evento</label>
             <div className="relative">
               <select
                 id="qr-manual-event"
                 value={manualEventId}
                 onChange={e => onEventChange(e.target.value)}
-                className="w-full bg-[#1a1617] border border-[#2d2728] rounded-xl px-4 py-3 text-sm text-white appearance-none focus:outline-none focus:border-[#f4bf4f] transition-colors"
+                className="w-full bg-[--color-bg-surface] border border-[--color-bg-surface-hover] rounded-xl px-4 py-3 text-sm text-white appearance-none focus:outline-none focus:border-[--color-gold-400] transition-colors"
               >
                 <option value="" disabled>Scegli l'evento...</option>
                 {events.map(ev => <option key={ev.id} value={ev.id}>{ev.name} ({ev.date})</option>)}
               </select>
-              <div aria-hidden="true" className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-[#f4bf4f]">
+              <div aria-hidden="true" className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-[--color-gold-400]">
                 <X size={14} className="rotate-45" />
               </div>
             </div>
           </div>
           <div className="space-y-2">
-            <label htmlFor="qr-manual-ticket" className="text-xs text-[#7f797a] ml-1 uppercase font-bold tracking-wider">Numero Biglietto</label>
+            <label htmlFor="qr-manual-ticket" className="text-xs text-[--color-text-tertiary] ml-1 uppercase font-bold tracking-wider">Numero Biglietto</label>
             <Input
               id="qr-manual-ticket"
               type="text"
@@ -360,7 +360,7 @@ function ManualEntryForm({ manualTicket, manualEventId, events, scanError, isHan
               className="text-center"
               aria-describedby="qr-manual-ticket-help"
             />
-            <p id="qr-manual-ticket-help" className="text-[10px] text-[#7f797a] text-center px-2 italic">
+            <p id="qr-manual-ticket-help" className="text-[10px] text-[--color-text-tertiary] text-center px-2 italic">
               Il biglietto deve essere stato pre-registrato dalla biglietteria autorizzata
             </p>
           </div>
@@ -374,7 +374,7 @@ function ManualEntryForm({ manualTicket, manualEventId, events, scanError, isHan
             type="button"
             onClick={onSwitchToScanner}
             aria-label="Passa alla scansione con fotocamera"
-            className="w-full inline-flex items-center justify-center gap-2 rounded-md py-[10px] text-[#f4bf4f] hover:text-[#e6a23c] transition-colors"
+            className="w-full inline-flex items-center justify-center gap-2 rounded-md py-[10px] text-[--color-gold-400] hover:text-[--color-gold-500] transition-colors"
           >
             <Camera aria-hidden="true" size={16} />
             Usa la fotocamera

--- a/apps/mobile/src/components/screens/RoleSelection.tsx
+++ b/apps/mobile/src/components/screens/RoleSelection.tsx
@@ -36,11 +36,11 @@ export function RoleSelection({ roles, showRoleJourney = true, onComplete }: Rol
       <Screen withBottomNavPadding={false}>
         <ScreenHeader gradient={false}>
           <div className="text-center">
-            <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-full mb-4">
-              <Star className="text-[#f4bf4f]" size={32} />
+            <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-[--color-burgundy-600] to-[--color-burgundy-800] rounded-full mb-4">
+              <Star className="text-[--color-gold-400]" size={32} />
             </div>
             <h2 className="mb-2">Scegli il tuo ruolo</h2>
-            <p className="text-[#b8b2b3]">Quale professione teatrale vuoi intraprendere?</p>
+            <p className="text-[--color-text-secondary]">Quale professione teatrale vuoi intraprendere?</p>
           </div>
         </ScreenHeader>
 
@@ -49,16 +49,16 @@ export function RoleSelection({ roles, showRoleJourney = true, onComplete }: Rol
             const Icon = roleIcons[role.id] ?? Users;
             return (
               <Card key={role.id} hoverable onClick={() => handleRoleSelect(role)} className="flex items-center gap-4">
-                <div className="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-xl flex items-center justify-center">
-                  <Icon className="text-[#f4bf4f]" size={24} />
+                <div className="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-[--color-burgundy-600] to-[--color-burgundy-800] rounded-xl flex items-center justify-center">
+                  <Icon className="text-[--color-gold-400]" size={24} />
                 </div>
 
                 <div className="flex-1 min-w-0">
                   <h4 className="mb-1 text-white">{role.name}</h4>
-                  <p className="text-xs text-[#9a9697]">{role.focus}</p>
+                  <p className="text-xs text-[--color-text-tertiary]">{role.focus}</p>
                 </div>
 
-                <ChevronRight className="text-[#9a9697] flex-shrink-0" size={20} />
+                <ChevronRight className="text-[--color-text-tertiary] flex-shrink-0" size={20} />
               </Card>
             );
           })}
@@ -80,35 +80,35 @@ export function RoleSelection({ roles, showRoleJourney = true, onComplete }: Rol
           <button
             type="button"
             onClick={() => setStep(1)}
-            className="flex items-center justify-center size-[44px] text-[#f4bf4f]"
+            className="flex items-center justify-center size-[44px] text-[--color-gold-400]"
             aria-label="Indietro"
           >
             <ArrowLeft size={24} />
           </button>
 
           <div className="mt-4 text-center mb-4">
-            <div className="inline-flex items-center justify-center w-20 h-20 bg-gradient-to-br from-[#a82847] to-[#6b1529] rounded-2xl mb-4 shadow-lg">
-              <Icon className="text-[#f4bf4f]" size={40} />
+            <div className="inline-flex items-center justify-center w-20 h-20 bg-gradient-to-br from-[--color-burgundy-600] to-[--color-burgundy-800] rounded-2xl mb-4 shadow-lg">
+              <Icon className="text-[--color-gold-400]" size={40} />
             </div>
             <h2 className="mb-3">{selectedRole.name}</h2>
-            <p className="text-[#b8b2b3] px-4">{selectedRole.focus}</p>
+            <p className="text-[--color-text-secondary] px-4">{selectedRole.focus}</p>
           </div>
 
           <Card className="mb-4">
-            <h4 className="mb-4 text-[#f4bf4f]">Caratteristiche principali</h4>
+            <h4 className="mb-4 text-[--color-gold-400]">Caratteristiche principali</h4>
 
             <div className="space-y-4">
               {Object.entries(selectedRole.stats).map(([key, value]) => (
                 <div key={key}>
                   <div className="flex justify-between mb-2">
-                    <span className="text-[#b8b2b3] capitalize">
+                    <span className="text-[--color-text-secondary] capitalize">
                       {key === 'presence' ? 'Presenza scenica' : key === 'precision' ? 'Precisione' : key === 'leadership' ? 'Leadership' : 'Creatività'}
                     </span>
                     <span className="text-white">{value}/100</span>
                   </div>
-                  <div className="h-2 bg-[#241f20] rounded-full overflow-hidden">
+                  <div className="h-2 bg-[--color-bg-surface-elevated] rounded-full overflow-hidden">
                     <div
-                      className="h-full bg-gradient-to-r from-[#e6a23c] to-[#f4bf4f] rounded-full transition-all duration-500"
+                      className="h-full bg-gradient-to-r from-[--color-gold-500] to-[--color-gold-400] rounded-full transition-all duration-500"
                       style={{ width: `${value}%` }}
                     />
                   </div>
@@ -146,21 +146,21 @@ export function RoleSelection({ roles, showRoleJourney = true, onComplete }: Rol
           </Card>
 
           {showRoleJourney && selectedRole.profile?.journey ? (
-            <Card className="mb-4 border border-[#f4bf4f]/20 bg-[#1a1617]">
+            <Card className="mb-4 border border-[--color-gold-400]/20 bg-[--color-bg-surface]">
               <div className="space-y-3">
                 {selectedRole.profile.journey.eyebrow ? (
-                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#f4bf4f]">
+                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[--color-gold-400]">
                     {selectedRole.profile.journey.eyebrow}
                   </p>
                 ) : null}
                 <div>
                   <h4 className="text-white">{selectedRole.profile.journey.headline}</h4>
-                  <p className="mt-1 text-sm text-[#b8b2b3]">{selectedRole.profile.journey.summary}</p>
+                  <p className="mt-1 text-sm text-[--color-text-secondary]">{selectedRole.profile.journey.summary}</p>
                 </div>
                 {(selectedRole.profile.journey.objectives ?? []).length ? (
                   <div className="space-y-2">
                     {(selectedRole.profile.journey.objectives ?? []).slice(0, 3).map((objective) => (
-                      <p key={objective} className="text-sm text-[#f7f3f4]">
+                      <p key={objective} className="text-sm text-[--color-text-primary]">
                         • {objective}
                       </p>
                     ))}
@@ -171,7 +171,7 @@ export function RoleSelection({ roles, showRoleJourney = true, onComplete }: Rol
                     {(selectedRole.profile.journey.starterBadgeLabels ?? []).map((badgeLabel) => (
                       <span
                         key={badgeLabel}
-                        className="rounded-full border border-[#f4bf4f]/20 bg-[#241f20] px-3 py-1 text-xs text-[#f4bf4f]"
+                        className="rounded-full border border-[--color-gold-400]/20 bg-[--color-bg-surface-elevated] px-3 py-1 text-xs text-[--color-gold-400]"
                       >
                         {badgeLabel}
                       </span>

--- a/apps/mobile/src/components/screens/Shop.tsx
+++ b/apps/mobile/src/components/screens/Shop.tsx
@@ -98,12 +98,17 @@ export function Shop({
 function BalanceCard({ cachet }: { cachet: number }) {
   return (
     <Card className="border border-[#2d2728] bg-gradient-to-br from-[#1a1617] to-[#241f20]">
-      <div className="flex items-start justify-between gap-4">
+      <div
+        className="flex items-start justify-between gap-4"
+        role="status"
+        aria-live="polite"
+        aria-label={`Saldo disponibile: ${cachet} cachet`}
+      >
         <div>
           <p className="text-xs uppercase tracking-wide text-[#b8b2b3]">Saldo disponibile</p>
           <p className="text-2xl text-white font-semibold mt-1">{cachet} Cachet</p>
         </div>
-        <div className="w-12 h-12 rounded-xl bg-[#241f20] border border-[#3d3a3b] flex items-center justify-center">
+        <div aria-hidden="true" className="w-12 h-12 rounded-xl bg-[#241f20] border border-[#3d3a3b] flex items-center justify-center">
           <ShoppingBag className="text-[#f4bf4f]" size={22} />
         </div>
       </div>
@@ -117,7 +122,13 @@ function FeedbackCard({ feedback }: { feedback: { type: 'ok' | 'error'; message:
       ? 'border border-[#52c41a]/40 bg-[#1d2a1d]'
       : 'border border-[#a82847]/50 bg-[#2a1a1f]'
     }>
-      <p className={feedback.type === 'ok' ? 'text-[#9be274]' : 'text-[#ff9aac]'}>{feedback.message}</p>
+      <p
+        role={feedback.type === 'error' ? 'alert' : 'status'}
+        aria-live={feedback.type === 'error' ? 'assertive' : 'polite'}
+        className={feedback.type === 'ok' ? 'text-[#9be274]' : 'text-[#ff9aac]'}
+      >
+        {feedback.message}
+      </p>
     </Card>
   );
 }
@@ -142,8 +153,13 @@ function ShopItemCard({
   const theatreRequiredMissing = item.category === 'rep_theatre' && (!theatreOptions.length || !selectedTheatre);
   const disabled = !canPurchase || busyItemCode != null || maxReached || insufficientCachet || theatreRequiredMissing;
 
+  const purchaseLabel = `Acquista ${item.title} per ${item.costCachet} cachet`;
+
   return (
-    <Card className="border border-white/5 bg-gradient-to-br from-[#1a1617] via-[#1d1819] to-[#221d1e]">
+    <Card
+      aria-label={`${item.title}: ${item.description}. Costo ${item.costCachet} cachet.`}
+      className="border border-white/5 bg-gradient-to-br from-[#1a1617] via-[#1d1819] to-[#221d1e]"
+    >
       <div className="space-y-4">
         <div className="flex items-start justify-between gap-4">
           <div>
@@ -171,7 +187,7 @@ function ShopItemCard({
               : theatreRequiredMissing ? 'Seleziona un teatro valido'
               : 'Disponibile'}
           </div>
-          <Button variant="primary" size="sm" disabled={disabled} onClick={onPurchase}>
+          <Button variant="primary" size="sm" disabled={disabled} onClick={onPurchase} aria-label={purchaseLabel}>
             Acquista
           </Button>
         </div>
@@ -207,11 +223,15 @@ function TheatreSelector({
 }) {
   return (
     <div className="space-y-2">
-      <p className="text-xs uppercase tracking-wide text-[#b8b2b3]">Teatro target</p>
+      <label htmlFor="shop-theatre-select" className="text-xs uppercase tracking-wide text-[#b8b2b3] block">
+        Teatro target
+      </label>
       {theatreOptions.length ? (
         <select
+          id="shop-theatre-select"
           value={selectedTheatre}
           onChange={e => onSelectTheatre(e.target.value)}
+          aria-label="Seleziona teatro target per il pack di reputazione"
           className="w-full rounded-xl border border-[#3d3a3b] bg-[#241f20] px-3 py-2 text-white outline-none focus:border-[#f4bf4f]"
         >
           {theatreOptions.map(o => (

--- a/apps/mobile/src/components/screens/Shop.tsx
+++ b/apps/mobile/src/components/screens/Shop.tsx
@@ -55,7 +55,7 @@ export function Shop({
     <Screen contentClassName="px-6 pt-6 pb-8 space-y-5">
       <header className="space-y-2">
         <h2 className="text-white">Shop</h2>
-        <p className="text-[#b8b2b3]">Spendi cachet per potenziamenti strategici.</p>
+        <p className="text-[--color-text-secondary]">Spendi cachet per potenziamenti strategici.</p>
       </header>
 
       <BalanceCard cachet={cachet} />
@@ -63,7 +63,7 @@ export function Shop({
       {feedback && <FeedbackCard feedback={feedback} />}
 
       {loading && (
-        <Card><p className="text-[#b8b2b3] text-sm">Caricamento catalogo shop...</p></Card>
+        <Card><p className="text-[--color-text-secondary] text-sm">Caricamento catalogo shop...</p></Card>
       )}
 
       {items.map(item => (
@@ -82,10 +82,10 @@ export function Shop({
       ))}
 
       {!items.length && !loading && (
-        <Card className="border border-[#3d3a3b] bg-[#1a1617]">
+        <Card className="border border-[--color-border-strong] bg-[--color-bg-surface]">
           <div className="flex items-start gap-3">
-            <AlertCircle className="text-[#f4bf4f] flex-shrink-0" size={18} />
-            <p className="text-sm text-[#b8b2b3]">Catalogo shop non disponibile al momento.</p>
+            <AlertCircle className="text-[--color-gold-400] flex-shrink-0" size={18} />
+            <p className="text-sm text-[--color-text-secondary]">Catalogo shop non disponibile al momento.</p>
           </div>
         </Card>
       )}
@@ -97,7 +97,7 @@ export function Shop({
 
 function BalanceCard({ cachet }: { cachet: number }) {
   return (
-    <Card className="border border-[#2d2728] bg-gradient-to-br from-[#1a1617] to-[#241f20]">
+    <Card className="border border-[--color-bg-surface-hover] bg-gradient-to-br from-[--color-bg-surface] to-[--color-bg-surface-elevated]">
       <div
         className="flex items-start justify-between gap-4"
         role="status"
@@ -105,11 +105,11 @@ function BalanceCard({ cachet }: { cachet: number }) {
         aria-label={`Saldo disponibile: ${cachet} cachet`}
       >
         <div>
-          <p className="text-xs uppercase tracking-wide text-[#b8b2b3]">Saldo disponibile</p>
+          <p className="text-xs uppercase tracking-wide text-[--color-text-secondary]">Saldo disponibile</p>
           <p className="text-2xl text-white font-semibold mt-1">{cachet} Cachet</p>
         </div>
-        <div aria-hidden="true" className="w-12 h-12 rounded-xl bg-[#241f20] border border-[#3d3a3b] flex items-center justify-center">
-          <ShoppingBag className="text-[#f4bf4f]" size={22} />
+        <div aria-hidden="true" className="w-12 h-12 rounded-xl bg-[--color-bg-surface-elevated] border border-[--color-border-strong] flex items-center justify-center">
+          <ShoppingBag className="text-[--color-gold-400]" size={22} />
         </div>
       </div>
     </Card>
@@ -119,13 +119,13 @@ function BalanceCard({ cachet }: { cachet: number }) {
 function FeedbackCard({ feedback }: { feedback: { type: 'ok' | 'error'; message: string } }) {
   return (
     <Card className={feedback.type === 'ok'
-      ? 'border border-[#52c41a]/40 bg-[#1d2a1d]'
-      : 'border border-[#a82847]/50 bg-[#2a1a1f]'
+      ? 'border border-[--color-success]/40 bg-[--color-success-soft-bg]'
+      : 'border border-[--color-burgundy-600]/50 bg-[--color-error-soft-bg]'
     }>
       <p
         role={feedback.type === 'error' ? 'alert' : 'status'}
         aria-live={feedback.type === 'error' ? 'assertive' : 'polite'}
-        className={feedback.type === 'ok' ? 'text-[#9be274]' : 'text-[#ff9aac]'}
+        className={feedback.type === 'ok' ? 'text-[--color-success-soft-text]' : 'text-[--color-error-soft-text]'}
       >
         {feedback.message}
       </p>
@@ -158,13 +158,13 @@ function ShopItemCard({
   return (
     <Card
       aria-label={`${item.title}: ${item.description}. Costo ${item.costCachet} cachet.`}
-      className="border border-white/5 bg-gradient-to-br from-[#1a1617] via-[#1d1819] to-[#221d1e]"
+      className="border border-white/5 bg-gradient-to-br from-[--color-bg-surface] via-[--color-bg-surface] to-[--color-bg-surface-elevated]"
     >
       <div className="space-y-4">
         <div className="flex items-start justify-between gap-4">
           <div>
             <h3 className="text-white text-lg">{item.title}</h3>
-            <p className="text-sm text-[#b8b2b3] mt-1">{item.description}</p>
+            <p className="text-sm text-[--color-text-secondary] mt-1">{item.description}</p>
           </div>
           {categoryLabel && <Badge variant="outline" size="sm">{categoryLabel}</Badge>}
         </div>
@@ -180,7 +180,7 @@ function ShopItemCard({
         )}
 
         <div className="flex items-center justify-between gap-3">
-          <div className="text-xs text-[#9a9697]">
+          <div className="text-xs text-[--color-text-tertiary]">
             {maxReached ? 'Limite acquisti raggiunto'
               : !canPurchase ? 'Acquisti temporaneamente disattivati'
               : insufficientCachet ? `Ti mancano ${item.costCachet - cachet} cachet`
@@ -200,10 +200,10 @@ function ItemMetaTags({ item }: { item: ShopCatalogItem }) {
   return (
     <div className="flex flex-wrap items-center gap-2 text-xs">
       <span className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-white/90">
-        <Coins size={12} className="text-[#f4bf4f]" /> {item.costCachet} cachet
+        <Coins size={12} className="text-[--color-gold-400]" /> {item.costCachet} cachet
       </span>
       <span className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-white/90">
-        <Sparkles size={12} className="text-[#f4bf4f]" /> +{item.effectValue}
+        <Sparkles size={12} className="text-[--color-gold-400]" /> +{item.effectValue}
       </span>
       {item.category === 'slot' && item.maxPurchasesPerUser != null && (
         <span className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-white/90">
@@ -223,7 +223,7 @@ function TheatreSelector({
 }) {
   return (
     <div className="space-y-2">
-      <label htmlFor="shop-theatre-select" className="text-xs uppercase tracking-wide text-[#b8b2b3] block">
+      <label htmlFor="shop-theatre-select" className="text-xs uppercase tracking-wide text-[--color-text-secondary] block">
         Teatro target
       </label>
       {theatreOptions.length ? (
@@ -232,14 +232,14 @@ function TheatreSelector({
           value={selectedTheatre}
           onChange={e => onSelectTheatre(e.target.value)}
           aria-label="Seleziona teatro target per il pack di reputazione"
-          className="w-full rounded-xl border border-[#3d3a3b] bg-[#241f20] px-3 py-2 text-white outline-none focus:border-[#f4bf4f]"
+          className="w-full rounded-xl border border-[--color-border-strong] bg-[--color-bg-surface-elevated] px-3 py-2 text-white outline-none focus:border-[--color-gold-400]"
         >
           {theatreOptions.map(o => (
             <option key={o.theatre} value={o.theatre}>{o.theatre} ({o.reputation}/100)</option>
           ))}
         </select>
       ) : (
-        <div className="rounded-xl border border-[#a82847]/40 bg-[#2a1a1f] p-3 text-sm text-[#ff9aac]">
+        <div className="rounded-xl border border-[--color-burgundy-600]/40 bg-[--color-error-soft-bg] p-3 text-sm text-[--color-error-soft-text]">
           Nessun teatro idoneo: devi registrare almeno un turno.
         </div>
       )}

--- a/apps/mobile/src/components/screens/Signup.tsx
+++ b/apps/mobile/src/components/screens/Signup.tsx
@@ -47,13 +47,13 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
     >
       <AuthFormLayout>
         <button type="button" onClick={onBack}
-          className="flex items-center justify-center size-[44px] text-[#f4bf4f]" aria-label="Indietro">
+          className="flex items-center justify-center size-[44px] text-[--color-gold-400]" aria-label="Indietro">
           <ArrowLeft size={24} />
         </button>
 
         <div className="mt-4 flex flex-col items-start gap-1">
-          <h1 className="text-2xl font-bold tracking-[-0.24px] text-[#f5f5f5]">Crea il tuo account</h1>
-          <p className="text-base text-[#b8b2b3]">Inizia la tua carriera teatrale</p>
+          <h1 className="text-2xl font-bold tracking-[-0.24px] text-[--color-text-primary]">Crea il tuo account</h1>
+          <p className="text-base text-[--color-text-secondary]">Inizia la tua carriera teatrale</p>
         </div>
 
         <form onSubmit={handleSubmit} className="mt-8 flex w-full max-w-[300px] flex-col gap-6 mx-auto">
@@ -71,7 +71,7 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
             <FormField label="Password" error={errors.password}>
               <FormInput type="password" value={password} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
                 autoComplete="new-password" hasError={!!errors.password} placeholder="••••••••" />
-              <p className="mt-2 !mb-0 text-base text-[#9a9697]">Almeno 8 caratteri</p>
+              <p className="mt-2 !mb-0 text-base text-[--color-text-tertiary]">Almeno 8 caratteri</p>
             </FormField>
 
             <FormField label="Conferma password" error={errors.confirmPassword}>
@@ -89,7 +89,7 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
           />
 
           {errorMessage && (
-            <p className="text-sm text-[#ff4d4f] text-center">{errorMessage}</p>
+            <p className="text-sm text-[--color-error] text-center">{errorMessage}</p>
           )}
 
           <Button type="submit" fullWidth disabled={isSubmitting} className={isSubmitting ? 'opacity-50 pointer-events-none' : ''}>
@@ -98,9 +98,9 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
         </form>
 
         <div className="mt-auto pt-6 text-center">
-          <p className="text-base text-[#b8b2b3]">Hai già un account?</p>
+          <p className="text-base text-[--color-text-secondary]">Hai già un account?</p>
           <button type="button" onClick={onLogin}
-            className="inline-flex items-center justify-center rounded-md px-2 py-2.5 text-base text-[#f4bf4f]">
+            className="inline-flex items-center justify-center rounded-md px-2 py-2.5 text-base text-[--color-gold-400]">
             Accedi
           </button>
         </div>
@@ -124,20 +124,20 @@ function TermsCheckbox({
 }) {
   return (
     <div>
-      <label htmlFor="terms" className="flex gap-3 items-start rounded-md py-1.5 text-sm text-[#b8b2b3]">
+      <label htmlFor="terms" className="flex gap-3 items-start rounded-md py-1.5 text-sm text-[--color-text-secondary]">
         <input id="terms" type="checkbox" checked={checked}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.checked)}
-          className="bg-[#241f20] border border-[#2d2728] size-6 accent-[#a82847]" />
+          className="bg-[--color-bg-surface-elevated] border border-[--color-bg-surface-hover] size-6 accent-[--color-burgundy-600]" />
         <span>
           Accetto i{' '}
           <button type="button" onClick={(e) => { e.preventDefault(); e.stopPropagation(); onViewTerms(); }}
-            className="text-[#f4bf4f] underline underline-offset-2">Termini e Condizioni</button>{' '}
+            className="text-[--color-gold-400] underline underline-offset-2">Termini e Condizioni</button>{' '}
           e la{' '}
           <button type="button" onClick={(e) => { e.preventDefault(); e.stopPropagation(); onViewPrivacy(); }}
-            className="text-[#f4bf4f] underline underline-offset-2">Privacy Policy</button>
+            className="text-[--color-gold-400] underline underline-offset-2">Privacy Policy</button>
         </span>
       </label>
-      {error && <p className="text-sm text-[#ff4d4f] mt-1">{error}</p>}
+      {error && <p className="text-sm text-[--color-error] mt-1">{error}</p>}
     </div>
   );
 }

--- a/apps/mobile/src/components/screens/Signup.tsx
+++ b/apps/mobile/src/components/screens/Signup.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Check } from 'lucide-react';
 import { Screen } from '../ui/Screen';
 import { FormField, FormInput, AuthFormLayout } from '../ui/FormField';
+import { PasswordInput } from '../ui/PasswordInput';
 import { Button } from '../ui/Button';
 
 interface SignupProps {
@@ -56,7 +57,7 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
           <p className="text-base text-[--color-text-secondary]">Inizia la tua carriera teatrale</p>
         </div>
 
-        <form onSubmit={handleSubmit} className="mt-8 flex w-full max-w-[300px] flex-col gap-6 mx-auto">
+        <form onSubmit={handleSubmit} className="mt-8 flex w-full max-w-[340px] flex-col gap-6 mx-auto">
           <FormField label="Nome visualizzato" error={errors.name}>
             <FormInput type="text" value={name} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
               autoComplete="name" hasError={!!errors.name} placeholder="Come vuoi essere chiamato" />
@@ -69,13 +70,13 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
 
           <div className="flex flex-col gap-4 w-full">
             <FormField label="Password" error={errors.password}>
-              <FormInput type="password" value={password} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
+              <PasswordInput value={password} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
                 autoComplete="new-password" hasError={!!errors.password} placeholder="••••••••" />
-              <p className="mt-2 !mb-0 text-base text-[--color-text-tertiary]">Almeno 8 caratteri</p>
+              <p className="mt-1.5 !mb-0 text-sm text-[--color-text-tertiary]">Almeno 8 caratteri</p>
             </FormField>
 
             <FormField label="Conferma password" error={errors.confirmPassword}>
-              <FormInput type="password" value={confirmPassword} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setConfirmPassword(e.target.value)}
+              <PasswordInput value={confirmPassword} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setConfirmPassword(e.target.value)}
                 autoComplete="new-password" hasError={!!errors.confirmPassword} placeholder="••••••••" />
             </FormField>
           </div>
@@ -124,19 +125,45 @@ function TermsCheckbox({
 }) {
   return (
     <div>
-      <label htmlFor="terms" className="flex gap-3 items-start rounded-md py-1.5 text-sm text-[--color-text-secondary]">
-        <input id="terms" type="checkbox" checked={checked}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.checked)}
-          className="bg-[--color-bg-surface-elevated] border border-[--color-bg-surface-hover] size-6 accent-[--color-burgundy-600]" />
+      {/* Custom styled checkbox — replaces native <input type="checkbox">
+          for visual consistency with the app design system. */}
+      <button
+        type="button"
+        role="checkbox"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className="flex gap-3 items-start w-full rounded-md py-1.5 text-left text-sm text-[--color-text-secondary]"
+      >
+        <span
+          aria-hidden="true"
+          className={[
+            'flex-shrink-0 flex items-center justify-center size-[22px] rounded-[6px] border-2 transition-colors duration-150 mt-[1px]',
+            checked
+              ? 'bg-[--color-burgundy-600] border-[--color-burgundy-600]'
+              : 'bg-[--color-bg-surface-elevated] border-[--color-bg-surface-hover]',
+          ].join(' ')}
+        >
+          {checked && <Check size={13} className="text-white" strokeWidth={3} />}
+        </span>
         <span>
           Accetto i{' '}
-          <button type="button" onClick={(e) => { e.preventDefault(); e.stopPropagation(); onViewTerms(); }}
-            className="text-[--color-gold-400] underline underline-offset-2">Termini e Condizioni</button>{' '}
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={(e) => { e.stopPropagation(); onViewTerms(); }}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); onViewTerms(); } }}
+            className="text-[--color-gold-400] underline underline-offset-2 cursor-pointer"
+          >Termini e Condizioni</span>{' '}
           e la{' '}
-          <button type="button" onClick={(e) => { e.preventDefault(); e.stopPropagation(); onViewPrivacy(); }}
-            className="text-[--color-gold-400] underline underline-offset-2">Privacy Policy</button>
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={(e) => { e.stopPropagation(); onViewPrivacy(); }}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); onViewPrivacy(); } }}
+            className="text-[--color-gold-400] underline underline-offset-2 cursor-pointer"
+          >Privacy Policy</span>
         </span>
-      </label>
+      </button>
       {error && <p className="text-sm text-[--color-error] mt-1">{error}</p>}
     </div>
   );

--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -235,31 +235,31 @@ function ChatHeader({ onBack, sessionCount, isLoading, isCreatingIssue, onOpenHi
   onBack: () => void; sessionCount: number; isLoading: boolean; isCreatingIssue: boolean; onOpenHistory: () => void;
 }) {
   return (
-    <Card className="border border-[#2d2728] bg-gradient-to-b from-[#241f20] to-[#1a1617] p-4 md:p-5">
+    <Card className="border border-[--color-bg-surface-hover] bg-gradient-to-b from-[--color-bg-surface-elevated] to-[--color-bg-surface] p-4 md:p-5">
       <div className="flex items-start gap-3 md:gap-4">
         <button type="button" onClick={onBack}
-          className="flex size-[44px] shrink-0 items-center justify-center rounded-xl border border-[#2d2728] bg-[#0f0d0e] text-[#f4bf4f] transition-colors hover:bg-[#241f20]"
+          className="flex size-[44px] shrink-0 items-center justify-center rounded-xl border border-[--color-bg-surface-hover] bg-[--color-bg-primary] text-[--color-gold-400] transition-colors hover:bg-[--color-bg-surface-elevated]"
           aria-label="Torna indietro">
           <ArrowLeft size={20} />
         </button>
         <div className="min-w-0 flex-1 space-y-2">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div className="min-w-0">
-              <p className="text-[12px] font-medium uppercase tracking-[0.08em] text-[#b8b2b3]">Supporto intelligente</p>
-              <h1 className="text-[25px] font-bold leading-[30px] text-[#f5f5f5]">Maxwell</h1>
+              <p className="text-[12px] font-medium uppercase tracking-[0.08em] text-[--color-text-secondary]">Supporto intelligente</p>
+              <h1 className="text-[25px] font-bold leading-[30px] text-[--color-text-primary]">Maxwell</h1>
             </div>
             <Button type="button" variant="ghost" size="sm" onClick={onOpenHistory}
-              className="h-[40px] rounded-xl border border-[#3b3436] px-3 text-[#f4bf4f]"
+              className="h-[40px] rounded-xl border border-[--color-border-subtle] px-3 text-[--color-gold-400]"
               aria-label={`Apri cronologia chat, ${sessionCount} sessioni`}>
               <History size={16} /> Cronologia
             </Button>
           </div>
           <div className="flex flex-wrap items-center gap-2" aria-live="polite">
-            <Badge variant="success" size="sm"><span className="size-1.5 rounded-full bg-[#52c41a]" /> Maxwell online</Badge>
+            <Badge variant="success" size="sm"><span className="size-1.5 rounded-full bg-[--color-success]" /> Maxwell online</Badge>
             {isLoading && <Badge variant="default" size="sm"><Loader2 size={12} className="animate-spin" /> Risposta in corso</Badge>}
             {isCreatingIssue && <Badge variant="outline" size="sm"><Clock3 size={12} /> Segnalazione in preparazione</Badge>}
           </div>
-          <p className="text-[13px] leading-[19px] text-[#9a9697]">
+          <p className="text-[13px] leading-[19px] text-[--color-text-tertiary]">
             Descrivi il problema con parole semplici. Maxwell ti risponde e, se serve, prepara automaticamente una segnalazione.
           </p>
         </div>
@@ -273,12 +273,12 @@ function ChatMessageArea({ messages, isLoading, errorMessage, activeSession, scr
   activeSession: ChatSession | null; scrollRef: React.RefObject<HTMLDivElement | null>;
 }) {
   return (
-    <Card className="flex min-h-0 flex-1 flex-col border border-[#2d2728] bg-[#120f10] p-0">
-      <div className="border-b border-[#2d2728] px-4 py-3">
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[12px] text-[#b8b2b3]">
-          <span className="inline-flex items-center gap-1.5 text-[#f4bf4f]"><Bot size={14} /> Chat attiva</span>
+    <Card className="flex min-h-0 flex-1 flex-col border border-[--color-bg-surface-hover] bg-[--color-bg-primary] p-0">
+      <div className="border-b border-[--color-bg-surface-hover] px-4 py-3">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[12px] text-[--color-text-secondary]">
+          <span className="inline-flex items-center gap-1.5 text-[--color-gold-400]"><Bot size={14} /> Chat attiva</span>
           {activeSession && (
-            <span className="inline-flex items-center gap-1 text-[#9a9697]">
+            <span className="inline-flex items-center gap-1 text-[--color-text-tertiary]">
               <Clock3 size={12} /> Aggiornata: {formatSessionDate(activeSession.updatedAt)}
             </span>
           )}
@@ -290,7 +290,7 @@ function ChatMessageArea({ messages, isLoading, errorMessage, activeSession, scr
           {messages.map(msg => <ChatBubble key={msg.id} message={msg} />)}
           {isLoading && <TypingIndicator />}
           {errorMessage && (
-            <div role="alert" className="rounded-xl border border-[#ff4d4f]/40 bg-[#ff4d4f]/10 px-3 py-2 text-[12px] leading-[18px] text-[#ffd8d8]">
+            <div role="alert" className="rounded-xl border border-[--color-error]/40 bg-[--color-error]/10 px-3 py-2 text-[12px] leading-[18px] text-[--color-error-on-dark]">
               {errorMessage}
             </div>
           )}
@@ -307,8 +307,8 @@ function ChatBubble({ message }: { message: SupportMessage }) {
     <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
       <article className={`max-w-[88%] rounded-2xl border px-3 py-2.5 md:max-w-[78%] ${
         isUser
-          ? 'border-[#7f2038] bg-gradient-to-b from-[#8c1c38] to-[#6b1529] text-white'
-          : 'border-[#2d2728] bg-[#1a1617] text-white'
+          ? 'border-[--color-burgundy-highlight] bg-gradient-to-b from-[--color-burgundy-700] to-[--color-burgundy-800] text-white'
+          : 'border-[--color-bg-surface-hover] bg-[--color-bg-surface] text-white'
       }`} aria-label={isUser ? 'Messaggio utente' : 'Messaggio Maxwell'}>
         <div className="mb-1.5 flex items-center justify-between gap-3 text-[11px]">
           <span className="inline-flex items-center gap-1">
@@ -328,13 +328,13 @@ function ChatBubble({ message }: { message: SupportMessage }) {
 function TypingIndicator() {
   return (
     <div className="flex justify-start">
-      <div className="max-w-[88%] rounded-2xl border border-[#2d2728] bg-[#1a1617] px-3 py-3 md:max-w-[78%]">
-        <div className="mb-2 inline-flex items-center gap-2 text-[12px] text-[#b8b2b3]">
+      <div className="max-w-[88%] rounded-2xl border border-[--color-bg-surface-hover] bg-[--color-bg-surface] px-3 py-3 md:max-w-[78%]">
+        <div className="mb-2 inline-flex items-center gap-2 text-[12px] text-[--color-text-secondary]">
           <Loader2 size={12} className="animate-spin" /> Maxwell sta scrivendo...
         </div>
         <div className="space-y-2">
-          <Skeleton className="h-2.5 w-40 bg-[#2d2728]" />
-          <Skeleton className="h-2.5 w-28 bg-[#2d2728]" />
+          <Skeleton className="h-2.5 w-40 bg-[--color-bg-surface-hover]" />
+          <Skeleton className="h-2.5 w-28 bg-[--color-bg-surface-hover]" />
         </div>
       </div>
     </div>
@@ -347,7 +347,7 @@ function ChatInputBar({ input, onInputChange, hasInput, isLoading, isCreatingIss
 }) {
   return (
     <div className="sticky bottom-[calc(env(safe-area-inset-bottom,_0px)+2px)]">
-      <Card className="border border-[#2d2728] bg-[#1a1617]/95 p-3 backdrop-blur md:p-4">
+      <Card className="border border-[--color-bg-surface-hover] bg-[--color-bg-surface]/95 p-3 backdrop-blur md:p-4">
         <div className="flex items-end gap-3">
           <Textarea
             value={input}
@@ -355,7 +355,7 @@ function ChatInputBar({ input, onInputChange, hasInput, isLoading, isCreatingIss
             placeholder="Scrivi il tuo messaggio..."
             rows={2}
             aria-label="Scrivi un messaggio per Maxwell"
-            className="max-h-40 min-h-[56px] bg-[#0f0d0e] text-[14px] leading-[20px] text-white border-[#2d2728] pr-4"
+            className="max-h-40 min-h-[56px] bg-[--color-bg-primary] text-[14px] leading-[20px] text-white border-[--color-bg-surface-hover] pr-4"
             onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); void onSend(); } }}
           />
           <Button type="button" onClick={onSend} disabled={!hasInput || isLoading}
@@ -365,9 +365,9 @@ function ChatInputBar({ input, onInputChange, hasInput, isLoading, isCreatingIss
             <span className="hidden md:inline">{isLoading ? 'Invio...' : 'Invia'}</span>
           </Button>
         </div>
-        <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-[11px] text-[#9a9697]">
+        <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-[11px] text-[--color-text-tertiary]">
           <span>Invio: Enter - Nuova riga: Shift + Enter</span>
-          {isCreatingIssue && <span className="text-[#f4bf4f]">Segnalazione automatica in corso</span>}
+          {isCreatingIssue && <span className="text-[--color-gold-400]">Segnalazione automatica in corso</span>}
         </div>
       </Card>
     </div>
@@ -379,10 +379,10 @@ function HistoryDrawer({ chatSessions, activeSessionId, isLoading, onSelectSessi
   onSelectSession: (id: string) => void; onNewSession: () => void;
 }) {
   return (
-    <DrawerContent className="border-[#2d2728] bg-[#120f10] text-white data-[vaul-drawer-direction=bottom]:max-h-[82vh] data-[vaul-drawer-direction=right]:w-full data-[vaul-drawer-direction=right]:max-w-[420px]">
-      <DrawerHeader className="border-b border-[#2d2728]">
+    <DrawerContent className="border-[--color-bg-surface-hover] bg-[--color-bg-primary] text-white data-[vaul-drawer-direction=bottom]:max-h-[82vh] data-[vaul-drawer-direction=right]:w-full data-[vaul-drawer-direction=right]:max-w-[420px]">
+      <DrawerHeader className="border-b border-[--color-bg-surface-hover]">
         <DrawerTitle className="text-left text-[18px] text-white">Cronologia chat</DrawerTitle>
-        {isLoading && <p className="mt-2 text-left text-[12px] text-[#f4bf4f]">Attendi la risposta di Maxwell prima di cambiare sessione.</p>}
+        {isLoading && <p className="mt-2 text-left text-[12px] text-[--color-gold-400]">Attendi la risposta di Maxwell prima di cambiare sessione.</p>}
       </DrawerHeader>
 
       <div className="px-4 pt-3">
@@ -399,20 +399,20 @@ function HistoryDrawer({ chatSessions, activeSessionId, isLoading, onSelectSessi
             return (
               <button key={session.id} type="button" onClick={() => onSelectSession(session.id)} disabled={isLoading}
                 className={`w-full rounded-xl border px-3 py-2.5 text-left transition-colors ${
-                  isActive ? 'border-[#a82847] bg-[#2d0a0f]/60' : 'border-[#2d2728] bg-[#1a1617] hover:bg-[#241f20]'
+                  isActive ? 'border-[--color-burgundy-600] bg-[--color-burgundy-950]/60' : 'border-[--color-bg-surface-hover] bg-[--color-bg-surface] hover:bg-[--color-bg-surface-elevated]'
                 }`} aria-pressed={isActive} aria-label={`Apri sessione del ${formatSessionDate(session.updatedAt)}`}>
                 <div className="flex items-center justify-between gap-3">
-                  <span className="text-[12px] leading-[18px] text-[#f4bf4f]">{formatSessionDate(session.updatedAt)}</span>
-                  {isActive && <span className="rounded-full border border-[#a82847] px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-[#f4bf4f]">Attiva</span>}
+                  <span className="text-[12px] leading-[18px] text-[--color-gold-400]">{formatSessionDate(session.updatedAt)}</span>
+                  {isActive && <span className="rounded-full border border-[--color-burgundy-600] px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-[--color-gold-400]">Attiva</span>}
                 </div>
-                <p className="mt-1 line-clamp-2 text-[12px] leading-[18px] text-[#b8b2b3]">{buildSessionPreview(session)}</p>
+                <p className="mt-1 line-clamp-2 text-[12px] leading-[18px] text-[--color-text-secondary]">{buildSessionPreview(session)}</p>
               </button>
             );
           })}
         </div>
       </ScrollArea>
 
-      <DrawerFooter className="border-t border-[#2d2728]">
+      <DrawerFooter className="border-t border-[--color-bg-surface-hover]">
         <DrawerClose asChild>
           <Button type="button" variant="ghost" className="h-[42px] rounded-xl">Chiudi</Button>
         </DrawerClose>

--- a/apps/mobile/src/components/screens/TermsAndConditions.tsx
+++ b/apps/mobile/src/components/screens/TermsAndConditions.tsx
@@ -18,25 +18,25 @@ export function TermsAndConditions({ onBack }: TermsAndConditionsProps) {
         <button
           type="button"
           onClick={onBack}
-          className="flex items-center justify-center size-[44px] text-[#f4bf4f]"
+          className="flex items-center justify-center size-[44px] text-[--color-gold-400]"
           aria-label="Indietro"
         >
           <ArrowLeft size={24} />
         </button>
 
         <div className="flex flex-col items-start gap-1">
-          <p className="text-[24px] leading-[31.2px] font-bold tracking-[-0.24px] text-[#f5f5f5]">
+          <p className="text-[24px] leading-[31.2px] font-bold tracking-[-0.24px] text-[--color-text-primary]">
             Termini e Condizioni
           </p>
-          <p className="text-[16px] leading-[25.6px] text-[#b8b2b3]">Condizioni d’uso</p>
+          <p className="text-[16px] leading-[25.6px] text-[--color-text-secondary]">Condizioni d’uso</p>
         </div>
 
-        <div className="bg-[#1a1617] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-4 flex flex-col gap-4">
-          <p className="text-[14px] leading-[20px] text-[#b8b2b3] !m-0">
+        <div className="bg-[--color-bg-surface] rounded-[16.4px] shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.1),0px_2px_4px_-2px_rgba(0,0,0,0.1)] p-4 flex flex-col gap-4">
+          <p className="text-[14px] leading-[20px] text-[--color-text-secondary] !m-0">
             Ultimo aggiornamento: 31 Dic 2025
           </p>
 
-          <div className="flex flex-col gap-3 text-[14px] leading-[20px] text-[#b8b2b3]">
+          <div className="flex flex-col gap-3 text-[14px] leading-[20px] text-[--color-text-secondary]">
             <p className="!m-0">
               Questo documento descrive le regole di utilizzo di Turni di Palco. Il testo è una base
               iniziale e potrà essere aggiornato.

--- a/apps/mobile/src/components/screens/TicketQrActivationPrototype.tsx
+++ b/apps/mobile/src/components/screens/TicketQrActivationPrototype.tsx
@@ -104,25 +104,25 @@ export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivati
       className="app-gradient justify-start"
       contentClassName="max-w-3xl space-y-6"
     >
-      <div className="flex items-center justify-between rounded-2xl border border-[#2d2728] bg-[#1a1617] px-4 py-3">
+      <div className="flex items-center justify-between rounded-2xl border border-[--color-bg-surface-hover] bg-[--color-bg-surface] px-4 py-3">
         <button
           type="button"
           onClick={onBack}
           aria-label="Torna indietro"
-          className="inline-flex items-center gap-2 rounded-md px-2 py-1 text-[#f4bf4f] hover:text-[#e6a23c]"
+          className="inline-flex items-center gap-2 rounded-md px-2 py-1 text-[--color-gold-400] hover:text-[--color-gold-500]"
         >
           <ArrowLeft aria-hidden="true" size={18} />
           Indietro
         </button>
-        <p className="text-xs text-[#b8b2b3]">Prototipo mobile ticket office + attivazione</p>
+        <p className="text-xs text-[--color-text-secondary]">Prototipo mobile ticket office + attivazione</p>
       </div>
 
-      <section className="rounded-2xl border border-[#2d2728] bg-[#1a1617] p-4 space-y-4">
+      <section className="rounded-2xl border border-[--color-bg-surface-hover] bg-[--color-bg-surface] p-4 space-y-4">
         <div className="flex items-center gap-2 text-white">
-          <QrCode size={18} className="text-[#f4bf4f]" />
+          <QrCode size={18} className="text-[--color-gold-400]" />
           <h3 className="text-base !m-0">1) Generazione payload e hash QR</h3>
         </div>
-        <p className="text-sm text-[#b8b2b3]">
+        <p className="text-sm text-[--color-text-secondary]">
           Struttura JSON richiesta: circuit, eventName, eventID, ticketNumber, date.
         </p>
         <div className="grid grid-cols-1 gap-3">
@@ -138,11 +138,11 @@ export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivati
         </Button>
 
         {generateMessage ? (
-          <p className="text-sm text-[#b8b2b3]" role="status" aria-live="polite">{generateMessage}</p>
+          <p className="text-sm text-[--color-text-secondary]" role="status" aria-live="polite">{generateMessage}</p>
         ) : null}
 
         {generated ? (
-          <div className="rounded-xl border border-[#2d2728] bg-[#0f0d0e] p-3 text-xs text-[#d9d4d5] space-y-2">
+          <div className="rounded-xl border border-[--color-bg-surface-hover] bg-[--color-bg-primary] p-3 text-xs text-[--color-text-secondary] space-y-2">
             <p className="!m-0"><strong>QR value (hash):</strong> {generated.qrValue}</p>
             <p className="!m-0 break-all"><strong>Hash SHA-256:</strong> {generated.hash}</p>
             <p className="!m-0 break-all"><strong>JSON:</strong> {generated.json}</p>
@@ -150,7 +150,7 @@ export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivati
         ) : null}
       </section>
 
-      <section className="rounded-2xl border border-[#2d2728] bg-[#1a1617] p-4 space-y-4">
+      <section className="rounded-2xl border border-[--color-bg-surface-hover] bg-[--color-bg-surface] p-4 space-y-4">
         <h3 className="text-base text-white !m-0">2) Scansione e attivazione one-shot</h3>
           <Input
             value={scanInput}
@@ -162,19 +162,19 @@ export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivati
           Verifica e attiva
         </Button>
         {scanMessage ? (
-          <p className="text-sm text-[#b8b2b3]" role="status" aria-live="polite">{scanMessage}</p>
+          <p className="text-sm text-[--color-text-secondary]" role="status" aria-live="polite">{scanMessage}</p>
         ) : null}
       </section>
 
-      <section className="rounded-2xl border border-[#2d2728] bg-[#1a1617] p-4 space-y-3">
+      <section className="rounded-2xl border border-[--color-bg-surface-hover] bg-[--color-bg-surface] p-4 space-y-3">
         <div className="flex items-center gap-2 text-white">
-          <Database size={18} className="text-[#f4bf4f]" />
+          <Database size={18} className="text-[--color-gold-400]" />
           <h3 className="text-base !m-0">Stato archivio locale prototipo</h3>
         </div>
         <div className="overflow-x-auto">
-          <table className="w-full text-xs text-left text-[#d9d4d5]">
+          <table className="w-full text-xs text-left text-[--color-text-secondary]">
             <thead>
-              <tr className="text-[#b8b2b3]">
+              <tr className="text-[--color-text-secondary]">
                 <th className="pb-2">Hash</th>
                 <th className="pb-2">Ticket</th>
                 <th className="pb-2">Stato</th>
@@ -184,11 +184,11 @@ export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivati
             <tbody>
               {records.length === 0 ? (
                 <tr>
-                  <td colSpan={4} className="py-2 text-[#7f797a]">Nessun ticket generato.</td>
+                  <td colSpan={4} className="py-2 text-[--color-text-tertiary]">Nessun ticket generato.</td>
                 </tr>
               ) : (
                 records.map((record) => (
-                  <tr key={record.hash} className="border-t border-[#2d2728]">
+                  <tr key={record.hash} className="border-t border-[--color-bg-surface-hover]">
                     <td className="py-2 pr-2">{record.hash.slice(0, 12)}…</td>
                     <td className="py-2 pr-2">{record.ticketNumber}</td>
                     <td className="py-2 pr-2">{record.status}</td>

--- a/apps/mobile/src/components/screens/TicketQrActivationPrototype.tsx
+++ b/apps/mobile/src/components/screens/TicketQrActivationPrototype.tsx
@@ -106,10 +106,12 @@ export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivati
     >
       <div className="flex items-center justify-between rounded-2xl border border-[#2d2728] bg-[#1a1617] px-4 py-3">
         <button
+          type="button"
           onClick={onBack}
+          aria-label="Torna indietro"
           className="inline-flex items-center gap-2 rounded-md px-2 py-1 text-[#f4bf4f] hover:text-[#e6a23c]"
         >
-          <ArrowLeft size={18} />
+          <ArrowLeft aria-hidden="true" size={18} />
           Indietro
         </button>
         <p className="text-xs text-[#b8b2b3]">Prototipo mobile ticket office + attivazione</p>
@@ -131,11 +133,13 @@ export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivati
           <Input value={date} onChange={(event) => setDate(event.target.value)} placeholder="Data ISO (es. 2026-02-11T11:54:00+01:00)" />
         </div>
 
-        <Button variant="primary" onClick={handleGenerate} disabled={busy}>
+        <Button variant="primary" onClick={handleGenerate} disabled={busy} aria-label="Genera QR ticket dai dati inseriti">
           Genera QR ticket
         </Button>
 
-        {generateMessage ? <p className="text-sm text-[#b8b2b3]">{generateMessage}</p> : null}
+        {generateMessage ? (
+          <p className="text-sm text-[#b8b2b3]" role="status" aria-live="polite">{generateMessage}</p>
+        ) : null}
 
         {generated ? (
           <div className="rounded-xl border border-[#2d2728] bg-[#0f0d0e] p-3 text-xs text-[#d9d4d5] space-y-2">
@@ -154,10 +158,12 @@ export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivati
             placeholder="Incolla hash o valore QR"
           />
 
-        <Button variant="secondary" onClick={handleActivate} disabled={busy}>
+        <Button variant="secondary" onClick={handleActivate} disabled={busy} aria-label="Verifica hash e attiva il ticket">
           Verifica e attiva
         </Button>
-        {scanMessage ? <p className="text-sm text-[#b8b2b3]">{scanMessage}</p> : null}
+        {scanMessage ? (
+          <p className="text-sm text-[#b8b2b3]" role="status" aria-live="polite">{scanMessage}</p>
+        ) : null}
       </section>
 
       <section className="rounded-2xl border border-[#2d2728] bg-[#1a1617] p-4 space-y-3">

--- a/apps/mobile/src/components/screens/Welcome.tsx
+++ b/apps/mobile/src/components/screens/Welcome.tsx
@@ -22,8 +22,8 @@ export function Welcome({ onStart, onLogin }: WelcomeProps) {
       >
         <WelcomeBranding />
 
-        <div className="animate-stagger-4 mt-6 mb-5 w-full max-w-[300px] bg-[#1a1617] border border-[#2d2728] rounded-2xl px-4 py-3">
-          <p id="welcome-description" className="!m-0 text-sm leading-relaxed text-center text-[#9a9697]">
+        <div className="animate-stagger-4 mt-6 mb-5 w-full max-w-[300px] bg-surface border border-surface-hover rounded-2xl px-4 py-3">
+          <p id="welcome-description" className="!m-0 text-sm leading-relaxed text-center text-subtle">
             Simula la carriera di un professionista del teatro e registra la tua
             partecipazione agli eventi reali ATCL registrando il numero del biglietto.
           </p>
@@ -55,7 +55,7 @@ export function Welcome({ onStart, onLogin }: WelcomeProps) {
 function WelcomeBranding() {
   return (
     <div className="flex flex-col items-center gap-5 pt-3">
-      <div className="animate-stagger-1 animate-float welcome-logo-pulse bg-gradient-to-b from-[#a82847] to-[#6b1529] rounded-[28px] size-[120px] flex items-center justify-center ring-1 ring-[#a82847]/30">
+      <div className="animate-stagger-1 animate-float welcome-logo-pulse bg-gradient-to-b from-burgundy-600 to-burgundy-800 rounded-[28px] size-[120px] flex items-center justify-center ring-1 ring-burgundy-600/30">
         <img alt="" className="size-[60px]" src={welcomeLogo} />
       </div>
       <div className="flex flex-col items-center gap-2">
@@ -69,7 +69,7 @@ function WelcomeBranding() {
         >
           Turni di Palco
         </p>
-        <p className="animate-stagger-3 text-[11px] leading-none text-[#9a9697] tracking-[0.14em] uppercase font-semibold">
+        <p className="animate-stagger-3 text-[11px] leading-none text-subtle tracking-[0.14em] uppercase font-semibold">
           Costruisci la tua carriera a teatro
         </p>
       </div>
@@ -91,8 +91,8 @@ function WelcomeButton({
   ariaLabel?: string;
 }) {
   const styles = variant === 'primary'
-    ? 'bg-gradient-to-b from-[#a82847] to-[#8c1c38] shadow-[0_4px_20px_rgba(168,40,71,0.35)] active:shadow-none text-white'
-    : 'border border-[#2d2728] bg-[#1a1617] active:bg-[#241f20] text-[#f4bf4f]';
+    ? 'bg-gradient-to-b from-burgundy-600 to-burgundy-700 shadow-[0_4px_20px_rgba(168,40,71,0.35)] active:shadow-none text-white'
+    : 'border border-surface-hover bg-surface active:bg-surface-elevated text-accent';
 
   return (
     <button

--- a/apps/mobile/src/components/screens/Welcome.tsx
+++ b/apps/mobile/src/components/screens/Welcome.tsx
@@ -14,25 +14,40 @@ export function Welcome({ onStart, onLogin }: WelcomeProps) {
       className="relative items-start justify-start h-[100dvh] overflow-hidden"
       contentClassName="relative w-full flex-1 px-6 pt-8 pb-[calc(env(safe-area-inset-bottom,_0px)+32px)] space-y-0 box-border"
     >
-      <div className="relative flex h-full flex-col items-center text-center">
+      <main
+        role="main"
+        aria-labelledby="welcome-title"
+        aria-describedby="welcome-description"
+        className="relative flex h-full flex-col items-center text-center"
+      >
         <WelcomeBranding />
 
         <div className="animate-stagger-4 mt-6 mb-5 w-full max-w-[300px] bg-[#1a1617] border border-[#2d2728] rounded-2xl px-4 py-3">
-          <p className="!m-0 text-sm leading-relaxed text-center text-[#9a9697]">
+          <p id="welcome-description" className="!m-0 text-sm leading-relaxed text-center text-[#9a9697]">
             Simula la carriera di un professionista del teatro e registra la tua
             partecipazione agli eventi reali ATCL registrando il numero del biglietto.
           </p>
         </div>
 
         <div className="mt-auto w-full flex flex-col items-center gap-3 pb-3">
-          <WelcomeButton variant="primary" onClick={onStart} className="animate-stagger-5">
+          <WelcomeButton
+            variant="primary"
+            onClick={onStart}
+            className="animate-stagger-5"
+            ariaLabel="Inizia: crea un nuovo profilo"
+          >
             Inizia
           </WelcomeButton>
-          <WelcomeButton variant="secondary" onClick={onLogin} className="animate-stagger-6">
+          <WelcomeButton
+            variant="secondary"
+            onClick={onLogin}
+            className="animate-stagger-6"
+            ariaLabel="Accedi con un profilo esistente"
+          >
             Accedi
           </WelcomeButton>
         </div>
-      </div>
+      </main>
     </Screen>
   );
 }
@@ -45,6 +60,7 @@ function WelcomeBranding() {
       </div>
       <div className="flex flex-col items-center gap-2">
         <p
+          id="welcome-title"
           className="animate-stagger-2 text-[32px] leading-[1.2] font-bold tracking-[-0.02em] text-transparent bg-clip-text"
           style={{
             WebkitTextFillColor: 'transparent',
@@ -66,11 +82,13 @@ function WelcomeButton({
   onClick,
   className = '',
   children,
+  ariaLabel,
 }: {
   variant: 'primary' | 'secondary';
   onClick: () => void;
   className?: string;
   children: React.ReactNode;
+  ariaLabel?: string;
 }) {
   const styles = variant === 'primary'
     ? 'bg-gradient-to-b from-[#a82847] to-[#8c1c38] shadow-[0_4px_20px_rgba(168,40,71,0.35)] active:shadow-none text-white'
@@ -80,6 +98,7 @@ function WelcomeButton({
     <button
       type="button"
       onClick={onClick}
+      aria-label={ariaLabel}
       className={`h-[50px] w-full max-w-[300px] rounded-2xl active:scale-[0.98] transition-all duration-150 ${styles} ${className}`}
     >
       <span className="block text-[17px] font-semibold leading-none">{children}</span>

--- a/apps/mobile/src/components/ui/Badge.tsx
+++ b/apps/mobile/src/components/ui/Badge.tsx
@@ -21,10 +21,10 @@ export function Badge({ children, variant = 'default', size = 'sm', animate = fa
   }, [animate]);
 
   const variants = {
-    default: 'bg-[#241f20] text-[#b8b2b3]',
-    success: 'bg-[#52c41a]/20 text-[#52c41a]',
-    gold: 'bg-gradient-to-b from-[#e6a23c] to-[#f4bf4f] text-[#0f0d0e]',
-    outline: 'border border-[#a82847] text-[#f4bf4f] bg-transparent'
+    default: 'bg-[--color-bg-surface-elevated] text-[--color-text-secondary]',
+    success: 'bg-[--color-success]/20 text-[--color-success]',
+    gold: 'bg-gradient-to-b from-[--color-gold-500] to-[--color-gold-400] text-[--color-bg-primary]',
+    outline: 'border border-[--color-burgundy-600] text-[--color-gold-400] bg-transparent'
   };
   
   const sizes = {

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -8,13 +8,13 @@ export const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-gradient-to-b from-[#8c1c38] to-[#a82847] text-white shadow-md hover:shadow-lg hover:from-[#6b1529] hover:to-[#8c1c38] active:scale-95',
-        primary: 'bg-gradient-to-b from-[#8c1c38] to-[#a82847] text-white shadow-md hover:shadow-lg hover:from-[#6b1529] hover:to-[#8c1c38] active:scale-95',
+        default: 'bg-gradient-to-b from-[--color-burgundy-700] to-[--color-burgundy-600] text-white shadow-md hover:shadow-lg hover:from-[--color-burgundy-800] hover:to-[--color-burgundy-700] active:scale-95',
+        primary: 'bg-gradient-to-b from-[--color-burgundy-700] to-[--color-burgundy-600] text-white shadow-md hover:shadow-lg hover:from-[--color-burgundy-800] hover:to-[--color-burgundy-700] active:scale-95',
         destructive: 'bg-red-600 text-white hover:bg-red-700 active:scale-95',
-        outline: 'border border-[#2d2728] bg-transparent text-[#f7f3f4] hover:bg-[#241f20] active:scale-95',
-        secondary: 'border-2 border-[#a82847] text-[#f4bf4f] bg-transparent hover:bg-[#a82847]/10 active:scale-95',
-        ghost: 'text-[#f4bf4f] hover:bg-[#241f20] active:scale-95',
-        link: 'text-[#f4bf4f] underline-offset-4 hover:underline',
+        outline: 'border border-[--color-bg-surface-hover] bg-transparent text-[--color-text-primary] hover:bg-[--color-bg-surface-elevated] active:scale-95',
+        secondary: 'border-2 border-[--color-burgundy-600] text-[--color-gold-400] bg-transparent hover:bg-[--color-burgundy-600]/10 active:scale-95',
+        ghost: 'text-[--color-gold-400] hover:bg-[--color-bg-surface-elevated] active:scale-95',
+        link: 'text-[--color-gold-400] underline-offset-4 hover:underline',
       },
       size: {
         default: 'px-6 py-3 text-base',

--- a/apps/mobile/src/components/ui/CopyrightNotice.tsx
+++ b/apps/mobile/src/components/ui/CopyrightNotice.tsx
@@ -9,7 +9,7 @@ export function CopyrightNotice({ className }: CopyrightNoticeProps) {
   return (
     <p
       className={cn(
-        'text-center text-[11px] leading-[16px] text-[#9a9697] !m-0',
+        'text-center text-[11px] leading-[16px] text-[--color-text-tertiary] !m-0',
         className
       )}
     >

--- a/apps/mobile/src/components/ui/ErrorOverlay.tsx
+++ b/apps/mobile/src/components/ui/ErrorOverlay.tsx
@@ -11,38 +11,38 @@ export type ErrorOverlayProps = {
 export function ErrorOverlay({ title, message, details, onReload, onHome }: ErrorOverlayProps) {
   return (
     <div
-      className="fixed inset-0 z-[1000] flex items-center justify-center bg-[#0f0d0e] px-6 py-10"
+      className="fixed inset-0 z-[1000] flex items-center justify-center bg-[--color-bg-primary] px-6 py-10"
       role="alertdialog"
       aria-modal="true"
       aria-live="assertive"
     >
       <section
-        className="w-full max-w-[520px] rounded-[24px] border border-[#2d2728] bg-[#1a1617] p-6 shadow-[0px_16px_40px_rgba(0,0,0,0.45)]"
+        className="w-full max-w-[520px] rounded-[24px] border border-[--color-bg-surface-hover] bg-[--color-bg-surface] p-6 shadow-[0px_16px_40px_rgba(0,0,0,0.45)]"
         role="document"
       >
-        <p className="text-[11px] uppercase tracking-[0.34em] text-[#9a9697]">Problema tecnico</p>
-        <h1 className="mt-2 text-[26px] leading-[32px] font-semibold text-[#f5f5f5]">{title}</h1>
-        <p className="mt-3 text-[15px] leading-[22px] text-[#b8b2b3]">{message}</p>
+        <p className="text-[11px] uppercase tracking-[0.34em] text-[--color-text-tertiary]">Problema tecnico</p>
+        <h1 className="mt-2 text-[26px] leading-[32px] font-semibold text-[--color-text-primary]">{title}</h1>
+        <p className="mt-3 text-[15px] leading-[22px] text-[--color-text-secondary]">{message}</p>
         <div className="mt-5 flex flex-wrap gap-3">
           <button
             type="button"
             onClick={onReload}
-            className="h-[44px] rounded-[16px] bg-gradient-to-b from-[#8c1c38] to-[#a82847] px-4 text-[16px] text-white"
+            className="h-[44px] rounded-[16px] bg-gradient-to-b from-[--color-burgundy-700] to-[--color-burgundy-600] px-4 text-[16px] text-white"
           >
             Ricarica
           </button>
           <button
             type="button"
             onClick={onHome}
-            className="h-[44px] rounded-[16px] border border-[#2d2728] px-4 text-[16px] text-[#f4bf4f]"
+            className="h-[44px] rounded-[16px] border border-[--color-bg-surface-hover] px-4 text-[16px] text-[--color-gold-400]"
           >
             Torna alla home
           </button>
         </div>
         {details ? (
-          <details className="mt-4 text-[12px] text-[#9a9697]">
+          <details className="mt-4 text-[12px] text-[--color-text-tertiary]">
             <summary className="cursor-pointer">Dettagli tecnici</summary>
-            <pre className="mt-2 whitespace-pre-wrap rounded-[12px] border border-[#2d2728] bg-[#141112] p-3 text-[12px] text-[#b8b2b3]">
+            <pre className="mt-2 whitespace-pre-wrap rounded-[12px] border border-[--color-bg-surface-hover] bg-[--color-code-bg] p-3 text-[12px] text-[--color-text-secondary]">
               {details}
             </pre>
           </details>

--- a/apps/mobile/src/components/ui/FormField.tsx
+++ b/apps/mobile/src/components/ui/FormField.tsx
@@ -12,11 +12,11 @@ interface FormFieldProps {
 export function FormField({ label, htmlFor, error, children, className }: FormFieldProps) {
   return (
     <div className={cn('flex flex-col gap-2 w-full', className)}>
-      <label htmlFor={htmlFor} className="text-base leading-6 text-[#b8b2b3]">
+      <label htmlFor={htmlFor} className="text-base leading-6 text-[--color-text-secondary]">
         {label}
       </label>
       {children}
-      {error && <p className="text-sm text-[#ff4d4f]">{error}</p>}
+      {error && <p className="text-sm text-[--color-error]">{error}</p>}
     </div>
   );
 }
@@ -28,12 +28,12 @@ interface FormInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
 export function FormInput({ hasError, className, ...props }: FormInputProps) {
   return (
     <div className={cn(
-      'bg-[#241f20] border-2 rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[#f4bf4f]',
-      hasError ? 'border-[#ff4d4f]' : 'border-[#2d2728]',
+      'bg-[--color-bg-surface-elevated] border-2 rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[--color-gold-400]',
+      hasError ? 'border-[--color-error]' : 'border-[--color-bg-surface-hover]',
     )}>
       <input
         className={cn(
-          'w-full h-full bg-transparent px-[10px] py-0 text-base leading-7 text-[#f5f5f5] placeholder:text-[#9a9697] focus:outline-none',
+          'w-full h-full bg-transparent px-[10px] py-0 text-base leading-7 text-[--color-text-primary] placeholder:text-[--color-text-tertiary] focus:outline-none',
           className,
         )}
         {...props}

--- a/apps/mobile/src/components/ui/FormField.tsx
+++ b/apps/mobile/src/components/ui/FormField.tsx
@@ -47,7 +47,9 @@ interface AuthLayoutProps {
 }
 
 export function AuthFormLayout({ children }: AuthLayoutProps) {
+  // overflow-y-auto + min-h-0 ensure the form is scrollable when the
+  // soft keyboard shrinks the viewport (especially on signup with many fields).
   return (
-    <div className="flex h-full flex-col">{children}</div>
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto">{children}</div>
   );
 }

--- a/apps/mobile/src/components/ui/Input.tsx
+++ b/apps/mobile/src/components/ui/Input.tsx
@@ -10,21 +10,21 @@ export function Input({ label, error, helperText, className = '', ...props }: In
   return (
     <div className="w-full">
       {label && (
-        <label className="block text-[#b8b2b3] mb-2">
+        <label className="block text-[--color-text-secondary] mb-2">
           {label}
         </label>
       )}
       <input
-        className={`w-full bg-[#241f20] border-2 ${
-          error ? 'border-[#ff4d4f]' : 'border-[#2d2728]'
-        } rounded-lg px-4 py-3 text-white placeholder:text-[#9a9697] focus:border-[#f4bf4f] focus:outline-none transition-colors ${className}`}
+        className={`w-full bg-[--color-bg-surface-elevated] border-2 ${
+          error ? 'border-[--color-error]' : 'border-[--color-bg-surface-hover]'
+        } rounded-lg px-4 py-3 text-white placeholder:text-[--color-text-tertiary] focus:border-[--color-gold-400] focus:outline-none transition-colors ${className}`}
         {...props}
       />
       {error && (
-        <p className="text-[#ff4d4f] mt-1 text-sm">{error}</p>
+        <p className="text-[--color-error] mt-1 text-sm">{error}</p>
       )}
       {helperText && !error && (
-        <p className="text-[#9a9697] mt-1 text-sm">{helperText}</p>
+        <p className="text-[--color-text-tertiary] mt-1 text-sm">{helperText}</p>
       )}
     </div>
   );

--- a/apps/mobile/src/components/ui/LiveRegion.tsx
+++ b/apps/mobile/src/components/ui/LiveRegion.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react';
+
+let _announce: ((msg: string, politeness?: 'polite' | 'assertive') => void) | null = null;
+
+export function announce(msg: string, politeness: 'polite' | 'assertive' = 'polite') {
+  _announce?.(msg, politeness);
+}
+
+export function LiveRegion() {
+  const politeRef = useRef<HTMLDivElement>(null);
+  const assertiveRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    _announce = (msg, politeness = 'polite') => {
+      const el = politeness === 'assertive' ? assertiveRef.current : politeRef.current;
+      if (!el) return;
+      el.textContent = '';
+      requestAnimationFrame(() => {
+        el.textContent = msg;
+      });
+    };
+    return () => {
+      _announce = null;
+    };
+  }, []);
+
+  return (
+    <>
+      <div ref={politeRef} aria-live="polite" aria-atomic="true" className="sr-only" />
+      <div ref={assertiveRef} aria-live="assertive" aria-atomic="true" className="sr-only" />
+    </>
+  );
+}

--- a/apps/mobile/src/components/ui/MetricTile.tsx
+++ b/apps/mobile/src/components/ui/MetricTile.tsx
@@ -16,15 +16,15 @@ export function MetricTile({ label, value, helper, icon, onClick, progress, anim
   return (
     <div
       className={cn(
-        'bg-[#1a1617] rounded-2xl p-3 border border-[#2d2728]',
-        onClick ? 'hover:bg-[#241f20] cursor-pointer active:scale-[0.98] transition-all duration-150 mobile-card-hover' : '',
+        'bg-[--color-bg-surface] rounded-2xl p-3 border border-[--color-bg-surface-hover]',
+        onClick ? 'hover:bg-[--color-bg-surface-elevated] cursor-pointer active:scale-[0.98] transition-all duration-150 mobile-card-hover' : '',
         animateOnMount ? 'animate-card-in' : ''
       )}
       onClick={onClick}
     >
       <div className="flex items-start justify-between gap-2 mb-2 min-h-[32px]">
-        <div className="text-xs leading-4 text-[#b8b2b3]">{label}</div>
-        {icon ? <div className="text-[#f4bf4f]">{icon}</div> : null}
+        <div className="text-xs leading-4 text-[--color-text-secondary]">{label}</div>
+        {icon ? <div className="text-[--color-gold-400]">{icon}</div> : null}
       </div>
       <div
         className={cn(
@@ -34,7 +34,7 @@ export function MetricTile({ label, value, helper, icon, onClick, progress, anim
       >
         {value}
       </div>
-      {helper ? <div className="text-xs text-[#9a9697]">{helper}</div> : null}
+      {helper ? <div className="text-xs text-[--color-text-tertiary]">{helper}</div> : null}
       {progress ? (
         <div className="mt-2">
           <ProgressBar value={progress.value} max={progress.max} size="sm" color={progress.color ?? 'burgundy'} />

--- a/apps/mobile/src/components/ui/MetricTile.tsx
+++ b/apps/mobile/src/components/ui/MetricTile.tsx
@@ -28,7 +28,7 @@ export function MetricTile({ label, value, helper, icon, onClick, progress, anim
       </div>
       <div
         className={cn(
-          'text-[52px] leading-none mt-2 mb-4 text-white font-semibold tracking-tight',
+          'text-[36px] leading-none mt-1 mb-3 text-white font-semibold tracking-tight',
           animateOnMount ? 'animate-number-pop' : ''
         )}
       >

--- a/apps/mobile/src/components/ui/PasswordInput.tsx
+++ b/apps/mobile/src/components/ui/PasswordInput.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+import { cn } from './utils';
+
+interface PasswordInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  hasError?: boolean;
+}
+
+/**
+ * Campo password con toggle visibilità (mostra/nascondi).
+ * Wrappa la stessa struttura di FormInput per coerenza visiva.
+ */
+export function PasswordInput({ hasError, className, ...props }: PasswordInputProps) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <div
+      className={cn(
+        'bg-[--color-bg-surface-elevated] border-2 rounded-[10px] flex h-[44px] items-center overflow-clip w-full transition-colors focus-within:border-[--color-gold-400]',
+        hasError ? 'border-[--color-error]' : 'border-[--color-bg-surface-hover]',
+      )}
+    >
+      <input
+        type={visible ? 'text' : 'password'}
+        className={cn(
+          'flex-1 h-full bg-transparent pl-[10px] pr-1 py-0 text-base leading-7 text-[--color-text-primary] placeholder:text-[--color-text-tertiary] focus:outline-none',
+          className,
+        )}
+        {...props}
+      />
+      <button
+        type="button"
+        onClick={() => setVisible(v => !v)}
+        aria-label={visible ? 'Nascondi password' : 'Mostra password'}
+        tabIndex={-1}
+        className="flex-shrink-0 flex items-center justify-center w-10 h-full text-[--color-text-tertiary] hover:text-[--color-text-secondary] transition-colors"
+      >
+        {visible
+          ? <EyeOff size={16} aria-hidden="true" />
+          : <Eye size={16} aria-hidden="true" />}
+      </button>
+    </div>
+  );
+}

--- a/apps/mobile/src/components/ui/PasswordInput.tsx
+++ b/apps/mobile/src/components/ui/PasswordInput.tsx
@@ -32,7 +32,6 @@ export function PasswordInput({ hasError, className, ...props }: PasswordInputPr
         type="button"
         onClick={() => setVisible(v => !v)}
         aria-label={visible ? 'Nascondi password' : 'Mostra password'}
-        tabIndex={-1}
         className="flex-shrink-0 flex items-center justify-center w-10 h-full text-[--color-text-tertiary] hover:text-[--color-text-secondary] transition-colors"
       >
         {visible

--- a/apps/mobile/src/components/ui/ProgressBar.tsx
+++ b/apps/mobile/src/components/ui/ProgressBar.tsx
@@ -37,20 +37,20 @@ export function ProgressBar({
   };
 
   const colors = {
-    burgundy: 'bg-gradient-to-r from-[#8c1c38] to-[#a82847]',
-    gold: 'bg-gradient-to-r from-[#e6a23c] to-[#f4bf4f]'
+    burgundy: 'bg-gradient-to-r from-[--color-burgundy-700] to-[--color-burgundy-600]',
+    gold: 'bg-gradient-to-r from-[--color-gold-500] to-[--color-gold-400]'
   };
 
   return (
     <div className="w-full">
       {showLabel && (
-        <div className="flex justify-between text-sm text-[#b8b2b3] mb-1">
+        <div className="flex justify-between text-sm text-[--color-text-secondary] mb-1">
           <span>{value}</span>
           <span>{max}</span>
         </div>
       )}
       <div
-        className={`w-full bg-[#241f20] rounded-full overflow-hidden ${heights[size]}`}
+        className={`w-full bg-[--color-bg-surface-elevated] rounded-full overflow-hidden ${heights[size]}`}
         role="progressbar"
         aria-valuenow={value}
         aria-valuemin={0}

--- a/apps/mobile/src/components/ui/Screen.tsx
+++ b/apps/mobile/src/components/ui/Screen.tsx
@@ -48,7 +48,7 @@ interface ScreenHeaderProps {
 
 export function ScreenHeader({ children, gradient = false, className }: ScreenHeaderProps) {
   return (
-    <div className={cn(gradient && 'bg-gradient-to-b from-[#2d0a0f] to-[#0f0d0e]', className)}>
+    <div className={cn(gradient && 'bg-gradient-to-b from-[--color-burgundy-950] to-[--color-bg-primary]', className)}>
       <div className="w-full app-content px-5 pt-5 pb-6 space-y-5">{children}</div>
     </div>
   );

--- a/apps/mobile/src/components/ui/Tag.tsx
+++ b/apps/mobile/src/components/ui/Tag.tsx
@@ -12,10 +12,10 @@ interface TagProps {
 
 export function Tag({ children, variant = 'default', className = '', size = 'md' }: TagProps) {
   const variants: Record<TagVariant, string> = {
-    default: 'bg-[#241f20] text-[#f4bf4f]',
-    outline: 'border border-[#f4bf4f]/40 text-[#f4bf4f]',
-    info: 'bg-[#f4bf4f]/10 text-[#f4bf4f]',
-    success: 'bg-[#52c41a]/10 text-[#52c41a] border border-[#52c41a]/30',
+    default: 'bg-[--color-bg-surface-elevated] text-[--color-gold-400]',
+    outline: 'border border-[--color-gold-400]/40 text-[--color-gold-400]',
+    info: 'bg-[--color-gold-400]/10 text-[--color-gold-400]',
+    success: 'bg-[--color-success]/10 text-[--color-success] border border-[--color-success]/30',
   };
 
   const sizes = {

--- a/apps/mobile/src/components/ui/WelcomeTutorial.tsx
+++ b/apps/mobile/src/components/ui/WelcomeTutorial.tsx
@@ -36,7 +36,7 @@ function useReducedMotion(): boolean {
 function SpotlightHighlight({ rect, reducedMotion }: { rect: DOMRect; reducedMotion: boolean }) {
   return (
     <div
-      className={`absolute border-2 border-[#f4bf4f] rounded-xl ${reducedMotion ? '' : 'animate-tutorial-spotlight-pulse'}`}
+      className={`absolute border-2 border-[--color-gold-400] rounded-xl ${reducedMotion ? '' : 'animate-tutorial-spotlight-pulse'}`}
       style={{
         top: rect.top - 8,
         left: rect.left - 8,
@@ -87,7 +87,7 @@ function StepCard({
 
   return (
     <div
-      className={`relative rounded-2xl border border-[#3a2f30] bg-[#1a1617] p-5 shadow-[0px_16px_40px_rgba(0,0,0,0.45)] ${reducedMotion ? '' : (position ? 'animate-tutorial-tooltip-in' : 'animate-tutorial-fade-in')}`}
+      className={`relative rounded-2xl border border-[--color-tutorial-border] bg-[--color-bg-surface] p-5 shadow-[0px_16px_40px_rgba(0,0,0,0.45)] ${reducedMotion ? '' : (position ? 'animate-tutorial-tooltip-in' : 'animate-tutorial-fade-in')}`}
       style={positionStyle}
     >
       {position && position.arrowDirection === 'up' && (
@@ -97,7 +97,7 @@ function StepCard({
         />
       )}
       <h3 className="text-lg font-semibold text-white">{title}</h3>
-      <p className="mt-2 text-sm leading-relaxed text-[#c9b8b9]">{description}</p>
+      <p className="mt-2 text-sm leading-relaxed text-[--color-tutorial-description]">{description}</p>
       {position && position.arrowDirection === 'down' && (
         <div
           className="tutorial-arrow-down"
@@ -131,7 +131,7 @@ function BottomControls({
         {Array.from({ length: total }, (_, i) => (
           <div
             key={i}
-            className={`h-2 w-2 rounded-full transition-colors ${i === step ? 'bg-[#f4bf4f]' : 'bg-[#3a2f30]'}`}
+            className={`h-2 w-2 rounded-full transition-colors ${i === step ? 'bg-[--color-gold-400]' : 'bg-[--color-tutorial-border]'}`}
           />
         ))}
       </div>
@@ -139,7 +139,7 @@ function BottomControls({
         ref={nextButtonRef}
         type="button"
         onClick={onNext}
-        className="h-[44px] w-full max-w-[320px] rounded-[16px] bg-gradient-to-b from-[#a82847] to-[#6b1529] text-[16px] font-semibold text-white"
+        className="h-[44px] w-full max-w-[320px] rounded-[16px] bg-gradient-to-b from-[--color-burgundy-600] to-[--color-burgundy-800] text-[16px] font-semibold text-white"
       >
         {isFirst ? 'Inizia' : isLast ? 'Inizia a esplorare' : 'Avanti'}
       </button>
@@ -147,7 +147,7 @@ function BottomControls({
         <button
           type="button"
           onClick={onSkip}
-          className="text-sm text-[#8a7a7b] underline"
+          className="text-sm text-[--color-text-tertiary] underline"
         >
           Salta tutorial
         </button>

--- a/apps/mobile/src/components/ui/skeleton.tsx
+++ b/apps/mobile/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("bg-[#241f20] animate-pulse rounded-lg", className)}
+      className={cn("bg-[--color-bg-surface-elevated] animate-pulse rounded-lg", className)}
       {...props}
     />
   );

--- a/apps/mobile/src/components/ui/sonner.tsx
+++ b/apps/mobile/src/components/ui/sonner.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useTheme } from 'next-themes';
 import { Toaster as Sonner, ToasterProps } from 'sonner';
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
+  const theme =
+    typeof document !== 'undefined'
+      ? (document.documentElement.getAttribute('data-theme') ?? 'dark')
+      : 'dark';
 
   return (
     <Sonner

--- a/apps/mobile/src/gameplay/minigames.ts
+++ b/apps/mobile/src/gameplay/minigames.ts
@@ -16,6 +16,13 @@ const ACTIVITY_PRIMARY_STAT: Partial<Record<string, keyof RoleStats>> = {
   equalizzazione: 'precision',
 };
 
+const DEFAULT_TIMING_SPEED = 0.045;
+const ACCESSIBLE_SPEED_MULTIPLIER = 0.6;
+const ACCESSIBLE_TOLERANCE_MULTIPLIER = 1.5;
+const TIMING_FEEDBACK_DELAY_MS = 900;
+const ACCESSIBLE_FEEDBACK_DELAY_MS = 1400;
+const MAX_TOLERANCE = 20;
+
 export type MinigameType = 'timing' | 'audio';
 
 export type MinigameRound = {
@@ -161,7 +168,17 @@ function withRandomTargets(config: MinigameConfig): MinigameConfig {
   return { ...config, rounds: config.rounds.map(r => ({ ...r, target: randomTarget() }) ) };
 }
 
-export function getMinigameConfig(activityId: string, roleId?: RoleId | null, roleStats?: RoleStats | null): MinigameConfig {
+export type ResolvedMinigameConfig = MinigameConfig & {
+  speed: number;
+  feedbackDelayMs: number;
+};
+
+export function getMinigameConfig(
+  activityId: string,
+  roleId?: RoleId | null,
+  roleStats?: RoleStats | null,
+  opts?: { accessibleMode?: boolean }
+): ResolvedMinigameConfig {
   const config = MINIGAME_BY_ACTIVITY[activityId] ?? FALLBACK_CONFIG;
 
   // Applica override narrativo/tematico specifico del ruolo
@@ -171,22 +188,40 @@ export function getMinigameConfig(activityId: string, roleId?: RoleId | null, ro
     : config;
 
   // Adatta la tolleranza alla stat primaria del ruolo (closes #471)
+  let statAdjustedBase = base;
   if (roleStats) {
     const statKey = ACTIVITY_PRIMARY_STAT[activityId];
     const statValue = statKey ? roleStats[statKey] : null;
     if (statValue != null) {
       const factor = 1 + (statValue - STAT_EFFECTS.statBaseline) / 200;
-      return withRandomTargets({
+      statAdjustedBase = {
         ...base,
         rounds: base.rounds.map(r => ({
           ...r,
           tolerance: Math.max(1, Math.round(r.tolerance * factor)),
         })),
-      });
+      };
     }
   }
 
-  return withRandomTargets(base);
+  // Accessible mode multipliers (issue #476)
+  const accessibleMode = opts?.accessibleMode ?? false;
+  const speedMultiplier = accessibleMode ? ACCESSIBLE_SPEED_MULTIPLIER : 1;
+  const toleranceMultiplier = accessibleMode ? ACCESSIBLE_TOLERANCE_MULTIPLIER : 1;
+  const feedbackDelayMs = accessibleMode ? ACCESSIBLE_FEEDBACK_DELAY_MS : TIMING_FEEDBACK_DELAY_MS;
+
+  const accessibleRounds = statAdjustedBase.rounds.map((r) => ({
+    ...r,
+    tolerance: Math.min(r.tolerance * toleranceMultiplier, MAX_TOLERANCE),
+  }));
+
+  const withTargets = withRandomTargets({ ...statAdjustedBase, rounds: accessibleRounds });
+
+  return {
+    ...withTargets,
+    speed: DEFAULT_TIMING_SPEED * speedMultiplier,
+    feedbackDelayMs,
+  };
 }
 
 export function computeRoundScore(target: number, hit: number, tolerance: number) {

--- a/apps/mobile/src/hooks/useAnnounce.ts
+++ b/apps/mobile/src/hooks/useAnnounce.ts
@@ -1,0 +1,5 @@
+import { announce } from '../components/ui/LiveRegion';
+
+export function useAnnounce() {
+  return announce;
+}

--- a/apps/mobile/src/providers/ThemeProvider.tsx
+++ b/apps/mobile/src/providers/ThemeProvider.tsx
@@ -1,0 +1,40 @@
+import React, { useCallback, useEffect, useMemo } from 'react';
+import { useGameState } from '../state/store';
+
+type Theme = 'dark' | 'light';
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+};
+
+const ThemeContext = React.createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const { state, updateProfile } = useGameState();
+  const theme: Theme = state.profile.theme === 'light' ? 'light' : 'dark';
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
+  const setTheme = useCallback(
+    (t: Theme) => {
+      updateProfile({ theme: t });
+    },
+    [updateProfile]
+  );
+
+  const value = useMemo<ThemeContextValue>(() => ({ theme, setTheme }), [theme, setTheme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = React.useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return ctx;
+}

--- a/apps/mobile/src/providers/ThemeProvider.tsx
+++ b/apps/mobile/src/providers/ThemeProvider.tsx
@@ -1,40 +1,57 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useGameState } from '../state/store';
 
-type Theme = 'dark' | 'light';
+export type ThemeSetting = 'dark' | 'light' | 'system';
+export type ResolvedTheme = 'dark' | 'light';
 
 type ThemeContextValue = {
-  theme: Theme;
-  setTheme: (t: Theme) => void;
+  theme: ThemeSetting;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (t: ThemeSetting) => void;
 };
 
 const ThemeContext = React.createContext<ThemeContextValue | null>(null);
 
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === 'undefined') return 'dark';
+  return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+}
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const { state, updateProfile } = useGameState();
-  const theme: Theme = state.profile.theme === 'light' ? 'light' : 'dark';
+  const theme: ThemeSetting = state.profile.theme ?? 'system';
+
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(getSystemTheme);
+
+  // Track OS-level preference changes
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: light)');
+    const handler = (e: MediaQueryListEvent) => setSystemTheme(e.matches ? 'light' : 'dark');
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  const resolvedTheme: ResolvedTheme = theme === 'system' ? systemTheme : theme;
 
   useEffect(() => {
-    if (typeof document === 'undefined') return;
-    document.documentElement.setAttribute('data-theme', theme);
-  }, [theme]);
+    document.documentElement.setAttribute('data-theme', resolvedTheme);
+  }, [resolvedTheme]);
 
   const setTheme = useCallback(
-    (t: Theme) => {
-      updateProfile({ theme: t });
-    },
+    (t: ThemeSetting) => updateProfile({ theme: t }),
     [updateProfile]
   );
 
-  const value = useMemo<ThemeContextValue>(() => ({ theme, setTheme }), [theme, setTheme]);
+  const value = useMemo<ThemeContextValue>(
+    () => ({ theme, resolvedTheme, setTheme }),
+    [theme, resolvedTheme, setTheme]
+  );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }
 
 export function useTheme(): ThemeContextValue {
   const ctx = React.useContext(ThemeContext);
-  if (!ctx) {
-    throw new Error('useTheme must be used within ThemeProvider');
-  }
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
   return ctx;
 }

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -242,7 +242,7 @@ export type PlayerProfile = {
   completedCourses: Record<string, string>;
   /** Corsi attualmente in corso: courseId → timestamp ISO di avvio. */
   activeCourses: Record<string, string>;
-  /** Tema UI preferito dall'utente. 'system' segue il tema del dispositivo. Default: 'dark'. */
+  /** Tema UI preferito dall'utente. 'system' segue il tema del dispositivo. Default: 'system'. */
   theme: 'dark' | 'light' | 'system';
   /** Modalità accessibile per i minigiochi timing (velocità ridotta, tolleranza maggiore). Default: false. */
   accessibleMode: boolean;
@@ -840,7 +840,7 @@ type ProfileUpsertPayload = {
   role_id: RoleId;
   profile_image?: string | null;
   leaderboard_visible?: boolean;
-  theme?: 'dark' | 'light';
+  theme?: 'dark' | 'light' | 'system';
   accessible_mode?: boolean;
   cookie_consent_at?: string | null;
   onboarding_completed_at?: string | null;
@@ -1973,7 +1973,7 @@ function createInitialState(): GameState {
       skills: { precision: 0, presence: 0, creativity: 0, leadership: 0 },
       completedCourses: {},
       activeCourses: {},
-      theme: 'dark',
+      theme: 'system',
       accessibleMode: false,
     },
     turns: [],
@@ -2047,7 +2047,9 @@ function loadState(): GameState {
     const parsed = JSON.parse(raw) as GameState;
     if (!parsed.profile) return createDefaultState();
     const safeRole = isRoleId(parsed.profile.roleId) ? parsed.profile.roleId : createDefaultState().profile.roleId;
-    const parsedTheme = parsed.profile.theme === 'light' ? 'light' : 'dark';
+    const rawTheme = parsed.profile.theme;
+    const parsedTheme: 'dark' | 'light' | 'system' =
+      rawTheme === 'light' || rawTheme === 'dark' || rawTheme === 'system' ? rawTheme : 'system';
     const parsedAccessibleMode =
       typeof parsed.profile.accessibleMode === 'boolean' ? parsed.profile.accessibleMode : false;
     return {

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -242,6 +242,10 @@ export type PlayerProfile = {
   completedCourses: Record<string, string>;
   /** Corsi attualmente in corso: courseId → timestamp ISO di avvio. */
   activeCourses: Record<string, string>;
+  /** Tema UI preferito dall'utente. 'system' segue il tema del dispositivo. Default: 'dark'. */
+  theme: 'dark' | 'light' | 'system';
+  /** Modalità accessibile per i minigiochi timing (velocità ridotta, tolleranza maggiore). Default: false. */
+  accessibleMode: boolean;
 };
 
 export type RegisterTurnInput = {
@@ -393,6 +397,8 @@ type DbProfileRow = {
   skills?: { precision: number; presence: number; creativity: number; leadership: number } | null;
   active_courses?: Record<string, string> | null;
   completed_courses?: Record<string, string> | null;
+  theme?: string | null;
+  accessible_mode?: boolean | null;
 };
 
 type DbBadgeRow = {
@@ -834,6 +840,8 @@ type ProfileUpsertPayload = {
   role_id: RoleId;
   profile_image?: string | null;
   leaderboard_visible?: boolean;
+  theme?: 'dark' | 'light';
+  accessible_mode?: boolean;
   cookie_consent_at?: string | null;
   onboarding_completed_at?: string | null;
   onboarding_variant?: 'full' | 'skipped_qr' | 'skipped_manual' | null;
@@ -1750,6 +1758,8 @@ function buildProfileUpsertPayload(userId: string, profile: PlayerProfile): Prof
     role_id: profile.roleId,
     profile_image: profile.profileImage ?? null,
     leaderboard_visible: profile.leaderboardVisible,
+    theme: profile.theme,
+    accessible_mode: profile.accessibleMode,
     ...(cookieConsentAt ? { cookie_consent_at: cookieConsentAt } : {}),
     onboarding_completed_at: profile.onboardingCompletedAt ?? null,
     onboarding_variant: profile.onboardingVariant ?? null,
@@ -1963,6 +1973,8 @@ function createInitialState(): GameState {
       skills: { precision: 0, presence: 0, creativity: 0, leadership: 0 },
       completedCourses: {},
       activeCourses: {},
+      theme: 'dark',
+      accessibleMode: false,
     },
     turns: [],
     eventPlans: [],
@@ -1993,6 +2005,8 @@ function createDemoState(): GameState {
       skills: { precision: 0, presence: 0, creativity: 0, leadership: 0 },
       completedCourses: {},
       activeCourses: {},
+      theme: 'dark',
+      accessibleMode: false,
     },
     turns: [
       {
@@ -2033,11 +2047,16 @@ function loadState(): GameState {
     const parsed = JSON.parse(raw) as GameState;
     if (!parsed.profile) return createDefaultState();
     const safeRole = isRoleId(parsed.profile.roleId) ? parsed.profile.roleId : createDefaultState().profile.roleId;
+    const parsedTheme = parsed.profile.theme === 'light' ? 'light' : 'dark';
+    const parsedAccessibleMode =
+      typeof parsed.profile.accessibleMode === 'boolean' ? parsed.profile.accessibleMode : false;
     return {
       profile: {
         ...createDefaultState().profile,
         ...parsed.profile,
         roleId: safeRole,
+        theme: parsedTheme,
+        accessibleMode: parsedAccessibleMode,
       },
       turns: Array.isArray(parsed.turns) ? parsed.turns : [],
       eventPlans: Array.isArray(parsed.eventPlans)
@@ -2277,7 +2296,7 @@ type GameContextValue = {
   unfollowEvent: (eventId: string) => Promise<void>;
   isEventFollowed: (eventId: string) => boolean;
   markBadgesSeen: () => void;
-  updateProfile: (updates: Partial<Pick<PlayerProfile, 'name' | 'email' | 'roleId' | 'profileImage' | 'leaderboardVisible'>>) => void;
+  updateProfile: (updates: Partial<Pick<PlayerProfile, 'name' | 'email' | 'roleId' | 'profileImage' | 'leaderboardVisible' | 'theme' | 'accessibleMode'>>) => void;
   registerTurn: (input: RegisterTurnInput) => Promise<RegisterTurnResult>;
   pendingBoostRequests: number;
   turnSyncFeedback: TurnSyncFeedback | null;
@@ -3924,6 +3943,10 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
                 skills: profileRow.skills ?? prev.profile.skills,
                 activeCourses: profileRow.active_courses ?? prev.profile.activeCourses,
                 completedCourses: profileRow.completed_courses ?? prev.profile.completedCourses,
+                theme: (profileRow.theme === 'light' || profileRow.theme === 'dark' || profileRow.theme === 'system')
+                  ? profileRow.theme
+                  : prev.profile.theme,
+                accessibleMode: profileRow.accessible_mode ?? prev.profile.accessibleMode,
               },
               eventPlans: prev.eventPlans,
               turns: remoteTurns,
@@ -4033,6 +4056,14 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
               onboardingVariant: (profile.onboarding_variant === 'full' || profile.onboarding_variant === 'skipped_qr' || profile.onboarding_variant === 'skipped_manual')
                 ? profile.onboarding_variant
                 : prev.profile.onboardingVariant,
+              theme:
+                profile.theme === 'light' || profile.theme === 'dark' || profile.theme === 'system'
+                  ? profile.theme
+                  : prev.profile.theme,
+              accessibleMode:
+                profile.accessible_mode != null
+                  ? profile.accessible_mode
+                  : prev.profile.accessibleMode,
             },
           }));
           setHasHydratedRemote(true);
@@ -4238,7 +4269,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   );
 
   const updateProfile = useCallback(
-    (updates: Partial<Pick<PlayerProfile, 'name' | 'email' | 'roleId' | 'profileImage' | 'leaderboardVisible'>>) => {
+    (updates: Partial<Pick<PlayerProfile, 'name' | 'email' | 'roleId' | 'profileImage' | 'leaderboardVisible' | 'theme' | 'accessibleMode'>>) => {
       let nextProfile: PlayerProfile | null = null;
       setState((prev: GameState) => {
         const nextRole =
@@ -5236,6 +5267,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         tokenAtcl: state.profile.tokenAtcl,
         lastActivityAt: new Date(state.profile.lastActivityAt).toISOString(),
         leaderboardVisible: state.profile.leaderboardVisible,
+        theme: state.profile.theme,
+        accessibleMode: state.profile.accessibleMode,
       },
       turns: state.turns,
       badges,

--- a/shared/styles/extracted-pwa-styles/style.css
+++ b/shared/styles/extracted-pwa-styles/style.css
@@ -6,27 +6,28 @@
 /* ═══ Variabili ══════════════════════════════════════════════════════════════ */
 
 :root {
-  --bg:          #0c0e14;
-  --surface:     #131620;
-  --surface-2:   #1b1f30;
-  --surface-3:   #222740;
+  --bg:          var(--color-bg-primary);
+  --surface:     var(--color-bg-surface);
+  --surface-2:   var(--color-bg-surface-elevated);
+  --surface-3:   var(--color-bg-surface-hover);
   --border:      rgba(255, 255, 255, 0.07);
   --border-hi:   rgba(255, 255, 255, 0.13);
 
-  --text:        #e8eaf0;
-  --text-2:      #8b90a8;
-  --text-3:      #4e5470;
+  --text:        var(--color-text-primary);
+  --text-2:      var(--color-text-secondary);
+  --text-3:      var(--color-text-tertiary);
   --mono:        "JetBrains Mono", "Fira Code", Consolas, monospace;
 
   --accent:      #6c8ef5;
+  --accent-hover: #5a7de8;
   --accent-dim:  rgba(108, 142, 245, 0.14);
   --accent-glow: rgba(108, 142, 245, 0.22);
 
-  --ok:          #34d399;
+  --ok:          var(--color-success);
   --ok-dim:      rgba(52, 211, 153, 0.12);
-  --warn:        #fbbf24;
+  --warn:        var(--color-warning);
   --warn-dim:    rgba(251, 191, 36, 0.12);
-  --err:         #f87171;
+  --err:         var(--color-error);
   --err-dim:     rgba(248, 113, 113, 0.12);
   --neutral-dim: rgba(148, 163, 184, 0.12);
 
@@ -35,6 +36,18 @@
   --r:           10px;
   --r-lg:        14px;
   --gap:         0.9rem;
+}
+
+[data-theme="light"] {
+  --accent:      #2952c8;
+  --accent-hover: #1e3ea0;
+  --accent-dim:  rgba(41, 82, 200, 0.1);
+  --accent-glow: rgba(41, 82, 200, 0.18);
+
+  --ok-dim:      rgba(56, 158, 13, 0.1);
+  --warn-dim:    rgba(212, 107, 8, 0.12);
+  --err-dim:     rgba(207, 19, 34, 0.1);
+  --neutral-dim: rgba(74, 68, 70, 0.08);
 }
 
 /* ═══ Reset ══════════════════════════════════════════════════════════════════ */
@@ -50,6 +63,10 @@ body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   color-scheme: dark;
+}
+
+[data-theme="light"] body {
+  color-scheme: light;
 }
 
 a { color: inherit; text-decoration: none; }
@@ -94,7 +111,7 @@ p { margin: 0; }
   height: 28px;
   border-radius: 7px;
   background: var(--accent);
-  color: #fff;
+  color: var(--color-text-on-burgundy);
   font-weight: 800;
   font-size: 0.9rem;
   display: flex;
@@ -406,7 +423,7 @@ p { margin: 0; }
   transition: transform 180ms, background 180ms;
 }
 
-.toggle--on .toggle-thumb { transform: translateX(15px); background: #fff; }
+.toggle--on .toggle-thumb { transform: translateX(15px); background: var(--color-text-on-burgundy); }
 
 /* Warning block */
 
@@ -464,10 +481,10 @@ p { margin: 0; }
 .btn-primary {
   background: var(--accent);
   border-color: transparent;
-  color: #fff;
+  color: var(--color-text-on-burgundy);
 }
 
-.btn-primary:hover { background: #5a7de8; border-color: transparent; }
+.btn-primary:hover { background: var(--accent-hover); border-color: transparent; }
 
 .btn-ghost {
   background: transparent;

--- a/shared/styles/extracted-pwa-styles/tokens.css
+++ b/shared/styles/extracted-pwa-styles/tokens.css
@@ -35,15 +35,15 @@
   --color-surface-800: var(--color-bg-surface);
   --color-surface-700: var(--color-bg-surface-elevated);
   
-  --color-ink: #0b1021; /* Keep or map to text-primary-inverse? */
+  --color-ink: var(--color-text-on-burgundy);
   --color-neutral-50: var(--color-text-primary);
   --color-neutral-100: var(--color-text-primary);
   --color-neutral-200: var(--color-text-secondary);
   --color-neutral-250: var(--color-text-tertiary);
-  --color-neutral-300: #d1d5db;
-  --color-neutral-350: #cbd5e1;
-  --color-neutral-375: #cdd8ee;
-  --color-neutral-500: #9ca3af;
+  --color-neutral-300: var(--color-text-secondary);
+  --color-neutral-350: var(--color-text-secondary);
+  --color-neutral-375: var(--color-text-tertiary);
+  --color-neutral-500: var(--color-text-tertiary);
   
   --color-sky-200: var(--color-gold-400); /* Eyebrow */
   --color-sky-300: var(--color-gold-500);
@@ -53,7 +53,7 @@
   --color-info-100: var(--color-text-secondary);
   
   --color-success-400: var(--color-success);
-  --color-success-100: #bbf7d0;
+  --color-success-100: var(--color-success);
   --color-warning-300: var(--color-warning);
   --color-danger-200: var(--color-error);
   --color-danger-300: var(--color-error);
@@ -80,8 +80,8 @@ body {
   --bg-hero: linear-gradient(135deg, rgba(168, 40, 71, 0.42), rgba(36, 31, 32, 0.9));
   --bg-map: var(--color-surface-800);
 
-  --border-regular: #2d2728;
-  --border-strong: #4a0e1a;
+  --border-regular: var(--color-bg-surface-hover);
+  --border-strong: var(--color-burgundy-900);
   --border-subtle: rgba(244, 191, 79, 0.24);
   --border-soft: rgba(36, 31, 32, 0.75);
 
@@ -148,42 +148,42 @@ body {
 
 body[data-theme="light"] {
   color-scheme: light;
-  --bg-body: #f7f9fc;
-  --bg-card: #ffffff;
-  --bg-card-strong: #f1f5f9;
-  --bg-panel: linear-gradient(160deg, rgba(15, 23, 42, 0.06), rgba(15, 23, 42, 0.03));
-  --bg-hero: linear-gradient(135deg, rgba(15, 23, 42, 0.06), rgba(15, 23, 42, 0.02));
-  --bg-map: #e8f0ff;
+  --bg-body: var(--color-bg-primary);
+  --bg-card: var(--color-bg-surface);
+  --bg-card-strong: var(--color-bg-surface-elevated);
+  --bg-panel: linear-gradient(160deg, rgba(26, 22, 23, 0.06), rgba(26, 22, 23, 0.03));
+  --bg-hero: linear-gradient(135deg, rgba(168, 40, 71, 0.08), rgba(244, 240, 241, 0.9));
+  --bg-map: var(--color-bg-surface-elevated);
 
-  --border-regular: #cbd5e1;
-  --border-strong: #94a3b8;
-  --border-subtle: #e2e8f0;
-  --border-soft: #e2e8f0;
+  --border-regular: var(--color-border);
+  --border-strong: var(--color-border-strong);
+  --border-subtle: var(--color-border);
+  --border-soft: var(--color-border);
 
-  --text-primary: #0f172a;
-  --text-secondary: #334155;
-  --text-muted: #475569;
-  --text-inverse: #ffffff;
-  --text-eyebrow: #0f172a;
-  --text-quiet: #475569;
+  --text-primary: var(--color-text-primary);
+  --text-secondary: var(--color-text-secondary);
+  --text-muted: var(--color-text-tertiary);
+  --text-inverse: var(--color-text-on-burgundy);
+  --text-eyebrow: var(--color-burgundy-700);
+  --text-quiet: var(--color-text-tertiary);
 
   --selection-bg: rgba(244, 191, 79, 0.2);
   --focus-ring: rgba(244, 191, 79, 0.35);
 
-  --surface-faint: #e2e8f0;
-  --surface-veil-soft: #ecf1fc;
-  --surface-veil: #edf2fb;
-  --surface-veil-strong: #e5ecfb;
-  --surface-veil-heavy: #dbeafe;
-  --surface-veil-bright: #d8e4ff;
+  --surface-faint: var(--color-bg-surface-elevated);
+  --surface-veil-soft: var(--color-bg-surface-elevated);
+  --surface-veil: var(--color-bg-surface);
+  --surface-veil-strong: var(--color-bg-surface-elevated);
+  --surface-veil-heavy: var(--color-bg-surface-hover);
+  --surface-veil-bright: rgba(184, 114, 10, 0.08);
   --surface-veil-highlight: rgba(15, 23, 42, 0.12);
   --surface-veil-contrast: rgba(15, 23, 42, 0.18);
   --surface-veil-stronger: rgba(15, 23, 42, 0.2);
 
-  --chip-surface: #e8f0ff;
-  --chip-border: #cbd5e1;
-  --pill-surface: #e2e8f0;
-  --pill-border: #cbd5e1;
+  --chip-surface: rgba(184, 114, 10, 0.08);
+  --chip-border: rgba(184, 114, 10, 0.2);
+  --pill-surface: var(--color-bg-surface-elevated);
+  --pill-border: var(--color-border);
   --pill-shadow: 0 6px 20px rgba(15, 23, 42, 0.1);
 
   --shadow-card: 0 10px 40px rgba(15, 23, 42, 0.14);

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -1,4 +1,4 @@
-﻿﻿﻿﻿@import "tailwindcss";
+﻿﻿﻿﻿﻿@import "tailwindcss";
 @source "../../apps/mobile/src/**/*.{ts,tsx,js,jsx,html}";
 @source "../../apps/mobile/index.html";
 @source "../../apps/mobile/*.html";

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -153,8 +153,7 @@ html[data-theme="light"] {
   --color-burgundy-700:         #a82847;
   /* Light-theme podium base: near-opaque white so the metallic gold/
      silver/bronze tints fade onto a paper card instead of into black. */
-  --color-podium-base:          rgba(255, 255, 255, 0.95);
-}
+  --color-podium-base:          rgba(255, 255, 255, 0.95);}
 
 html[data-theme="light"] body,
 html[data-theme="light"] body.mobile-fixed-bg {

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -1,4 +1,4 @@
-﻿﻿﻿@import "tailwindcss";
+﻿﻿﻿﻿@import "tailwindcss";
 @source "../../apps/mobile/src/**/*.{ts,tsx,js,jsx,html}";
 @source "../../apps/mobile/index.html";
 @source "../../apps/mobile/*.html";

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+﻿@import "tailwindcss";
 @source "../../apps/mobile/src/**/*.{ts,tsx,js,jsx,html}";
 @source "../../apps/mobile/index.html";
 @source "../../apps/mobile/*.html";
@@ -6,7 +6,8 @@
 @import "./extracted-pwa-styles/layout.css";
 @import "./extracted-pwa-styles/style.css";
 
-:root {
+:root,
+[data-theme='dark'] {
   --color-burgundy-950: #2d0a0f;
   --color-burgundy-900: #4a0e1a;
   --color-burgundy-800: #6b1529;
@@ -26,6 +27,11 @@
   --color-success: #52c41a;
   --color-error: #ff4d4f;
   --color-warning: #faad14;
+  --color-border: rgba(255, 255, 255, 0.08);
+  --color-border-strong: rgba(255, 255, 255, 0.15);
+  --color-surface-overlay: rgba(0, 0, 0, 0.4);
+  --color-text-on-burgundy: #ffffff;
+  --color-focus-ring: #f4bf4f;
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
   --space-md: 1rem;
@@ -342,8 +348,7 @@ html[data-theme="light"] .text-white {
    that need a guaranteed-white text in either theme should use the
    semantic `.text-on-accent` class below instead of `text-white`. */
 .text-on-accent { color: #ffffff; }
-
-@layer base {
+@layer base {
   * {
     margin: 0;
     padding: 0;
@@ -461,7 +466,7 @@ html[data-theme="light"] .text-white {
   }
 
   :focus-visible {
-    outline: 2px solid var(--color-gold-400);
+    outline: 2px solid var(--color-focus-ring);
     outline-offset: 2px;
   }
 
@@ -502,6 +507,26 @@ html[data-theme="light"] .text-white {
     outline: 2px solid var(--color-gold-400);
     outline-offset: 2px;
   }
+}
+
+[data-theme='light'] body.mobile-fixed-bg::before {
+  background-color: var(--color-bg-primary);
+  background-image: linear-gradient(
+    180deg,
+    rgba(250, 249, 249, 1) 0%,
+    rgba(244, 240, 241, 1) 52%,
+    rgba(232, 220, 224, 1) 100%
+  );
+}
+
+[data-theme='light'] .app-gradient {
+  background-color: var(--color-bg-primary);
+  background-image: linear-gradient(
+    180deg,
+    rgba(250, 249, 249, 1) 0%,
+    rgba(244, 240, 241, 1) 52%,
+    rgba(232, 220, 224, 1) 100%
+  );
 }
 
 @keyframes fadeIn {
@@ -1233,4 +1258,25 @@ html[data-theme="light"] .text-white {
   .animate-tutorial-spotlight-pulse {
     animation: none;
   }
+}
+
+@theme {
+  --color-surface: var(--color-bg-surface);
+  --color-surface-elevated: var(--color-bg-surface-elevated);
+  --color-surface-hover: var(--color-bg-surface-hover);
+  --color-primary-bg: var(--color-bg-primary);
+  --color-text-default: var(--color-text-primary);
+  --color-text-muted: var(--color-text-secondary);
+  --color-text-subtle: var(--color-text-tertiary);
+  --color-accent: var(--color-gold-400);
+  --color-accent-hover: var(--color-gold-500);
+  --color-accent-strong: var(--color-gold-600);
+  --color-brand: var(--color-burgundy-700);
+  --color-brand-dark: var(--color-burgundy-900);
+  --color-brand-darkest: var(--color-burgundy-950);
+  --color-border-default: var(--color-border);
+  --color-border-strong: var(--color-border-strong);
+  --color-overlay: var(--color-surface-overlay);
+  --color-on-brand: var(--color-text-on-burgundy);
+  --color-focus: var(--color-focus-ring);
 }

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -159,8 +159,7 @@ html[data-theme="light"] body,
 html[data-theme="light"] body.mobile-fixed-bg {
   background-color: var(--color-bg-primary);
   background-image: none;
-  color: var(--color-text-primary);
-}
+  color: var(--color-text-primary);}
 
 html[data-theme="light"] body.mobile-fixed-bg::before {
   background-color: var(--color-bg-primary);

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -1,4 +1,4 @@
-﻿@import "tailwindcss";
+﻿﻿@import "tailwindcss";
 @source "../../apps/mobile/src/**/*.{ts,tsx,js,jsx,html}";
 @source "../../apps/mobile/index.html";
 @source "../../apps/mobile/*.html";
@@ -1279,4 +1279,4 @@ html[data-theme="light"] .text-white {
   --color-overlay: var(--color-surface-overlay);
   --color-on-brand: var(--color-text-on-burgundy);
   --color-focus: var(--color-focus-ring);
-}
+}

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -1,4 +1,4 @@
-﻿﻿@import "tailwindcss";
+﻿﻿﻿@import "tailwindcss";
 @source "../../apps/mobile/src/**/*.{ts,tsx,js,jsx,html}";
 @source "../../apps/mobile/index.html";
 @source "../../apps/mobile/*.html";

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -348,7 +348,8 @@ html[data-theme="light"] .text-white {
    that need a guaranteed-white text in either theme should use the
    semantic `.text-on-accent` class below instead of `text-white`. */
 .text-on-accent { color: #ffffff; }
-@layer base {
+
+@layer base {
   * {
     margin: 0;
     padding: 0;
@@ -1279,4 +1280,4 @@ html[data-theme="light"] .text-white {
   --color-overlay: var(--color-surface-overlay);
   --color-on-brand: var(--color-text-on-burgundy);
   --color-focus: var(--color-focus-ring);
-}
+}

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -168,8 +168,7 @@ html[data-theme="light"] body.mobile-fixed-bg::before {
     #f3ecdc 0%,
     #ede5d6 55%,
     #e6dcc7 100%
-  );
-}
+  );}
 
 html[data-theme="light"] .app-gradient {
   background-color: var(--color-bg-primary);

--- a/supabase/migrations/20260417130000_accessibility_preferences.sql
+++ b/supabase/migrations/20260417130000_accessibility_preferences.sql
@@ -1,0 +1,4 @@
+-- Issue #476: accessibility preferences (theme, accessible mode)
+alter table profiles
+  add column if not exists theme text default 'dark' check (theme in ('dark', 'light')),
+  add column if not exists accessible_mode boolean default false;

--- a/supabase/migrations/20260417140000_accessibility_theme_system.sql
+++ b/supabase/migrations/20260417140000_accessibility_theme_system.sql
@@ -1,0 +1,10 @@
+-- Issue #476: aggiungi valore 'system' alla colonna theme (segue tema OS)
+alter table profiles
+  drop constraint if exists profiles_theme_check;
+
+alter table profiles
+  add constraint profiles_theme_check check (theme in ('dark', 'light', 'system'));
+
+-- Aggiorna il default a 'system' per i nuovi utenti
+alter table profiles
+  alter column theme set default 'system';


### PR DESCRIPTION
## Sommario

Check visivo del mobile → 8 fix di UX/polish identificati e implementati.

## Modifiche principali

### 🆕 Nuovo componente
- **`PasswordInput`** — campo password con toggle mostra/nascondi (Eye/EyeOff); riutilizzabile in Login e Signup

### 🔧 Fix UX critici
- **Login / Signup** — usa `PasswordInput` per i campi password; form allargato da `max-w-[300px]` a `max-w-[340px]` per sfruttare meglio lo schermo
- **Login** — `Password dimenticata?` ridotto da `py-2.5 mt-2` a `py-1 mt-1` (eliminati ~28 px di spazio sprecato tra campo e submit)
- **Signup** — checkbox Termini/Privacy sostituita con componente custom (bordo + icona Check): era un `<input type=checkbox>` nativo con solo `accent-color`, fuori design system e touch target borderline
- **CookieConsent** — bottone `Rifiuta` ora è un vero button `h-[44px]` con bordo visibile, parificato all'Accetta per GDPR (era solo testo sottolineato)
- **AuthFormLayout** — aggiunto `overflow-y-auto min-h-0`: il form di signup è ora scrollabile quando la tastiera virtuale restringe il viewport

### 🎨 Fix visual
- **MetricTile** — valore da `text-[52px]` → `text-[36px]`: troppo grande in griglia 2 colonne, su numeri a più cifre traboccava dal tile
- **BottomNav** — label tab da `9.5px` → `11px`: sotto il minimo iOS (11px) / Android (12sp)
- **Home EventCard** — rimossa `Calendar size={50}` + `slice(0,6)` rotta (su date ISO `2024-05-25` produceva `"2024-0"`); aggiunto `EventDateTile` che mostra giorno + mese in italiano

## Testing
- `tsc --noEmit` senza errori
- Check visivo manuale con Puppeteer (iPhone 12, 390×844)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
