### PR TITLE
fix: reverse delete order in cleanup-events to prevent inconsistency on partial failure

### DIFF
--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -115,14 +115,12 @@ serve(async (req) => {
 
     const eventIds = eventsToDelete.map(e => e.id)
 
-    // Delete child rows first to avoid FK violations (planned_participations references events).
-    const { error: deleteParticipationsError } = await supabaseClient
-      .from('planned_participations')
-      .delete()
-      .in('event_id', eventIds)
-
-    if (deleteParticipationsError) throw deleteParticipationsError
-
+    // Delete events first. The planned_participations FK is defined with
+    // ON DELETE CASCADE, so the DB automatically removes child rows when
+    // the parent event is deleted. This order is safer than deleting
+    // participations first: if the events delete fails nothing is lost,
+    // whereas the previous order could leave parent rows without their
+    // child participation records on a partial failure (fixes #1254).
     const { error: deleteError } = await supabaseClient
       .from('events')
       .delete()


### PR DESCRIPTION
Closes #1254

## Changes
- Reversed the delete order in `supabase/functions/cleanup-events/index.ts`: now deletes `events` first, then lets the DB cascade to `planned_participations`
- The `planned_participations.event_id` FK is defined with `ON DELETE CASCADE` (migration `20260313110000_planned_participations.sql`, line 13), so deleting `events` automatically removes child rows
- Previously, deleting `planned_participations` first meant that if the subsequent `events` delete failed, the parent event rows would remain with their child participation records permanently gone — a non-atomic inconsistency
- With the new order, if the `events` delete fails nothing has been removed and the data remains fully consistent

---
_Generated by [Claude Code](https://claude.ai/code/session_011aqPsCCaJ6uKgkQXy2rkWp)_