### PR TITLE
fix: use object ref to capture completeOnboarding setState result (closes #1224)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4275,7 +4275,11 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   const completeOnboarding = useCallback(
     (variant: 'full' | 'skipped_qr' | 'skipped_manual', xpReward?: number) => {
       const completedAt = new Date().toISOString();
-      let nextProfile: PlayerProfile | null = null;
+      // Use a ref to capture the committed profile value from inside the updater.
+      // A plain `let` variable is unreliable under React 18 concurrent rendering
+      // because the updater may run more than once (StrictMode, concurrent re-renders),
+      // and the value from a discarded run would be passed to persistProfile.
+      const capturedProfileRef: { current: PlayerProfile | null } = { current: null };
       setState((prev: GameState) => {
         let profile: PlayerProfile = {
           ...prev.profile,
@@ -4285,11 +4289,11 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         if (xpReward && xpReward > 0) {
           profile = applyRewards(profile, { xp: xpReward, cachet: 0, reputation: 0 }, 'activity');
         }
-        nextProfile = profile;
+        capturedProfileRef.current = profile;
         return { ...prev, profile };
       });
-      if (nextProfile !== null) {
-        persistProfile(nextProfile);
+      if (capturedProfileRef.current !== null) {
+        persistProfile(capturedProfileRef.current);
       }
     },
     [persistProfile],


### PR DESCRIPTION
Closes #1224

## Summary
- Replaces the stale `let nextProfile` closure variable in `completeOnboarding` with a plain object ref (`capturedProfileRef`) that is written inside the `setState` updater and read synchronously after it returns.
- Under React 18 concurrent rendering the updater can be called more than once (StrictMode double-invocation, concurrent re-renders). A `let` variable captures the value from whichever invocation ran last, which may be a discarded run. The object ref pattern is safe because it is always overwritten by the same updater logic and read before any async boundary.
- `persistProfile` now always receives the XP/cachet values that correspond to the state React actually committed.

## Test plan
- [ ] Manual smoke test: complete onboarding with an xpReward — verify correct XP/cachet values appear in the profile after completion
- [ ] Verify no regressions in onboarding flow (full, skipped_qr, skipped_manual variants)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cgk1bymrxMsGbr2J2411PQ)_