### PR TITLE
fix: delete planned_participations before events to avoid FK violations (#1245)

### DIFF
--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -113,10 +113,20 @@ serve(async (req) => {
 
     console.log(`🗑️ Trovati ${eventsToDelete.length} eventi da cancellare`)
 
+    const eventIds = eventsToDelete.map(e => e.id)
+
+    // Delete child rows first to avoid FK violations (planned_participations references events).
+    const { error: deleteParticipationsError } = await supabaseClient
+      .from('planned_participations')
+      .delete()
+      .in('event_id', eventIds)
+
+    if (deleteParticipationsError) throw deleteParticipationsError
+
     const { error: deleteError } = await supabaseClient
       .from('events')
       .delete()
-      .in('id', eventsToDelete.map(e => e.id))
+      .in('id', eventIds)
 
     if (deleteError) throw deleteError
 


### PR DESCRIPTION
## Summary

- Before bulk-deleting `events` rows in `cleanup-events`, now first deletes all `planned_participations` rows whose `event_id` references those events.
- This satisfies the foreign-key constraint (child rows deleted before parent rows) and prevents both FK violations and orphan rows.

## Test plan

- [ ] Deploy function to a staging environment with existing `planned_participations` rows linked to old events.
- [ ] Trigger `cleanup-events` and confirm no FK error is returned.
- [ ] Verify `planned_participations` rows for the deleted events are gone.
- [ ] Verify events older than the cutoff are deleted.

Closes #1245

https://claude.ai/code/session_01Xh2TWreifxAtmfcKkc3Ahq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xh2TWreifxAtmfcKkc3Ahq)_