### PR TITLE
fix: add auth options to service-role client in ticket-activation (closes #1198)

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -49,7 +49,9 @@ serve(async (req: Request) => {
     return jsonResponse({ error: 'Missing environment variables' }, 500);
   }
 
-  const supabase = createClient(supabaseUrl, serviceKey);
+  const supabase = createClient(supabaseUrl, serviceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let body: Record<string, any>;


### PR DESCRIPTION
Closes #1198

Add `auth: { autoRefreshToken: false, persistSession: false }` to the service-role Supabase client created in `ticket-activation/index.ts`, matching the pattern used in other fixed edge functions to prevent unintended token refresh and session persistence on a server-side service-role client.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rog6ktH59SsSqJChZ5wXKw)_