### PR TITLE
fix: add pending turn to state.turns in registerTurn retry/fallback branch (closes #1225)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4580,6 +4580,18 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           error: errorMessage,
         }, 'warn');
         enqueueSupabaseMutation(queuedMutation);
+        // Add the pending turn record to local state immediately so the UI
+        // shows the turn while waiting for the offline sync flush to complete.
+        // applyTurnRegistrationResult handles duplicates by ID (merge), so
+        // adding the record here is safe and idempotent.
+        setState((prev: GameState) => {
+          const alreadyPresent = prev.turns.some((t) => t.id === pendingTurnRecord.id);
+          const nextTurns = (alreadyPresent
+            ? prev.turns.map((t) => (t.id === pendingTurnRecord.id ? { ...t, ...pendingTurnRecord } : t))
+            : [pendingTurnRecord, ...prev.turns]
+          ).slice(0, MAX_TURNS);
+          return { ...prev, turns: nextTurns };
+        });
         setTurnSyncFeedback({
           syncStatus: 'pending',
           boostRequested,


### PR DESCRIPTION
Closes #1225

## Summary
- In the retry/fallback branch of `registerTurn` (online path, retryable RPC error), adds a `setState` call to insert `pendingTurnRecord` into `state.turns` immediately after enqueuing the mutation — before returning.
- The duplicate-by-ID merge logic mirrors that used in `applyTurnRegistrationResult`, so when the offline sync eventually confirms the turn with server-authoritative rewards, the record is updated cleanly without duplication.
- Eliminates the window where the turn is absent from `state.turns` (and thus from badge/stat computations) between the failed RPC call and the offline sync flush.

## Test plan
- [ ] Manual smoke test: register a turn while simulating a retryable network error — verify the turn appears in the turns list immediately without waiting for sync
- [ ] Verify that when the offline sync flushes and `applyTurnRegistrationResult` runs, the turn record is updated (not duplicated) with server-authoritative rewards

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cgk1bymrxMsGbr2J2411PQ)_