### PR TITLE
fix: call setHasHydratedRemote(true) on all error paths in loadRemoteState

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3850,11 +3850,13 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
               userRes.error,
               profileRes.error,
             ]);
+            setHasHydratedRemote(true);
             return;
           }
 
           if (turnsRes.error) {
             notifyCriticalError('Non riusciamo a caricare i turni dal database.', [turnsRes.error]);
+            setHasHydratedRemote(true);
             return;
           }
 


### PR DESCRIPTION
Closes #1176

When `userRes.error || profileRes.error` or `turnsRes.error` was set in `loadRemoteState`, the function returned early without calling `setHasHydratedRemote(true)`. This left the app permanently blocked since hydration-gated operations check `hasHydratedRemote` before proceeding.

Added `setHasHydratedRemote(true)` before each early-return on fetch error so the app is always unblocked even when remote data cannot be loaded.

---
_Generated by [Claude Code](https://claude.ai/code/session_012KEEGhwqrpzH2WwCC24HbY)_