### PR TITLE
fix: clear eventPlans and followedEvents in resetProgress

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4937,6 +4937,10 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           totalSlots: 3,
           remainingSlots: 3,
         });
+        setEventPlans([]);
+        setEventPlansLoading(false);
+        setFollowedEvents([]);
+        setFollowedEventsLoading(false);
 
         if (isSupabaseConfigured && supabase && authUserId && !shouldQueueReset) {
           await Promise.all([refreshTurnStats(), refreshTheatreReputation(), refreshBadges()]);


### PR DESCRIPTION
Closes #1169

## What changed
Added the missing `setEventPlans([])`, `setEventPlansLoading(false)`, `setFollowedEvents([])`, and `setFollowedEventsLoading(false)` calls inside `resetProgress` in `apps/mobile/src/state/store.tsx`. These mirror the same calls already present in `resetState()`, ensuring that planned/followed events are cleared immediately when progress is reset rather than persisting until the next remote sync cycle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFr9vfQmgkLep6Hi5ejBfV)_