### PR TITLE
fix: add AbortController timeout to fetchUserHash

### DIFF
--- a/apps/mobile/src/services/analytics.ts
+++ b/apps/mobile/src/services/analytics.ts
@@ -221,11 +221,20 @@ async function fetchUserHash(userId: string): Promise<string | undefined> {
       headers['Authorization'] = `Bearer ${_authToken}`;
     }
 
-    const response = await fetch(edgeFnUrl, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({ userId }),
-    });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 8000);
+
+    let response: Response;
+    try {
+      response = await fetch(edgeFnUrl, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ userId }),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     if (!response.ok) {
       // Log solo in dev per non inquinare la produzione con warning non


### PR DESCRIPTION
Closes #1219

## Changes

The `fetch()` call to the `pseudonymize-user-id` Edge Function in `fetchUserHash` (`apps/mobile/src/services/analytics.ts`) had no timeout or abort signal. If the Edge Function or network stalled, `fetchUserHash` would never resolve, permanently blocking `getUserHash()` and every `track()` call for the entire session.

**Fix**: Added an `AbortController` with an 8-second timeout (`setTimeout`) to the `fetch()` call. The timeout is cleared in a `finally` block to avoid leaking timers. An aborted fetch throws and is caught by the existing `catch` block, which returns `undefined` and degrades gracefully without breaking the UX.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuF68dG2cbNLkaoVDGvZzZ)_