### PR TITLE
fix: add autoRefreshToken/persistSession to cleanup-events service-role client

### DIFF
--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -59,7 +59,9 @@ serve(async (req) => {
       })
     }
 
-    const supabaseClient = createClient(supabaseUrl, serviceKey)
+    const supabaseClient = createClient(supabaseUrl, serviceKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    })
 
     const url = new URL(req.url)
     const rawDays = url.searchParams.get('days') ?? ''


### PR DESCRIPTION
Closes #1179

The service-role Supabase client in `cleanup-events` was created without `{ auth: { autoRefreshToken: false, persistSession: false } }`, which can cause unintended session persistence in the Deno edge function context.

Adds the same options already present in `dev-access`, `event-links`, `mobile-logs`, and other edge functions.

---
_Generated by [Claude Code](https://claude.ai/code/session_012KEEGhwqrpzH2WwCC24HbY)_