### PR TITLE
fix: prevent UI freeze on exception in TicketQrActivationPrototype

### DIFF
--- a/apps/mobile/src/components/screens/TicketQrActivationPrototype.tsx
+++ b/apps/mobile/src/components/screens/TicketQrActivationPrototype.tsx
@@ -75,9 +75,14 @@ export function TicketQrActivationPrototype({ userId, onBack }: TicketQrActivati
     const hash = pendingActivationHash;
     setPendingActivationHash(null);
     setBusy(true);
-    const result = await activateTicketHash(hash, userId);
-    setScanMessage(result.ok ? 'Ticket attivato correttamente.' : result.error);
-    setBusy(false);
+    try {
+      const result = await activateTicketHash(hash, userId);
+      setScanMessage(result.ok ? 'Ticket attivato correttamente.' : result.error);
+    } catch (error) {
+      setScanMessage(error instanceof Error ? error.message : 'Errore durante l\'attivazione del ticket.');
+    } finally {
+      setBusy(false);
+    }
   };
 
   return (


### PR DESCRIPTION
Closes #1261

## Summary
- Wrapped `await activateTicketHash(...)` in `handleConfirmActivation` in a `try/catch/finally` block
- `finally` always calls `setBusy(false)` to prevent permanent UI freeze
- `catch` sets an error message via `setScanMessage` to inform the user of failures

---
_Generated by [Claude Code](https://claude.ai/code/session_018s98p15k5r6h5MrxiDXxFT)_