### PR TITLE
fix: delete narrative_history rows on account deletion (GDPR Art. 17)

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -67,6 +67,7 @@ serve(async (req) => {
     { table: 'activity_completions', key: 'user_id' },
     { table: 'user_badges', key: 'user_id' },
     { table: 'planned_participations', key: 'user_id' },
+    { table: 'narrative_history', key: 'user_id' },
     { table: 'turns', key: 'user_id' },
     { table: 'profiles', key: 'id' },
   ] as const;


### PR DESCRIPTION
Closes #1157

`store.tsx completeNarrativeChoice` writes rows to the `narrative_history` table, but the `delete-my-account` Edge Function never deleted them. This is a GDPR Art. 17 (right to erasure) violation — user data persisted after account deletion.

Added `{ table: 'narrative_history', key: 'user_id' }` to the `tablesToDelete` array in `supabase/functions/delete-my-account/index.ts`, positioned before `turns` and `profiles` to respect FK dependency order.

---
_Generated by [Claude Code](https://claude.ai/code/session_017thp7nCmvAMHuSmZ3CNMwU)_