### PR TITLE
fix: clear leaderboard state in resetProgress

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4964,6 +4964,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         setEventPlansLoading(false);
         setFollowedEvents([]);
         setFollowedEventsLoading(false);
+        setLeaderboard([]);
+        setLeaderboardLoading(false);
 
         // Clear the narrative idempotency guard so that narrative rewards can
         // be replayed after a progress reset in the same session (closes #1199).


### PR DESCRIPTION
Closes #1214

`resetProgress` was not calling `setLeaderboard([])` or `setLeaderboardLoading(false)`, so after a progress reset the Leaderboard screen continued to show stale pre-reset data until `refreshLeaderboard` was manually triggered.

Added both calls alongside the other state resets in `resetProgress`, mirroring the pattern already used in `resetState` (the logout path).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWTCV8Tcdx96i5modrrkqU)_