### PR TITLE
fix: skip state overwrite in purchaseShopItem on duplicate RPC response

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4656,15 +4656,23 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           };
         }
 
-        setState((prev: GameState) => ({
-          ...prev,
-          profile: {
-            ...prev.profile,
-            cachet: rpcResponse.cachet_balance_after,
-            reputation: rpcResponse.profile_reputation_after,
-            extraActivitySlots: rpcResponse.extra_slots_after,
-          },
-        }));
+        setState((prev: GameState) => {
+          if (rpcResponse.status === 'duplicate') {
+            // Duplicate: purchase already counted — do not overwrite local
+            // cachet/reputation/extraActivitySlots with potentially-stale
+            // server balances that reflect pre-purchase state.
+            return prev;
+          }
+          return {
+            ...prev,
+            profile: {
+              ...prev.profile,
+              cachet: rpcResponse.cachet_balance_after,
+              reputation: rpcResponse.profile_reputation_after,
+              extraActivitySlots: rpcResponse.extra_slots_after,
+            },
+          };
+        });
 
         refreshActivitySlotsStatus().catch(() => {});
         if (rpcResponse.theatre) {


### PR DESCRIPTION
Closes #1167

Applies the same duplicate-status guard from `completeActivity` (#1128) to `purchaseShopItem`: local `cachet`, `reputation`, and `extraActivitySlots` are no longer overwritten with stale server balances when the RPC returns `status: 'duplicate'`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012F1ar3ZBQhVYB3iz24AdkE)_