### PR TITLE
fix: clear appliedNarrativeChoicesRef in resetState

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -5197,6 +5197,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       totalSlots,
       remainingSlots: totalSlots,
     });
+    // Clear the narrative idempotency guard so that replaying scenes after a
+    // progress reset in the same session yields rewards correctly (closes #1130).
+    appliedNarrativeChoicesRef.current = new Set();
   }, []);
 
   // GDPR Art. 17 – Diritto alla cancellazione: elimina account e tutti i dati utente.


### PR DESCRIPTION
Closes #1130

## Changes
- In `resetState()`, added `appliedNarrativeChoicesRef.current = new Set()` to clear the narrative idempotency guard set.
- Without this fix, after a progress reset in the same session, replaying any narrative scene would yield zero rewards because the idempotency guard (`appliedNarrativeChoicesRef`) still contained all previously-seen `sceneId:choiceId` keys from before the reset, causing the guard to falsely trigger.

https://claude.ai/code/session_01W6FzkU4Rh3WxPL1VB8zTUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6FzkU4Rh3WxPL1VB8zTUQ)_