### PR TITLE
fix: move persistProfile outside setState updater in completeOnboarding (closes #1152)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4261,6 +4261,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   const completeOnboarding = useCallback(
     (variant: 'full' | 'skipped_qr' | 'skipped_manual', xpReward?: number) => {
       const completedAt = new Date().toISOString();
+      let nextProfile: PlayerProfile | null = null;
       setState((prev: GameState) => {
         let profile: PlayerProfile = {
           ...prev.profile,
@@ -4270,9 +4271,12 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         if (xpReward && xpReward > 0) {
           profile = applyRewards(profile, { xp: xpReward, cachet: 0, reputation: 0 }, 'activity');
         }
-        persistProfile(profile);
+        nextProfile = profile;
         return { ...prev, profile };
       });
+      if (nextProfile !== null) {
+        persistProfile(nextProfile);
+      }
     },
     [persistProfile],
   );


### PR DESCRIPTION
Closes #1152

`completeOnboarding` was calling the async `persistProfile` function directly inside the `setState` updater callback. React may invoke updater functions more than once (e.g. in StrictMode or concurrent features), which could cause duplicate network calls or race conditions.

The fix follows the same pattern already used by `updateProfile` in the same file: capture the computed profile in a `nextProfile` variable inside the updater (which remains a pure function), then call `persistProfile(nextProfile)` after `setState` returns.

---
_Generated by [Claude Code](https://claude.ai/code/session_016GiCCHdFCnV6t3TokSHQYY)_