### PR TITLE
fix: add admin role check to resolve_hash in ticket-activation

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -155,6 +155,15 @@ serve(async (req: Request) => {
     }
 
     if (action === 'resolve_hash') {
+      const resolveRoleSingle = authenticatedUser?.app_metadata?.role as string | undefined;
+      const resolveRolesArray = authenticatedUser?.app_metadata?.roles as string[] | undefined;
+      const isResolveAdmin =
+        resolveRoleSingle === 'admin' ||
+        (Array.isArray(resolveRolesArray) && resolveRolesArray.includes('admin'));
+      if (!isResolveAdmin) {
+        return jsonResponse({ error: 'Accesso negato: ruolo admin richiesto' }, 403);
+      }
+
       if (!hash || typeof hash !== 'string') {
         return jsonResponse({ error: 'Missing hash' }, 400);
       }


### PR DESCRIPTION
Closes #1238

`resolve_hash` required auth but had no admin role guard, allowing any authenticated user to probe arbitrary 64-char hex hashes and enumerate ticket existence and activation status.

**Fix:** Add the same `app_metadata.role === 'admin'` / `app_metadata.roles?.includes('admin')` check to `resolve_hash` that `reserve_hash` already uses, returning 403 for non-admin callers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nqy4kDUDzkANvnBWMVufJk)_