### PR TITLE
fix: add catch block in Signup.handleSubmit to display errors to users

### DIFF
--- a/apps/mobile/src/components/screens/Signup.tsx
+++ b/apps/mobile/src/components/screens/Signup.tsx
@@ -20,6 +20,7 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
   const [confirmPassword, setConfirmPassword] = useState('');
   const [acceptTerms, setAcceptTerms] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -31,9 +32,12 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
     if (password !== confirmPassword) newErrors.confirmPassword = 'Le password non corrispondono';
     if (!acceptTerms) newErrors.terms = 'Devi accettare i termini e la privacy';
     if (Object.keys(newErrors).length > 0) { setErrors(newErrors); return; }
+    setSubmitError(null);
     setIsSubmitting(true);
     try {
       await onSignup(name, email.trim().toLowerCase(), password);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : 'Errore durante la registrazione. Riprova.');
     } finally {
       setIsSubmitting(false);
     }
@@ -88,8 +92,8 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
             onViewPrivacy={onViewPrivacy}
           />
 
-          {errorMessage && (
-            <p className="text-sm text-[#ff4d4f] text-center">{errorMessage}</p>
+          {(errorMessage || submitError) && (
+            <p className="text-sm text-[#ff4d4f] text-center">{submitError ?? errorMessage}</p>
           )}
 
           <Button type="submit" fullWidth disabled={isSubmitting} className={isSubmitting ? 'opacity-50 pointer-events-none' : ''}>


### PR DESCRIPTION
Closes #1265

## Summary
- Added `submitError` local state to `Signup` component
- Added `catch (err)` block to `handleSubmit` that sets `submitError` with the thrown error message
- The existing error display in the form now also shows `submitError` so users see feedback when `onSignup` throws

---
_Generated by [Claude Code](https://claude.ai/code/session_018s98p15k5r6h5MrxiDXxFT)_