### PR TITLE
fix: remove duplicate onAuthChange call in handleLogin (closes #1290)

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -104,8 +104,9 @@ export function useAuth(
         });
         const shouldSetName = shouldUpdateName(profile.name, email, displayName);
         updateProfile(shouldSetName ? { name: displayName, email } : { email });
-        onAuthChange('home');
-    }, [onAuthChange, profile.name, updateProfile]);
+        // Navigation to 'home' is handled by the onAuthStateChange SIGNED_IN listener;
+        // calling onAuthChange here as well would fire it twice on every successful login.
+    }, [profile.name, updateProfile]);
 
     const handleSignup = useCallback(async (name: string, email: string, password: string) => {
         setAuthError(null);


### PR DESCRIPTION
Closes #1290

## What
`handleLogin` called `onAuthChange('home')` directly after a successful sign-in, and then the `onAuthStateChange` `SIGNED_IN` listener called it again — resulting in two navigation events on every login.

## How
Removed the explicit `onAuthChange('home')` call from `handleLogin`; navigation is now handled exclusively by the `onAuthStateChange` `SIGNED_IN` listener, which already has the correct logic including the `suppressSignedInNavigation` guard.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrCBGd2GMDG31aoefdqSMX)_