### PR TITLE
fix: delay URL.revokeObjectURL in exportUserData to prevent silent download failure

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -5494,7 +5494,10 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    // Delay revoking the object URL to give the browser time to start the download.
+    // Calling revokeObjectURL synchronously after a.click() can silently abort the
+    // download on Firefox and slow devices before the fetch begins (closes #1235).
+    window.setTimeout(() => URL.revokeObjectURL(url), 100);
   }, [state.profile, state.turns, authUserId, badges, theatreReputation, eventPlans]);
 
   const value = useMemo<GameContextValue>(


### PR DESCRIPTION
Closes #1235

`URL.revokeObjectURL` was called synchronously immediately after `a.click()`, which can revoke the blob URL before the browser has had a chance to begin the download. This causes silent download failures on Firefox and slow devices.

**Fix:** Wrap the revoke call in `window.setTimeout(..., 100)` to give the browser a short window to start fetching the blob before the URL is invalidated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nqy4kDUDzkANvnBWMVufJk)_