### PR TITLE
fix: reset tutorialCompleted in resetProgress

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4906,6 +4906,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           });
         }
 
+        if (authUserId) writeTutorialCompleted(authUserId, false);
         setState((prev: GameState) => ({
           ...prev,
           profile: {
@@ -4925,6 +4926,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             completedCourses: {},
             onboardingCompletedAt: null,
             onboardingVariant: null,
+            tutorialCompleted: false,
           },
           turns: [],
         }));


### PR DESCRIPTION
Closes #1170

## What changed
Added `tutorialCompleted: false` to the profile spread inside the `setState` updater in `resetProgress`, and added a `writeTutorialCompleted(authUserId, false)` call before it to clear the localStorage key. This mirrors the pattern used by `resetTutorial()` and ensures the tutorial is re-shown after a full progress reset, consistent with how `onboardingCompletedAt`/`onboardingVariant` are also cleared in the same block.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFr9vfQmgkLep6Hi5ejBfV)_