### PR TITLE
fix: ensure hasHydratedRemote=true even on WatchdogTimeoutError

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3985,7 +3985,11 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       );
     };
 
-    loadRemoteState().catch((err: unknown) => console.warn('[store] loader rejected', err));
+    loadRemoteState()
+      .catch((err: unknown) => console.warn('[store] loader rejected', err))
+      .finally(() => {
+        if (isMounted) setHasHydratedRemote(true);
+      });
 
     return () => {
       isMounted = false;


### PR DESCRIPTION
Closes #1204

Adds `.finally(() => { if (isMounted) setHasHydratedRemote(true); })` to the `loadRemoteState` outer call so that a `WatchdogTimeoutError` timeout no longer permanently blocks hydration-gated features.

When `withMobileWatchdog` times out during `loadRemoteState`, `Promise.race()` rejects with a `WatchdogTimeoutError` that bypasses all `setHasHydratedRemote(true)` calls inside the task body. The `.finally` block guarantees the flag is set to `true` regardless of how the load attempt ended, mirroring the correct pattern already used in `restoreSession`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBE57gN9Wb4rks6NvPb7RA)_