### PR TITLE
fix: add autoRefreshToken/persistSession to dev-access Supabase client (closes #1151)

### DIFF
--- a/supabase/functions/dev-access/index.ts
+++ b/supabase/functions/dev-access/index.ts
@@ -111,6 +111,7 @@ serve(async (req) => {
     global: {
       headers: { Authorization: authHeader },
     },
+    auth: { autoRefreshToken: false, persistSession: false },
   });
 
   const { data, error } = await supabaseClient.auth.getUser();


### PR DESCRIPTION
Closes #1151

The `createClient` call in `supabase/functions/dev-access/index.ts` was missing `auth: { autoRefreshToken: false, persistSession: false }` in its options object. This matches the pattern used by all other edge functions in the repo (e.g. `event-links`). Without these options, the Supabase client may attempt token refresh or session persistence in a serverless edge context where it has no meaning and can cause unexpected behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_016GiCCHdFCnV6t3TokSHQYY)_