### PR TITLE
fix: block local activation fallback when activateRemotely returns null

### DIFF
--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -547,6 +547,15 @@ export async function activateTicketHash(
     if (remote !== null) {
       return { ok: false, error: 'Risposta server inattesa durante l\'attivazione ticket.' };
     }
+
+    // remote === null means activateRemotely returned early because the
+    // supabase client was null at invocation time (race condition). When
+    // Supabase is configured, we must NOT fall through to local-only
+    // activation — that would mark the ticket as activated without any
+    // server confirmation (closes #1133).
+    if (isSupabaseConfigured) {
+      return { ok: false, error: 'Servizio non disponibile. Riprova tra qualche istante.' };
+    }
   } catch (error) {
     if (shouldLogActivationError(error)) {
       console.error('Remote activation failed:', error);


### PR DESCRIPTION
Closes #1133

## Changes
- In `activateTicketHash`, added an explicit guard after the `remote !== null` check: when `activateRemotely` returns `null` (meaning `supabase` was null at invocation time due to a race condition) AND `isSupabaseConfigured` is true, the function now returns an error instead of falling through to the local-only activation path.
- Without this fix, a race condition where `supabase` became null between the function call and `activateRemotely`'s internal check would silently mark the ticket as activated locally without any server confirmation.

https://claude.ai/code/session_01W6FzkU4Rh3WxPL1VB8zTUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6FzkU4Rh3WxPL1VB8zTUQ)_