### PR TITLE
fix: slice action field to 100 chars before echoing into error response

### DIFF
--- a/supabase/functions/mobile-logs/index.ts
+++ b/supabase/functions/mobile-logs/index.ts
@@ -149,7 +149,7 @@ serve(async (req: Request) => {
   }
 
   try {
-    const action = typeof body.action === 'string' ? body.action.trim() : 'ingest_logs';
+    const action = typeof body.action === 'string' ? body.action.trim().slice(0, 100) : 'ingest_logs';
     if (action !== 'ingest_logs') {
       return jsonResponse({ error: `Azione non supportata: ${action}` }, 400);
     }


### PR DESCRIPTION
Closes #1145

## What changed
In `supabase/functions/mobile-logs/index.ts`, the `action` field from the request body was trimmed but not length-limited before being interpolated into the 400 error response JSON. This allowed an authenticated caller to send an arbitrarily large `action` string and receive an equally large response body, wasting Supabase compute and egress bandwidth.

The fix adds `.slice(0, 100)` to the `action` field extraction — consistent with how `source` (sliced to 120), `duplicatePolicy` (sliced to 80), and `clientUserId` (sliced to 200) are already handled in the same function.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwJke6wXS6oo4LLex3Z5yK)_