### PR TITLE
fix: reset remote state arrays in resetState to prevent stale data after logout

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -5239,6 +5239,19 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     setFeatureFlags({ ...MOBILE_FEATURE_FLAGS_DEFAULTS });
     setFeatureFlagsSource('default');
     setFeatureFlagsReady(true);
+    // Reset remote-state arrays and loading flags so stale data from a previous
+    // session is not visible after logout (closes #1185).
+    setRemoteTurnStats(null);
+    setStatsLoading(false);
+    setRemoteTheatreReputation([]);
+    setTheatreReputationLoading(false);
+    setLeaderboard([]);
+    setLeaderboardLoading(false);
+    setRemoteBadges([]);
+    setBadgesLoading(false);
+    setShopCatalog(DEFAULT_SHOP_CATALOG);
+    setShopCatalogLoading(false);
+    setActivitySlotsLoading(false);
     const totalSlots = 3 + next.profile.extraActivitySlots;
     setActivitySlotsStatus({
       usedToday: 0,


### PR DESCRIPTION
Closes #1185

In `resetState` (called on logout), several remote-state arrays and loading flags were not being cleared: `remoteTurnStats`, `statsLoading`, `remoteTheatreReputation`, `theatreReputationLoading`, `leaderboard`, `leaderboardLoading`, `remoteBadges`, `badgesLoading`, `shopCatalog`, `shopCatalogLoading`, and `activitySlotsLoading`. This caused stale data from the previous session to remain visible until the next successful remote hydration. All missing fields are now reset to their initial values inside `resetState`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC99d9jFAtYiLjF46DgQ73)_