### PR TITLE
fix: bound turns and my_badges Supabase queries with .limit(500) to prevent unbounded memory use (#1247)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -2515,7 +2515,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           await supabase!.rpc('evaluate_my_badges');
           const { data, error } = await supabase!
             .from('my_badges')
-            .select('id,title,description,icon,metric,threshold,is_hidden,unlocked_at,seen_at,unlocked');
+            .select('id,title,description,icon,metric,threshold,is_hidden,unlocked_at,seen_at,unlocked')
+            .order('unlocked_at', { ascending: false, nullsFirst: false })
+            .limit(500);
           if (!error && data) {
             const nextBadges: Badge[] = (data as DbBadgeRow[]).map((row) => ({
               id: row.id,
@@ -3846,7 +3848,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           const [userRes, profileRes, turnsRes] = await Promise.all([
             supabase!.auth.getUser(),
             supabase!.from('profiles').select('*').eq('id', authUserId).maybeSingle(),
-            supabase!.from('turns').select('*').eq('user_id', authUserId).order('created_at', { ascending: false }).limit(100),
+            supabase!.from('turns').select('*').eq('user_id', authUserId).order('created_at', { ascending: false }).limit(500),
           ]);
 
           if (!isMounted) return;


### PR DESCRIPTION
## Summary

- `loadRemoteState` now fetches at most 500 `turns` rows (previously 100 — bumped to match the spec and existing `MAX_TURNS` intent) ordered by `created_at DESC`, ensuring only the most recent records are loaded.
- `refreshBadges` now fetches at most 500 `my_badges` rows ordered by `unlocked_at DESC` (nulls last), preventing unbounded fetches from the view when a user accumulates many badge rows over time.
- Both changes prevent silent Supabase result truncation and memory spikes on devices with large turn/badge history.

## Test plan

- [ ] Load the app as a user with many turns (>500) and confirm only the most recent 500 are shown.
- [ ] Confirm badges still display correctly after the limit is applied.
- [ ] Confirm no regression on new accounts with few turns/badges.

Closes #1247

https://claude.ai/code/session_01Xh2TWreifxAtmfcKkc3Ahq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xh2TWreifxAtmfcKkc3Ahq)_