### PR TITLE
fix: validate userId UUID format before constructing storage bucket path

### DIFF
--- a/apps/mobile/src/services/storage.ts
+++ b/apps/mobile/src/services/storage.ts
@@ -5,9 +5,15 @@ const PROFILE_UPLOAD_WATCHDOG_MS = 30000;
 const ALLOWED_IMAGE_MIME_PREFIX = 'image/';
 const MAX_PROFILE_IMAGE_BYTES = 5 * 1024 * 1024;
 
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function uploadProfileImage(userId: string, file: File): Promise<string> {
   return withMobileWatchdog(async () => {
     if (!supabase) throw new Error('Supabase non configurato');
+
+    if (!UUID_PATTERN.test(userId)) {
+      throw new Error('userId non valido: formato UUID atteso');
+    }
 
     if (!file.type.startsWith(ALLOWED_IMAGE_MIME_PREFIX)) {
       throw new Error('Formato immagine non valido');


### PR DESCRIPTION
Closes #1147

## What changed
In `apps/mobile/src/services/storage.ts`, `uploadProfileImage` was constructing the Supabase Storage path directly from the raw `userId` parameter without any format validation. A non-UUID `userId` (e.g. from demo mode, anonymous auth, or a future OAuth provider) would silently create an object under an unexpected prefix that would never be cleaned up by the account-deletion flow.

The fix adds a UUID format check (`UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i`) at the top of the function body. If the ID does not match the standard UUID format, the function throws a descriptive error (`'userId non valido: formato UUID atteso'`) rather than silently writing to an unintended bucket path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwJke6wXS6oo4LLex3Z5yK)_