### PR TITLE
fix: add missing deps to NarrativeScene useEffect

### DIFF
--- a/apps/mobile/src/components/screens/NarrativeScene.tsx
+++ b/apps/mobile/src/components/screens/NarrativeScene.tsx
@@ -134,7 +134,7 @@ export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }
     });
 
     return () => controller.abort();
-  }, [local.phase]);
+  }, [local.phase, sceneId, roleId, roleStats]);
 
   if (local.phase === 'loading') {
     return (


### PR DESCRIPTION
Closes #1218

## Changes

The `useEffect` in `NarrativeScene.tsx` that fetches narrative scenes was only listing `[local.phase]` in its dependency array, while closing over `sceneId`, `roleId`, and `roleStats` from props. This meant that if any of those props changed while `local.phase === 'loading'`, the scene fetch would use stale/wrong context and role-based access checks could be bypassed.

**Fix**: Added `sceneId`, `roleId`, and `roleStats` to the `useEffect` dependency array so the effect re-runs whenever any of those values change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuF68dG2cbNLkaoVDGvZzZ)_