### PR TITLE
fix: persist profile after narrative choice rewards (closes #1200)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4846,10 +4846,20 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       };
 
       // 1. Apply rewards locally — visible immediately in Home/profile.
-      setState((prev: GameState) => ({
-        ...prev,
-        profile: applyRewards(prev.profile, rewards, 'activity'),
-      }));
+      // Capture the resulting profile so we can persist it to Supabase below.
+      let capturedProfile: PlayerProfile | null = null;
+      setState((prev: GameState) => {
+        const nextProfile = applyRewards(prev.profile, rewards, 'activity');
+        capturedProfile = nextProfile;
+        return { ...prev, profile: nextProfile };
+      });
+
+      // 1b. Persist updated profile to server so XP/cachet/reputation survive
+      // a page reload (closes #1200). Same pattern used by startCourse /
+      // completeCourse: capturedProfile is non-null when the updater ran.
+      if (capturedProfile !== null) {
+        persistProfile(capturedProfile);
+      }
 
       // 2. Persist to narrative_history (append-only, RLS-scoped to user).
       // Best-effort: a failed insert does not roll back local rewards. Without
@@ -4874,7 +4884,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
       return { ok: true, rewards };
     },
-    [authUserId]
+    [authUserId, persistProfile]
   );
 
   const resetProgress = useCallback(async () => {


### PR DESCRIPTION
Closes #1200

In `completeNarrativeChoice`, capture the updated `PlayerProfile` from the `setState` updater and call `persistProfile` so that XP/cachet/reputation rewards granted by narrative choices are synced to the server profile and survive a page reload. Also adds `persistProfile` to the `useCallback` dependency array. Matches the same capture-then-persist pattern used by `startCourse` and `completeCourse`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rog6ktH59SsSqJChZ5wXKw)_