### PR TITLE
fix: use stable-callback ref pattern in ActivitiesHub to prevent infinite render loop

### DIFF
--- a/apps/mobile/src/components/screens/ActivitiesHub.tsx
+++ b/apps/mobile/src/components/screens/ActivitiesHub.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { ListChecks, Ticket } from 'lucide-react';
 import { Card } from '../ui/Card';
 import { Screen } from '../ui/Screen';
@@ -24,11 +24,14 @@ export function ActivitiesHub({
     return null;
   }, [activeSection, showActivities, showTurns]);
 
+  const onSectionChangeRef = useRef(onSectionChange);
+  useEffect(() => { onSectionChangeRef.current = onSectionChange; });
+
   useEffect(() => {
     if (resolvedSection && resolvedSection !== activeSection) {
-      onSectionChange(resolvedSection);
+      onSectionChangeRef.current(resolvedSection);
     }
-  }, [activeSection, onSectionChange, resolvedSection]);
+  }, [activeSection, resolvedSection]);
 
   const showSwitcher = showTurns && showActivities;
 


### PR DESCRIPTION
Closes #1267

## Summary
- Introduced `onSectionChangeRef` to store the latest `onSectionChange` callback
- Removed `onSectionChange` from the `useEffect` dependency array that calls it
- This prevents infinite render loops when non-memoized parent callbacks are passed as props

---
_Generated by [Claude Code](https://claude.ai/code/session_018s98p15k5r6h5MrxiDXxFT)_