### PR TITLE
fix: guard refreshEventPlanning with isMounted check in loadCatalog

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3816,6 +3816,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             activities: nextActivities,
           });
           await refreshEventPlanning(nextEvents);
+          if (!isMounted) return;
         },
         {
           operation: 'loadCatalog',


### PR DESCRIPTION
Closes #1207

Inside `loadCatalog`, after the last `if (!isMounted) return` check, `setCatalog(...)` was called and then `await refreshEventPlanning(nextEvents)` was called without a further `isMounted` guard. If the component unmounted during `refreshEventPlanning`, its internal `setState` calls would fire on an unmounted component. This adds `if (!isMounted) return;` immediately after `await refreshEventPlanning(nextEvents)` to prevent that.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gjy6miJuCZ4RBeMwCfZ5v9)_