### PR TITLE
fix: remove notifyCriticalError from refreshLeaderboard (closes #1153)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -2583,7 +2583,6 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           setLeaderboard(nextLeaderboard);
         } catch (error) {
           console.warn('Supabase leaderboard fetch failed', error);
-          notifyCriticalError('Non riusciamo a caricare la classifica dal database.', [error]);
           setLeaderboard([]);
         } finally {
           setLeaderboardLoading(false);


### PR DESCRIPTION
Closes #1153

`refreshLeaderboard` was calling `notifyCriticalError` when the leaderboard fetch failed, which surfaces a critical error dialog to the user. The leaderboard is decorative/non-critical data and a fetch failure should not be treated as a critical error.

The fix removes the `notifyCriticalError` call, leaving just the existing `console.warn` and the `setLeaderboard([])` fallback — matching the silent-fail pattern used by other non-critical refresh functions in the same file (e.g. shop catalog fetch, activity slots fetch, feature flags fetch).

---
_Generated by [Claude Code](https://claude.ai/code/session_016GiCCHdFCnV6t3TokSHQYY)_