### PR TITLE
fix: queue persistProfile when hasHydratedRemote is false

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4183,8 +4183,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
   const persistProfile = useCallback(
     (profile: PlayerProfile) => {
-      if (!supabase || !authUserId || !hasHydratedRemote) {
-        logOfflineSync('persistProfile skipped: remote state not ready', {
+      if (!supabase || !authUserId) {
+        logOfflineSync('persistProfile skipped: missing supabase client or auth user', {
           hasSupabaseClient: Boolean(supabase),
           authUserId,
           hasHydratedRemote,
@@ -4202,6 +4202,18 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         userId: authUserId,
         payload,
       };
+      if (!hasHydratedRemote) {
+        // Remote state is still being loaded (e.g. slow connection during FTUE).
+        // Queue the mutation so it is flushed once hydration completes instead
+        // of silently discarding the profile update.
+        logOfflineSync('persistProfile queued: hydration not yet complete', {
+          authUserId,
+          roleId: profile.roleId,
+          level: profile.level,
+        }, 'warn');
+        enqueueSupabaseMutation(queuedMutation);
+        return;
+      }
       if (isNavigatorOffline()) {
         logOfflineSync('persistProfile queued because browser is offline', { authUserId });
         enqueueSupabaseMutation(queuedMutation);


### PR DESCRIPTION
Closes #1232

## What changed

`persistProfile` previously combined `!supabase`, `!authUserId`, and `!hasHydratedRemote` into a single early-return guard, silently discarding any profile mutation called before remote hydration completed.

This caused permanent data loss for first-time users on slow connections during FTUE: `completeOnboarding` / `updateProfile` etc. applied the change to local state but the Supabase upsert was never queued or retried.

## Fix

The guard is now split into two distinct checks:

1. **Missing `supabase` or `authUserId`** → still returns early (nothing to queue against).
2. **`hasHydratedRemote` is `false`** → builds the `profile_upsert` mutation and calls `enqueueSupabaseMutation`, which deduplicates (keeps only the latest upsert per user) and triggers a flush. The mutation is persisted in the offline queue and synced once hydration completes.

This is consistent with how the offline path and sync-error paths already fall back to the queue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzvsvGDKYN8SjhzC7T7yRY)_