### PR TITLE
fix: Realtime profiles handler missing skills and course fields

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4072,6 +4072,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
               onboardingVariant: (profile.onboarding_variant === 'full' || profile.onboarding_variant === 'skipped_qr' || profile.onboarding_variant === 'skipped_manual')
                 ? profile.onboarding_variant
                 : prev.profile.onboardingVariant,
+              skills: profile.skills ?? prev.profile.skills,
+              activeCourses: profile.active_courses ?? prev.profile.activeCourses,
+              completedCourses: profile.completed_courses ?? prev.profile.completedCourses,
             },
           }));
           setHasHydratedRemote(true);


### PR DESCRIPTION
Closes #1163

## Problem
The Supabase Realtime `postgres_changes` handler for the `profiles` table in `apps/mobile/src/state/store.tsx` updated most profile fields live, but omitted:
- `skills`
- `activeCourses` (mapped from `active_courses`)
- `completedCourses` (mapped from `completed_courses`)

This caused the local state to become stale for these fields after a Realtime push, even though `loadRemoteState` correctly handled them on initial load.

## Fix
Added the three missing field mappings to the Realtime `setState` block, mirroring the pattern already used in `loadRemoteState`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012F1ar3ZBQhVYB3iz24AdkE)_