### PR TITLE
fix: wire setAnalyticsAuthToken from Supabase session in AppShell

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -12,7 +12,7 @@ import { hasStoredAuthState, PUBLIC_SCREENS } from '../lib/auth-storage';
 import { openInMaps, openEventsMap } from '../lib/navigation-utils';
 import { uploadProfileImage } from '../services/storage';
 import { initErrorHandler, subscribeToCriticalErrors, getLastCriticalError, clearLastCriticalError } from '../services/error-handler';
-import { getUserHash, trackShareClicked } from '../services/analytics';
+import { getUserHash, setAnalyticsAuthToken, trackShareClicked } from '../services/analytics';
 import { buildShareUrl, sharePayload } from '../lib/share';
 import { PENDING_EVENT_KEY, readPendingEventFromUrl, stripEventLinkParams } from '../lib/event-linking';
 import type { ActivatedEventPayload } from '../services/ticket-activation';
@@ -332,6 +332,27 @@ export function AppShell() {
     const pending = getLastCriticalError();
     if (pending) setCriticalError(pending);
     return subscribeToCriticalErrors(payload => setCriticalError(prev => prev ?? payload));
+  }, []);
+
+  // Sync Supabase JWT into the analytics module so pseudonymize-user-id calls
+  // include the Authorization header (issue #1284). We subscribe to every auth
+  // state change so token refreshes are picked up automatically.
+  useEffect(() => {
+    if (!supabase) return;
+
+    // Seed with the current session immediately (handles page reloads where the
+    // user is already signed in before this effect runs).
+    supabase.auth.getSession().then(({ data }) => {
+      setAnalyticsAuthToken(data.session?.access_token ?? null);
+    }).catch(() => undefined);
+
+    const { data: authListener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setAnalyticsAuthToken(session?.access_token ?? null);
+    });
+
+    return () => {
+      authListener?.subscription.unsubscribe();
+    };
   }, []);
 
   // Lock body scroll on critical error

--- a/apps/mobile/src/services/analytics.ts
+++ b/apps/mobile/src/services/analytics.ts
@@ -219,6 +219,15 @@ async function fetchUserHash(userId: string): Promise<string | undefined> {
 
     if (_authToken) {
       headers['Authorization'] = `Bearer ${_authToken}`;
+    } else {
+      // No auth token available — the Edge Function will return 401 and the
+      // call would silently yield `userHash: undefined`. Skip the network
+      // request entirely and let the caller degrade gracefully (issue #1284).
+      const env = (import.meta as { env?: Record<string, string | undefined> }).env;
+      if (env?.DEV) {
+        console.warn('[analytics] setAnalyticsAuthToken has not been called — skipping pseudonymize-user-id request.');
+      }
+      return undefined;
     }
 
     const controller = new AbortController();


### PR DESCRIPTION
Closes #1284

## What changed

`setAnalyticsAuthToken` was exported from `analytics.ts` but never called anywhere, so `_authToken` remained `null` in production. Every call to the `pseudonymize-user-id` Edge Function was sent without an `Authorization` header, received a 401, and returned `undefined` — causing every analytics event to have `userHash: undefined`.

**`AppShell.tsx`**: imports `setAnalyticsAuthToken` and adds a `useEffect` that:
- Seeds the token immediately via `supabase.auth.getSession()` (handles page reloads where the user is already signed in)
- Subscribes to `onAuthStateChange` to keep the token in sync on sign-in, token refresh, and sign-out

**`analytics.ts`**: adds a defensive early-return in `fetchUserHash` when `_authToken` is null. Instead of making a doomed HTTP request that would receive a 401 and silently yield `undefined`, the function now returns `undefined` immediately and logs a dev-only warning — making the misconfiguration visible during development without impacting production UX.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1J3gobBUPo8HRvo7yrduX)_