### PR TITLE
fix: type exportUserData as () => Promise<void> in GameContextValue

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -2314,7 +2314,7 @@ type GameContextValue = {
    *   della sessione non mostrerebbe il banner). */
   deleteAccount: (options?: { onBeforeSignOut?: () => void; onSignOutFailed?: () => void }) => Promise<void>;
   /** GDPR Art. 15/20 – scarica copia di tutti i dati personali in JSON. */
-  exportUserData: () => void;
+  exportUserData: () => Promise<void>;
   changePassword: (newPassword: string, currentPassword?: string) => Promise<void>;
   sendPasswordResetEmail: (email: string) => Promise<void>;
   completeTutorial: () => void;


### PR DESCRIPTION
Closes #1236

`exportUserData` is declared as `() => void` in `GameContextValue` but the implementation is `async`. This mismatch causes callers to silently swallow any thrown errors.

**Fix:** Update the type declaration in `GameContextValue` to `() => Promise<void>` to accurately reflect the async implementation and allow proper error handling by callers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nqy4kDUDzkANvnBWMVufJk)_