### PR TITLE
fix: add auth options to event-links supabase client to prevent session bleed

### DIFF
--- a/supabase/functions/event-links/index.ts
+++ b/supabase/functions/event-links/index.ts
@@ -110,6 +110,7 @@ serve(async (req) => {
     global: {
       headers: { Authorization: authHeader },
     },
+    auth: { autoRefreshToken: false, persistSession: false },
   });
 
   const { data: { user }, error: authError } = await supabase.auth.getUser();


### PR DESCRIPTION
Closes #1146

## What changed
In `supabase/functions/event-links/index.ts`, the Supabase client created for JWT verification was missing `auth: { autoRefreshToken: false, persistSession: false }`. Every other edge function in this project already passes these options.

Without these flags, the Supabase JS client may start an internal token-refresh timer and attempt to persist/read session data via in-memory storage shared across requests within the same Deno isolate, creating a potential for cross-request session bleed in long-lived isolates.

The fix adds the missing `auth` options, consistent with `delete-my-account`, `mobile-logs`, `pseudonymize-user-id`, `ticket-activation`, `cleanup-events`, and all other edge functions in the project.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwJke6wXS6oo4LLex3Z5yK)_