### PR TITLE
fix: remove duplicate refreshEventPlanning call in loadCatalog

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3815,8 +3815,10 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             events: nextEvents,
             activities: nextActivities,
           });
-          await refreshEventPlanning(nextEvents);
-          if (!isMounted) return;
+          // Do NOT call refreshEventPlanning here: the useEffect watching
+          // catalog.events (below) will call it once the state update is
+          // committed, avoiding a duplicate get_my_planned_participations RPC
+          // that was fired on every catalog load (closes #1215).
         },
         {
           operation: 'loadCatalog',


### PR DESCRIPTION
Closes #1215

`loadCatalog` was calling `setCatalog({ events: nextEvents })` followed immediately by `await refreshEventPlanning(nextEvents)`. The `setCatalog` call triggers a `useEffect` watching `catalog.events` which also calls `refreshEventPlanning`, so the RPC `get_my_planned_participations` was firing twice on every catalog load.

Removed the explicit `await refreshEventPlanning(nextEvents)` call from `loadCatalog`, letting the existing `useEffect` handle it once `catalog.events` is committed to state. Added a comment explaining why to prevent future regressions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWTCV8Tcdx96i5modrrkqU)_