### PR TITLE
fix: use correct column 'activated_by' for ticket_activations in delete-my-account

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -64,7 +64,7 @@ serve(async (req) => {
 
   // 1. Delete game data (cascade-safe: ordered by FK dependencies)
   const tablesToDelete = [
-    { table: 'ticket_activations', key: 'user_id' },
+    { table: 'ticket_activations', key: 'activated_by' },
     { table: 'activity_completions', key: 'user_id' },
     { table: 'user_badges', key: 'user_id' },
     { table: 'planned_participations', key: 'user_id' },


### PR DESCRIPTION
Closes #1194

The `tablesToDelete` array in `supabase/functions/delete-my-account/index.ts` referenced the `ticket_activations` table with column key `'user_id'`, but the actual column in that table is `'activated_by'`. This caused a PostgREST error when trying to delete the user's ticket activations, which added `ticket_activations` to `failedTables` and triggered the abort guard — blocking the entire account deletion for any user who had ever activated a ticket.

**Fix:** Changed `key: 'user_id'` to `key: 'activated_by'` for the `ticket_activations` entry in `tablesToDelete`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjzo6MLBGqz7DvXFCqvr8D)_