### PR TITLE
fix: reset hasHydratedRemote to false in resetState (v2)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -5214,6 +5214,10 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     // Clear the narrative idempotency guard so that replaying scenes after a
     // progress reset in the same session yields rewards correctly (closes #1130).
     appliedNarrativeChoicesRef.current = new Set();
+    // Reset hydration flag so persistProfile's guard re-arms and does not sync
+    // blank default state to the DB if called before the next remote hydration
+    // completes (closes #1132).
+    setHasHydratedRemote(false);
   }, []);
 
   // GDPR Art. 17 – Diritto alla cancellazione: elimina account e tutti i dati utente.


### PR DESCRIPTION
Closes #1132

## Changes
- Added `setHasHydratedRemote(false)` to `resetState()`.
- Without this fix, `hasHydratedRemote` remained `true` after a reset, so `persistProfile`'s guard (`if (!supabase || !authUserId || !hasHydratedRemote) return`) would not block a call to `persistProfile` immediately after reset — potentially syncing blank default state to the DB before the next remote hydration completed.
- (v2: rebased onto current main after merge conflict with #1130 fix)

https://claude.ai/code/session_01W6FzkU4Rh3WxPL1VB8zTUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6FzkU4Rh3WxPL1VB8zTUQ)_