### PR TITLE
fix: do not overwrite cachet/reputation on duplicate activity

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4752,10 +4752,13 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
         const rewards = rpcResponse.rewards_applied;
         setState((prev: GameState) => {
-          const profileAfterRewards =
-            rpcResponse.status === 'duplicate'
-              ? prev.profile
-              : applyRewards(prev.profile, rewards, 'activity');
+          if (rpcResponse.status === 'duplicate') {
+            // Duplicate: rewards already counted — do not overwrite local
+            // cachet/reputation with potentially-stale server balances that
+            // may not reflect concurrent mutations (e.g. a shop purchase).
+            return prev;
+          }
+          const profileAfterRewards = applyRewards(prev.profile, rewards, 'activity');
           return {
             ...prev,
             profile: {


### PR DESCRIPTION
Closes #1128

## Changes
- In `completeActivity`, when the RPC returns `status === 'duplicate'`, the local state is now left unchanged instead of being overwritten with the server's `cachet_balance_after`/`reputation_after`. This prevents concurrent mutations (e.g. a shop purchase that occurred between the RPC call and the setState) from being silently lost.
- Previously, both branches of the conditional (`duplicate` vs non-duplicate) unconditionally applied the server's balances. Now only the non-duplicate path applies them.

https://claude.ai/code/session_01W6FzkU4Rh3WxPL1VB8zTUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6FzkU4Rh3WxPL1VB8zTUQ)_