### PR TITLE
fix: replace break with continue in flushQueuedSupabaseMutations retry path

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -2966,7 +2966,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           continue;
         }
 
-        break;
+        continue;
       }
     } finally {
       offlineSyncInFlightRef.current = false;


### PR DESCRIPTION
Closes #1209

When a queued mutation returned a `'retry'` status and was not yet at max attempts, the flush loop executed `break` instead of `continue`, stopping processing of ALL remaining mutations in the queue for that flush cycle — even completely independent ones. This changes `break` to `continue` so the loop continues with subsequent mutations after scheduling a retry.

https://claude.ai/code/session_01Gjy6miJuCZ4RBeMwCfZ5v9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gjy6miJuCZ4RBeMwCfZ5v9)_