### PR TITLE
fix: remove redundant setTimeout in requestAiIssue to fix double-timeout race

### DIFF
--- a/apps/mobile/src/services/ai.ts
+++ b/apps/mobile/src/services/ai.ts
@@ -254,8 +254,11 @@ export async function requestAiIssue({
   payload: AiSupportIssuePayload;
   endpoint?: string;
 }) {
+  // Use a single AbortController driven by withMobileWatchdog's timeout.
+  // A redundant window.setTimeout at the same interval would create a race
+  // where the outer abort fires after withMobileWatchdog already resolved,
+  // surfacing a false watchdog error banner (closes #1239).
   const controller = new AbortController();
-  const abortTimeout = window.setTimeout(() => controller.abort(), AI_ISSUE_REQUEST_WATCHDOG_MS);
   try {
     return await withMobileWatchdog(async () => {
       const target = resolveIssueEndpoint(endpoint);
@@ -283,7 +286,5 @@ export async function requestAiIssue({
   } catch (error) {
     controller.abort();
     throw error;
-  } finally {
-    window.clearTimeout(abortTimeout);
   }
 }


### PR DESCRIPTION
Closes #1239

Both `window.setTimeout` and `withMobileWatchdog` fired at `AI_ISSUE_REQUEST_WATCHDOG_MS`, creating a race where the outer abort could trigger after `withMobileWatchdog` already resolved — surfacing a false watchdog error banner to the user.

**Fix:** Remove the redundant `window.setTimeout` (and its paired `clearTimeout`) so `withMobileWatchdog` is the single authoritative timeout. The `AbortController` is preserved and still cancels the in-flight `fetch` when the catch block calls `controller.abort()` on any error, including a watchdog timeout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nqy4kDUDzkANvnBWMVufJk)_