### PR TITLE
fix: delete ticket_activations rows in delete-my-account

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -64,6 +64,7 @@ serve(async (req) => {
 
   // 1. Delete game data (cascade-safe: ordered by FK dependencies)
   const tablesToDelete = [
+    { table: 'ticket_activations', key: 'user_id' },
     { table: 'activity_completions', key: 'user_id' },
     { table: 'user_badges', key: 'user_id' },
     { table: 'planned_participations', key: 'user_id' },


### PR DESCRIPTION
Closes #1184

Add `ticket_activations` to the list of tables deleted during account deletion in the `delete-my-account` edge function. This closes a GDPR Art. 17 gap where `ticket_activations` rows were orphaned after account deletion. The table is prepended to the existing deletion sequence (before `activity_completions`) to respect FK dependency order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC99d9jFAtYiLjF46DgQ73)_