### PR TITLE
fix: add auth options to service-role client in import-spazio-rossellini

### DIFF
--- a/supabase/functions/import-spazio-rossellini/index.ts
+++ b/supabase/functions/import-spazio-rossellini/index.ts
@@ -231,7 +231,9 @@ serve(async (req) => {
     }
   }
 
-  const supabase = createClient(supabaseUrl, serviceKey);
+  const supabase = createClient(supabaseUrl, serviceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
 
   try {
     const [sitemapUrls, categorySlugs, apiEvents] = await Promise.all([


### PR DESCRIPTION
Closes #1188

Add `{ auth: { autoRefreshToken: false, persistSession: false } }` as the third argument to the `createClient` call that creates the service-role client in the `import-spazio-rossellini` edge function. This prevents the Supabase JS client from attempting unnecessary token refresh and session persistence for a server-side service-role client, matching the pattern already used in other edge functions in this repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC99d9jFAtYiLjF46DgQ73)_