### PR TITLE
fix: add .limit(10000) to exportUserData Supabase queries to prevent OOM/timeout

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -5414,22 +5414,26 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           .from('turns')
           .select('*')
           .eq('user_id', authUserId)
-          .order('created_at', { ascending: false }),
+          .order('created_at', { ascending: false })
+          .limit(10000),
         supabase
           .from('activity_completions')
           .select('*')
           .eq('user_id', authUserId)
-          .order('created_at', { ascending: false }),
+          .order('created_at', { ascending: false })
+          .limit(10000),
         supabase
           .from('narrative_history')
           .select('*')
           .eq('user_id', authUserId)
-          .order('created_at', { ascending: false }),
+          .order('created_at', { ascending: false })
+          .limit(10000),
         supabase
           .from('shop_purchases')
           .select('*')
           .eq('user_id', authUserId)
-          .order('created_at', { ascending: false }),
+          .order('created_at', { ascending: false })
+          .limit(10000),
       ]);
       if (!turnsError && Array.isArray(turnsData)) {
         allTurns = (turnsData as DbTurnRow[]).map((turn) => ({


### PR DESCRIPTION
Closes #1252

## Changes
- Added `.limit(10000)` to each of the four concurrent Supabase queries in `exportUserData` (turns, activity_completions, narrative_history, shop_purchases)
- Prevents unbounded result sets from causing OOM errors or timeouts for power users with large amounts of data
- 10,000 rows is a safe ceiling that covers all realistic user data volumes while protecting server resources

---
_Generated by [Claude Code](https://claude.ai/code/session_011aqPsCCaJ6uKgkQXy2rkWp)_