### PR TITLE
fix: add prevRoleStatsRef guard to trigger scene re-init on stat changes

### DIFF
--- a/apps/mobile/src/components/screens/NarrativeScene.tsx
+++ b/apps/mobile/src/components/screens/NarrativeScene.tsx
@@ -88,10 +88,20 @@ export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }
   // only runs on the initial mount).
   const prevSceneIdRef = React.useRef(sceneId);
   const prevRoleIdRef = React.useRef(roleId);
+  const prevRoleStatsRef = React.useRef(roleStats);
   useEffect(() => {
-    if (sceneId !== prevSceneIdRef.current || roleId !== prevRoleIdRef.current) {
+    const prevStats = prevRoleStatsRef.current;
+    const statsChanged = roleStats !== prevStats && (
+      !roleStats || !prevStats ||
+      roleStats.presence !== prevStats.presence ||
+      roleStats.precision !== prevStats.precision ||
+      roleStats.leadership !== prevStats.leadership ||
+      roleStats.creativity !== prevStats.creativity
+    );
+    if (sceneId !== prevSceneIdRef.current || roleId !== prevRoleIdRef.current || statsChanged) {
       prevSceneIdRef.current = sceneId;
       prevRoleIdRef.current = roleId;
+      prevRoleStatsRef.current = roleStats;
       setLocal(resolveInitialState(sceneId, roleId, roleStats));
     }
   }, [sceneId, roleId, roleStats]);


### PR DESCRIPTION
Closes #1251

## Changes
- Added `prevRoleStatsRef` to the re-initialization effect guard in `NarrativeScene.tsx`
- The guard now compares all four `RoleStats` fields (presence, precision, leadership, creativity) against their previous values
- When any stat changes, `resolveInitialState` is called and `prevRoleStatsRef` is updated, ensuring choice availability gates are refreshed after mid-session stat improvements

---
_Generated by [Claude Code](https://claude.ai/code/session_011aqPsCCaJ6uKgkQXy2rkWp)_