### PR TITLE
fix: add AbortController timeout to GitHub API fetch (closes #1287)

### DIFF
--- a/supabase/functions/app-version/index.ts
+++ b/supabase/functions/app-version/index.ts
@@ -90,11 +90,15 @@ serve(async (req) => {
 
   const url = `https://api.github.com/repos/${repo}/commits?per_page=${limit}`;
   let response: Response;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 8000);
   try {
-    response = await fetch(url, { headers });
+    response = await fetch(url, { headers, signal: controller.signal });
   } catch (err) {
     console.error('[app-version] GitHub fetch failed', err);
     return errorResponse('Impossibile caricare il changelog', 502);
+  } finally {
+    clearTimeout(timeoutId);
   }
   if (!response.ok) {
     console.error('[app-version] GitHub API error', response.status, response.statusText);


### PR DESCRIPTION
Closes #1287

## What
The GitHub API `fetch` call in `app-version` had no timeout, allowing the edge function to hang indefinitely.

## How
Added an `AbortController` with an 8-second timeout (matching the pattern used in `analytics.ts`), wrapped in try/finally to always clear the timeout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrCBGd2GMDG31aoefdqSMX)_