### PR TITLE
fix: make JWT auth unconditional in app-version function

### DIFF
--- a/supabase/functions/app-version/index.ts
+++ b/supabase/functions/app-version/index.ts
@@ -42,20 +42,25 @@ serve(async (req) => {
 
   const supabaseUrl = Deno.env.get('SUPABASE_URL');
   const anonKey = Deno.env.get('SUPABASE_ANON_KEY');
-  if (supabaseUrl && anonKey) {
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return errorResponse('Autenticazione richiesta', 401);
-    }
-    const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2.48.0');
-    const userClient = createClient(supabaseUrl, anonKey, {
-      global: { headers: { Authorization: authHeader } },
-      auth: { autoRefreshToken: false, persistSession: false },
+  if (!supabaseUrl || !anonKey) {
+    return new Response(JSON.stringify({ error: 'Service misconfigured' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
-    const { data: { user }, error: authError } = await userClient.auth.getUser();
-    if (authError || !user) {
-      return errorResponse('Autenticazione richiesta', 401);
-    }
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return errorResponse('Autenticazione richiesta', 401);
+  }
+  const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2.48.0');
+  const userClient = createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  const { data: { user }, error: authError } = await userClient.auth.getUser();
+  if (authError || !user) {
+    return errorResponse('Autenticazione richiesta', 401);
   }
 
   const appVersion = Deno.env.get('APP_VERSION') ?? '0.0.5';


### PR DESCRIPTION
Closes #1158

The `app-version` Edge Function wrapped the entire JWT verification block in `if (supabaseUrl && anonKey) { ... }`. When either env var was absent or misconfigured, the entire auth check was silently skipped and any unauthenticated caller received the full GitHub changelog response.

Inverted the guard: if `!supabaseUrl || !anonKey`, return a 500 "Service misconfigured" response immediately. The JWT verification (`authHeader` check + `getUser()` call) now always runs unconditionally, so unauthenticated requests are always rejected with 401.

---
_Generated by [Claude Code](https://claude.ai/code/session_017thp7nCmvAMHuSmZ3CNMwU)_