### PR TITLE
fix: delay blob URL revocation in handleAddToCalendar (closes #1288)

### DIFF
--- a/apps/mobile/src/components/screens/EventDetails.tsx
+++ b/apps/mobile/src/components/screens/EventDetails.tsx
@@ -107,7 +107,7 @@ export function EventDetails({
     document.body.appendChild(anchor);
     anchor.click();
     document.body.removeChild(anchor);
-    URL.revokeObjectURL(url);
+    setTimeout(() => URL.revokeObjectURL(url), 10_000);
   };
 
   const handleSavePlanning = async () => {


### PR DESCRIPTION
Closes #1288

## What
`URL.revokeObjectURL()` was called synchronously after `anchor.click()`, revoking the blob URL before the browser's async download pipeline could fetch the data, silently aborting the `.ics` download on mobile browsers.

## How
Wrapped the revocation in `setTimeout(..., 10_000)` to give the browser time to start the download, matching the pattern applied in #1235 for `exportUserData`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrCBGd2GMDG31aoefdqSMX)_