### PR TITLE
fix: pass telemetry params on offline activity_insert replay

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -882,6 +882,13 @@ type ActivityInsertPayload = {
   user_id: string;
   activity_id: string;
   rewards: Rewards;
+  // Optional telemetry fields — included when the activity was queued online
+  // and replayed during offline-sync flush. Missing fields default to null/1
+  // on the server, but omitting them loses telemetry entirely (closes #1129).
+  score?: number | null;
+  rating?: string | null;
+  attempts?: number | null;
+  duration_ms?: number | null;
 };
 
 type FollowEventMutationPayload = {
@@ -2762,6 +2769,10 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           const { data, error } = await supabase.rpc('complete_activity_with_slots', {
             p_activity_id: mutation.payload.activity_id,
             p_client_action_id: mutation.payload.id,
+            p_score: mutation.payload.score ?? null,
+            p_rating: mutation.payload.rating ?? null,
+            p_attempts: mutation.payload.attempts ?? 1,
+            p_duration_ms: mutation.payload.duration_ms ?? null,
           });
           if (error) {
             return shouldRetrySyncError(error)


### PR DESCRIPTION
Closes #1129

## Changes
- Added optional telemetry fields (`score`, `rating`, `attempts`, `duration_ms`) to `ActivityInsertPayload` type so they can be stored in the offline queue.
- In `executeQueuedSupabaseMutation` for `activity_insert`, the `complete_activity_with_slots` RPC call now passes all four telemetry parameters (`p_score`, `p_rating`, `p_attempts`, `p_duration_ms`) from the payload instead of omitting them, preventing silent telemetry loss during offline-queued activity replays.

https://claude.ai/code/session_01W6FzkU4Rh3WxPL1VB8zTUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6FzkU4Rh3WxPL1VB8zTUQ)_