### PR TITLE
fix: add isMounted guard in AccountSettings usePermissions to prevent setState after unmount

### DIFF
--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Accessibility,
   ArrowLeft, Bell, Camera, ChevronRight, Download, FileText, History, KeyRound,
@@ -549,9 +549,15 @@ function usePermissions() {
     notifications: null, camera: null, geolocation: null,
   });
 
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => { isMountedRef.current = false; };
+  }, []);
+
   const refreshAll = useCallback(async () => {
     if (typeof navigator === 'undefined' || !navigator.permissions?.query) {
-      setPermissionStatuses({ notifications: 'unsupported', camera: 'unsupported', geolocation: 'unsupported' });
+      if (isMountedRef.current) setPermissionStatuses({ notifications: 'unsupported', camera: 'unsupported', geolocation: 'unsupported' });
       return;
     }
     const queryPerm = (name: string) =>
@@ -561,7 +567,7 @@ function usePermissions() {
     const [notifications, camera, geolocation] = await Promise.all([
       queryPerm('notifications'), queryPerm('camera'), queryPerm('geolocation'),
     ]);
-    setPermissionStatuses({ notifications, camera, geolocation });
+    if (isMountedRef.current) setPermissionStatuses({ notifications, camera, geolocation });
   }, []);
 
   useEffect(() => { void refreshAll().catch(() => {}); }, [refreshAll]);


### PR DESCRIPTION
Closes #1268

## Summary
- Added `isMountedRef` to `usePermissions` hook in `AccountSettings.tsx`
- Added a `useEffect` with cleanup that sets `isMountedRef.current = false` on unmount
- Guarded all `setPermissionStatuses` calls inside `refreshAll` with `if (isMountedRef.current)` to prevent setState on unmounted component

---
_Generated by [Claude Code](https://claude.ai/code/session_018s98p15k5r6h5MrxiDXxFT)_