### PR TITLE
fix: use getUser() for server-side token verification in ticket-activation

### DIFF
--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -201,6 +201,17 @@ async function getAccessTokenForFunctions(): Promise<string> {
     throw new Error(SESSION_REQUIRED_MESSAGE);
   }
 
+  // Use getUser() for server-side token verification to prevent use of stale
+  // or replayed session tokens (closes #1177). getSession() only reads from
+  // local storage and cannot detect server-side revocations.
+  const { error: userError } = await supabase.auth.getUser();
+  if (userError) {
+    await invalidateAuthSession();
+    throw new Error(SESSION_REQUIRED_MESSAGE);
+  }
+
+  // After server-verified the user is still valid, retrieve the session to
+  // obtain the access token. If the token is close to expiry, refresh it first.
   const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
   if (sessionError) {
     await invalidateAuthSession();
@@ -215,7 +226,7 @@ async function getAccessTokenForFunctions(): Promise<string> {
     !sessionToken || !expiresAt || expiresAt <= nowSeconds + TOKEN_REFRESH_SKEW_SECONDS;
 
   if (!shouldRefresh && sessionToken) {
-    if (import.meta.env.DEV) console.log('[ticket-activation] Using cached token, hasToken:', true, 'remaining_s:', expiresAt - nowSeconds);
+    if (import.meta.env.DEV) console.log('[ticket-activation] Using server-verified token, hasToken:', true, 'remaining_s:', expiresAt - nowSeconds);
     return sessionToken;
   }
 


### PR DESCRIPTION
Closes #1177

`getAccessTokenForFunctions` was calling `supabase.auth.getSession()` to obtain the access token, which only reads from local storage and cannot detect server-side revocations or replayed tokens.

Added a `supabase.auth.getUser()` call before retrieving the session, which performs server-side token verification. If the server rejects the token, the session is invalidated and the function throws immediately, preventing use of stale or replayed session tokens.

---
_Generated by [Claude Code](https://claude.ai/code/session_012KEEGhwqrpzH2WwCC24HbY)_