### PR TITLE
fix: handle missing email in loadRemoteState profile creation (closes #1123)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3864,6 +3864,13 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
               notifyCriticalError('Non riusciamo a creare il profilo utente.', [insertRes.error]);
             }
             profileRow = insertRes.data ?? null;
+          } else if (!profileRow) {
+            // No profile row exists and the authenticated user has no email address
+            // (e.g. anonymous auth, OAuth provider that did not supply an email).
+            // Silently unblocking the app with a blank profile would leave it in an
+            // invalid state, so surface a critical error instead. Closes #1123.
+            notifyCriticalError('Non riusciamo a creare il profilo utente: email mancante.', []);
+            return;
           }
 
           if (!isMounted) return;


### PR DESCRIPTION
## Intent

Fixes #1123: when an authenticated user has no email address (e.g. anonymous auth, OAuth without email), `loadRemoteState` was silently skipping the profile INSERT and calling `setHasHydratedRemote(true)`, leaving the app operating on a blank/invalid profile with no error shown.

## Key Changes

**`apps/mobile/src/state/store.tsx`** — added `else if (!profileRow)` branch immediately after the INSERT block (line ~3867):

```ts
} else if (!profileRow) {
  // No profile row exists and the authenticated user has no email address
  // (e.g. anonymous auth, OAuth provider that did not supply an email).
  // Silently unblocking the app with a blank profile would leave it in an
  // invalid state, so surface a critical error instead. Closes #1123.
  notifyCriticalError('Non riusciamo a creare il profilo utente: email mancante.', []);
  return;
}
```

When `profileRow` is null and `user.email` is falsy, `notifyCriticalError` is now called and the function returns early — preventing `setHasHydratedRemote(true)` from being reached with no valid profile.

## Distinction from related issues

- **#1103**: INSERT fails with a DB error (already handled by the existing `insertRes.error` check)
- **#1046**: INSERT fails but `hasHydratedRemote` was set anyway
- **#1123** (this PR): INSERT is never attempted because `email` is absent — previously a silent no-op

## Testing

- Manual: verified logic path via code inspection — the `else if` clause only fires when `profileRow` is null AND `userRes.data?.user?.email` is falsy (the original `if` condition is false).
- No existing tests were broken; the change adds an early-return guard on an unreachable path in normal authenticated flows.

https://claude.ai/code/session_019gXKhyxGeDkL7kejkmeudP

---
_Generated by [Claude Code](https://claude.ai/code/session_019gXKhyxGeDkL7kejkmeudP)_