### PR TITLE
fix: escape label, description, and href in linkCard to prevent XSS

### DIFF
--- a/apps/pwa/src/dashboard.ts
+++ b/apps/pwa/src/dashboard.ts
@@ -55,11 +55,12 @@ function flagRow(flag: FeatureFlag): string {
 }
 
 function linkCard(label: string, href: string, description: string): string {
+  const safeHref = /^https?:\/\//i.test(href) ? href : '#';
   return `
-    <a href="${href}" target="_blank" rel="noopener noreferrer"
+    <a href="${escapeHtml(safeHref)}" target="_blank" rel="noopener noreferrer"
       class="block bg-[#241f20] hover:bg-[#2e2728] border border-neutral-800 hover:border-neutral-700 rounded-lg p-4 transition-colors group">
-      <p class="text-sm font-semibold text-neutral-100 group-hover:text-[#f4bf4f] transition-colors">${label}</p>
-      <p class="text-xs text-neutral-500 mt-0.5">${description}</p>
+      <p class="text-sm font-semibold text-neutral-100 group-hover:text-[#f4bf4f] transition-colors">${escapeHtml(label)}</p>
+      <p class="text-xs text-neutral-500 mt-0.5">${escapeHtml(description)}</p>
     </a>
   `;
 }


### PR DESCRIPTION
Closes #1171

## What changed
Applied `escapeHtml()` to `label` and `description` in `linkCard()` in `apps/pwa/src/dashboard.ts`, consistent with the existing `flagRow()` helper in the same file. Also added a `safeHref` check that rejects non-`https?://` URIs (replacing them with `#`) and passes the result through `escapeHtml()` before injecting into the HTML attribute, preventing potential `javascript:` URI injection. This closes an unsafe inconsistency even though current call sites use hardcoded strings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFr9vfQmgkLep6Hi5ejBfV)_