### PR TITLE
fix: await ensureTheaterScenesLoaded before loadScene in handleContinue

### DIFF
--- a/apps/mobile/src/components/screens/NarrativeScene.tsx
+++ b/apps/mobile/src/components/screens/NarrativeScene.tsx
@@ -218,9 +218,19 @@ export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }
   }
 
   if (local.phase === 'outcome') {
-    const handleContinue = () => {
+    const handleContinue = async () => {
       if (local.finished) { onClose(); return; }
       const nextSceneId = local.run.currentSceneId;
+      // Theater scenes live in a lazy chunk and require the registry to be
+      // populated before `loadScene` can find them (issue #1283).
+      if (nextSceneId.startsWith(THEATER_ID_PREFIX)) {
+        try {
+          await ensureTheaterScenesLoaded();
+        } catch {
+          setLocal({ phase: 'error', message: `Scenario "${nextSceneId}" non disponibile al momento.` });
+          return;
+        }
+      }
       const nextScene = loadScene(nextSceneId);
       if (!nextScene) {
         setLocal({ phase: 'error', message: `Scenario "${nextSceneId}" non trovato.` });


### PR DESCRIPTION
Closes #1283

## What changed

`handleContinue` in the `outcome` phase of `NarrativeScene.tsx` was calling `loadScene()` synchronously for all scene IDs, including `theater_`-prefixed ones. Theater scenes live in a lazy chunk and are only available after `ensureTheaterScenesLoaded()` is awaited — so the synchronous call always returned `null`, making any multi-scene theater narrative unplayable beyond the first scene.

The fix makes `handleContinue` async and awaits `ensureTheaterScenesLoaded()` before calling `loadScene()` whenever the next scene ID starts with `theater_`. The lazy chunk is already cached after the first call so there is no repeated network overhead. Error handling follows the same pattern used in the existing `useEffect` for theater scene loading.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1J3gobBUPo8HRvo7yrduX)_