### PR TITLE
fix: guard geolocation callbacks with isMounted check in AccountSettings

### DIFF
--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -606,11 +606,13 @@ function usePermissions() {
       } else {
         navigator.geolocation.getCurrentPosition(
           () => {
+            if (!isMountedRef.current) return;
             setPermissionStatuses(p => ({ ...p, geolocation: 'granted' }));
             setPermissionMessages(p => ({ ...p, geolocation: 'Permesso geolocalizzazione concesso.' }));
             void refreshAll();
           },
           () => {
+            if (!isMountedRef.current) return;
             setPermissionStatuses(p => ({ ...p, geolocation: 'denied' }));
             setPermissionMessages(p => ({ ...p, geolocation: 'Permesso geolocalizzazione negato.' }));
             void refreshAll();


### PR DESCRIPTION
Closes #1269

## Summary
- Added `if (!isMountedRef.current) return;` guards to both the success and error callbacks of `navigator.geolocation.getCurrentPosition()` in `usePermissions` (reusing the `isMountedRef` already added by #1268)
- Prevents `setPermissionStatuses` and `setPermissionMessages` from firing on an unmounted component if the geolocation response arrives after the user navigates away

---
_Generated by [Claude Code](https://claude.ai/code/session_018s98p15k5r6h5MrxiDXxFT)_