### PR TITLE
fix: wrap onSubmit in try/catch in NarrativeScene to prevent stuck UI

### DIFF
--- a/apps/mobile/src/components/screens/NarrativeScene.tsx
+++ b/apps/mobile/src/components/screens/NarrativeScene.tsx
@@ -277,12 +277,18 @@ export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }
       return;
     }
 
-    const submitResult = await onSubmit({
-      sceneId: activeScene.id,
-      choiceId: choice.id,
-      rewards: outcome.rewards,
-      setFlags: outcome.setFlags,
-    });
+    let submitResult: { ok: boolean; rewards?: Rewards; error?: string };
+    try {
+      submitResult = await onSubmit({
+        sceneId: activeScene.id,
+        choiceId: choice.id,
+        rewards: outcome.rewards,
+        setFlags: outcome.setFlags,
+      });
+    } catch (error) {
+      setLocal({ phase: 'error', message: error instanceof Error ? error.message : 'Errore nel salvataggio della scelta' });
+      return;
+    }
 
     if (!submitResult.ok) {
       setLocal({ phase: 'error', message: submitResult.error ?? 'Errore nel salvataggio della scelta' });


### PR DESCRIPTION
Closes #1263

## Summary
- Wrapped `await onSubmit(...)` in `handleChoose` in a `try/catch` block
- If `onSubmit` throws, the UI now transitions to the `error` phase with a message instead of remaining locked in the `submitting` state

---
_Generated by [Claude Code](https://claude.ai/code/session_018s98p15k5r6h5MrxiDXxFT)_