### PR TITLE
fix: re-run resolveInitialState when sceneId/roleId change in NarrativeScene (#1246)

### DIFF
--- a/apps/mobile/src/components/screens/NarrativeScene.tsx
+++ b/apps/mobile/src/components/screens/NarrativeScene.tsx
@@ -82,6 +82,20 @@ export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }
     resolveInitialState(sceneId, roleId, roleStats)
   );
 
+  // Re-run resolveInitialState whenever sceneId or roleId change so that
+  // navigating between scenes or switching roles shows fresh state rather
+  // than the stale value captured by the lazy useState initializer (which
+  // only runs on the initial mount).
+  const prevSceneIdRef = React.useRef(sceneId);
+  const prevRoleIdRef = React.useRef(roleId);
+  useEffect(() => {
+    if (sceneId !== prevSceneIdRef.current || roleId !== prevRoleIdRef.current) {
+      prevSceneIdRef.current = sceneId;
+      prevRoleIdRef.current = roleId;
+      setLocal(resolveInitialState(sceneId, roleId, roleStats));
+    }
+  }, [sceneId, roleId, roleStats]);
+
   const startLoad = useCallback(() => {
     setLocal({ phase: 'loading' });
   }, []);


### PR DESCRIPTION
## Summary

- The lazy `useState` initializer in `NarrativeScene` only executes on mount, so changing the `sceneId` or `roleId` props left stale scene state on screen.
- Added a `useEffect` with refs tracking the previous `sceneId` and `roleId` values; whenever either prop changes, `resolveInitialState` is re-invoked and `local` state is reset accordingly.
- The existing async-load `useEffect` (which fires when `local.phase === 'loading'`) handles the rest of the load flow for theater/Maxwell scenes correctly after the reset.

## Test plan

- [ ] Navigate from one narrative scene to another (different `sceneId`) and confirm the new scene is shown, not the previous one.
- [ ] Switch role (different `roleId`) while a scene is open and confirm state resets.
- [ ] Confirm Maxwell daily scenes still show `daily_done` after completion on re-open.
- [ ] Confirm theater scenes still go through the `loading` phase and resolve correctly.

Closes #1246

https://claude.ai/code/session_01Xh2TWreifxAtmfcKkc3Ahq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xh2TWreifxAtmfcKkc3Ahq)_