### PR TITLE
fix: add auth options to service-role adminClient in dev-access

### DIFF
--- a/supabase/functions/dev-access/index.ts
+++ b/supabase/functions/dev-access/index.ts
@@ -127,7 +127,9 @@ serve(async (req) => {
   }
 
   if (serviceRoleKey) {
-    const adminClient = createClient(supabaseUrl, serviceRoleKey);
+    const adminClient = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
     const userRoles = getUserRoles(user as Record<string, unknown>);
     const auditEntry: DevAccessAudit = {
       user_id: user.id,


### PR DESCRIPTION
Closes #1186

Add `{ auth: { autoRefreshToken: false, persistSession: false } }` as the third argument to the `createClient` call that creates the service-role `adminClient` in the `dev-access` edge function. This matches the pattern already used by other edge functions in this repo (e.g. `delete-my-account`) and prevents the Supabase JS client from attempting unnecessary token refresh and session persistence for a server-side service-role client.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC99d9jFAtYiLjF46DgQ73)_