### PR TITLE
fix: use JSON.stringify for unambiguous narrative choice dedup key

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4836,7 +4836,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       // Idempotency guard: prevent double-credit if this function is called
       // more than once for the same scene+choice (re-render, offline-queue
       // replay, race condition, or app restart mid-scene).
-      const choiceKey = `${input.sceneId}:${input.choiceId}`;
+      const choiceKey = JSON.stringify([input.sceneId, input.choiceId]);
       if (appliedNarrativeChoicesRef.current.has(choiceKey)) {
         logOfflineSync('completeNarrativeChoice skipped — already applied', { choiceKey }, 'warn');
         return { ok: true, rewards: { xp: 0, cachet: 0, reputation: 0 } };


### PR DESCRIPTION
Closes #1208

The idempotency key in `completeNarrativeChoice` was built as `` `${input.sceneId}:${input.choiceId}` ``. Since `:` is the separator AND a legal character in IDs, distinct `(sceneId, choiceId)` pairs could produce the same key, causing legitimate choices to be silently rejected. This replaces the template literal with `JSON.stringify([input.sceneId, input.choiceId])` for an unambiguous key.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gjy6miJuCZ4RBeMwCfZ5v9)_