### PR TITLE
fix: use getUser() instead of getSession() in changePassword

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4936,9 +4936,13 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           }
 
           if (currentPassword) {
-            const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
-            if (sessionError) throw sessionError;
-            const email = sessionData.session?.user.email;
+            // Use getUser() (network-verified) instead of getSession() (locally
+            // cached) so that an empty/stale local session cache does not cause
+            // a false "Email mancante" error when the user IS authenticated
+            // (closes #1135).
+            const { data: userData, error: userError } = await supabase.auth.getUser();
+            if (userError) throw userError;
+            const email = userData.user?.email;
             if (!email) {
               throw new Error('Email mancante');
             }


### PR DESCRIPTION
Closes #1135

## Changes
- In `changePassword`, replaced `supabase.auth.getSession()` with `supabase.auth.getUser()` to obtain the user's email for current-password verification.
- `getSession()` reads from the local cache and may return null/stale data even when the user is authenticated (e.g. after token refresh cleared the local cache), causing a misleading "Email mancante" error. `getUser()` makes a network-verified call to the Supabase auth server, ensuring the email is always available when the user is genuinely authenticated.

https://claude.ai/code/session_01W6FzkU4Rh3WxPL1VB8zTUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6FzkU4Rh3WxPL1VB8zTUQ)_