### PR TITLE
fix: use getUser() for auth guard to prevent access with revoked tokens

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -223,13 +223,11 @@ export function useAuth(
         if (!supabase) return;
         let mounted = true;
 
-        supabase.auth.getSession().then(({ data, error }) => {
-            if (!mounted || error) return;
-            if (data.session?.user) {
-                applyUserProfileRef.current(data.session.user, {
-                    navigateTo: 'home',
-                });
-            }
+        supabase.auth.getUser().then(({ data, error }) => {
+            if (!mounted || error || !data.user) return;
+            applyUserProfileRef.current(data.user, {
+                navigateTo: 'home',
+            });
         }).catch(() => undefined);
 
         const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {


### PR DESCRIPTION
Closes #1222

## What changed
Replaced `getSession()` with `getUser()` in the authentication guard inside `useAuth.ts`. `getSession()` reads only from local storage and does not verify the token server-side, allowing users with revoked or expired tokens to reach protected screens. `getUser()` validates the token with the Supabase Auth server and correctly denies access when the session is no longer valid.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Y74MDAUFpPUuSy9KdxUuc)_