### PR TITLE
fix: clear appliedNarrativeChoicesRef in resetProgress (closes #1199)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4949,6 +4949,10 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         setFollowedEvents([]);
         setFollowedEventsLoading(false);
 
+        // Clear the narrative idempotency guard so that narrative rewards can
+        // be replayed after a progress reset in the same session (closes #1199).
+        appliedNarrativeChoicesRef.current = new Set();
+
         if (isSupabaseConfigured && supabase && authUserId && !shouldQueueReset) {
           await Promise.all([refreshTurnStats(), refreshTheatreReputation(), refreshBadges()]);
         }


### PR DESCRIPTION
Closes #1199

Add `appliedNarrativeChoicesRef.current = new Set()` inside `resetProgress` so that narrative rewards can be replayed after a progress reset within the same session. The idempotency guard was already cleared in `resetState` (logout) but was missing from `resetProgress`, which blocked narrative reward replay after in-session resets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rog6ktH59SsSqJChZ5wXKw)_