### PR TITLE
fix: add shop_purchases to tablesToDelete in delete-my-account

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -69,6 +69,7 @@ serve(async (req) => {
     { table: 'user_badges', key: 'user_id' },
     { table: 'planned_participations', key: 'user_id' },
     { table: 'narrative_history', key: 'user_id' },
+    { table: 'shop_purchases', key: 'user_id' },
     { table: 'turns', key: 'user_id' },
     { table: 'profiles', key: 'id' },
   ] as const;


### PR DESCRIPTION
Closes #1195

**What was wrong:** The `shop_purchases` table was completely absent from the `tablesToDelete` array in `supabase/functions/delete-my-account/index.ts`. Since `shop_purchases` has a `user_id` column (confirmed in migrations), purchase history was never deleted on account deletion — a GDPR Article 17 violation.

**What was changed:** Added `{ table: 'shop_purchases', key: 'user_id' }` to the `tablesToDelete` array, positioned before `turns` to respect FK dependency order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjzo6MLBGqz7DvXFCqvr8D)_