### PR TITLE
fix: remove follow_event mutations from offline queue on reset_progress

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -1594,9 +1594,12 @@ function enqueueQueuedSupabaseMutation(input: QueuedSupabaseMutationInput) {
   }
 
   if (input.kind === 'reset_progress') {
+    // When a reset_progress is queued, remove all pending follow_event_insert and
+    // follow_event_delete mutations for the same user. Those plans are wiped by the
+    // reset, so replaying them after the reset would re-create deleted plans (closes #1178).
     queue = queue.filter((mutation) => {
       if (mutation.userId !== input.userId) return true;
-      return mutation.kind === 'follow_event_insert' || mutation.kind === 'follow_event_delete';
+      return mutation.kind !== 'follow_event_insert' && mutation.kind !== 'follow_event_delete';
     });
   }
   const dedupedSize = queue.length;


### PR DESCRIPTION
Closes #1178

When `reset_progress` is enqueued, the dedup logic was incorrectly keeping `follow_event_insert` and `cancel_event_plan` (i.e. `follow_event_delete`) mutations for the same user — the filter condition was inverted. Those event plans are wiped by the reset, so replaying them would re-create deleted plans.

Fix: invert the filter so `follow_event_insert` and `follow_event_delete` mutations are pruned (not kept) when `reset_progress` is queued for the same user.

---
_Generated by [Claude Code](https://claude.ai/code/session_012KEEGhwqrpzH2WwCC24HbY)_