### PR TITLE
fix: reset eventPlans in GameState inside resetProgress setState

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4948,6 +4948,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             tutorialCompleted: false,
           },
           turns: [],
+          eventPlans: [],
         }));
 
         setRemoteTurnStats(null);


### PR DESCRIPTION
Closes #1206

`resetProgress` called `setEventPlans([])` for the display layer but did not include `eventPlans: []` in the `setState` spread that persists `GameState`. Since `saveState` persists the full `GameState`, stale `eventPlans` survived page reload. This adds `eventPlans: []` explicitly to the reset object, mirroring how `turns: []` is already reset.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gjy6miJuCZ4RBeMwCfZ5v9)_