### PR TITLE
fix: migrate SupportChat history from displayName to userId key (closes #1289)

### DIFF
--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -73,7 +73,12 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
     const currentDisplayName = displayNameRef.current;
     const currentUserId = userIdRef.current;
     const currentHistoryId = currentUserId || currentDisplayName;
-    const stored = loadChatHistory(currentHistoryId);
+    let stored = loadChatHistory(currentHistoryId);
+    // Migrate history from the displayName fallback key when userId becomes available
+    if (!stored.length && currentUserId && currentDisplayName !== currentUserId) {
+      stored = loadChatHistory(currentDisplayName);
+      if (stored.length) saveChatHistory(currentUserId, stored);
+    }
     if (stored.length) {
       setChatSessions(stored);
       setActiveSessionId(stored[0].id);


### PR DESCRIPTION
Closes #1289

## What
Chat history started under the `displayName` fallback key (before auth hydration) was lost when `userId` became available, because `loadChatHistory(userId)` returned empty and a fresh greeting was shown.

## How
When the initialization effect fires with a non-null `userId` and finds no history under the `userId` key, it checks the old `displayName` key and migrates any existing sessions to the `userId` key before restoring them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrCBGd2GMDG31aoefdqSMX)_