### PR TITLE
fix: guard service-role bypass against empty SUPABASE_SERVICE_ROLE_KEY

### DIFF
--- a/supabase/functions/import-atcl-lazio/index.ts
+++ b/supabase/functions/import-atcl-lazio/index.ts
@@ -207,7 +207,9 @@ serve(async (req) => {
   const callerToken = authHeader.slice('Bearer '.length);
 
   // Service-role key allows the control-plane to call this function without a user session.
-  if (callerToken !== serviceKey) {
+  // The non-empty check prevents an empty-string SUPABASE_SERVICE_ROLE_KEY from
+  // accidentally matching an empty Bearer token and bypassing auth (closes #1131).
+  if (!serviceKey || callerToken !== serviceKey) {
     const userClient = createClient(supabaseUrl, anonKey, {
       global: { headers: { Authorization: authHeader } },
       auth: { autoRefreshToken: false, persistSession: false },

--- a/supabase/functions/import-spazio-rossellini/index.ts
+++ b/supabase/functions/import-spazio-rossellini/index.ts
@@ -210,7 +210,9 @@ serve(async (req) => {
   const callerToken = authHeader.slice('Bearer '.length);
 
   // Service-role key allows the control-plane to call this function without a user session.
-  if (callerToken !== serviceKey) {
+  // The non-empty check prevents an empty-string SUPABASE_SERVICE_ROLE_KEY from
+  // accidentally matching an empty Bearer token and bypassing auth (closes #1131).
+  if (!serviceKey || callerToken !== serviceKey) {
     const userClient = createClient(supabaseUrl, anonKey, {
       global: { headers: { Authorization: authHeader } },
       auth: { autoRefreshToken: false, persistSession: false },


### PR DESCRIPTION
Closes #1131

## Changes
- In both `import-atcl-lazio/index.ts` and `import-spazio-rossellini/index.ts`, the service-role key bypass condition now also checks `!serviceKey` before comparing tokens: `if (!serviceKey || callerToken !== serviceKey)`.
- Without this guard, if `SUPABASE_SERVICE_ROLE_KEY` is misconfigured as an empty string, a request with `Bearer ` (empty token) would satisfy `"" === ""` and bypass JWT auth, gaining admin bulk-import access without any authentication.
- The fix ensures that an empty/falsy service key always routes through normal user JWT verification.

https://claude.ai/code/session_01W6FzkU4Rh3WxPL1VB8zTUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6FzkU4Rh3WxPL1VB8zTUQ)_