### PR TITLE
fix: add catch block in Shop.handlePurchase to prevent silent failure

### DIFF
--- a/apps/mobile/src/components/screens/Shop.tsx
+++ b/apps/mobile/src/components/screens/Shop.tsx
@@ -46,6 +46,8 @@ export function Shop({
       } else {
         setFeedback({ type: 'error', message: formatRejection(result) });
       }
+    } catch (err) {
+      setFeedback({ type: 'error', message: err instanceof Error ? err.message : 'Errore durante l\'acquisto. Riprova.' });
     } finally {
       setBusyItemCode(null);
     }


### PR DESCRIPTION
Closes #1262

## Summary
- Added a `catch (err)` block to `handlePurchase` in `Shop.tsx`
- Thrown exceptions now set the `feedback` state with an error message visible to the user instead of being silently swallowed

---
_Generated by [Claude Code](https://claude.ai/code/session_018s98p15k5r6h5MrxiDXxFT)_