### PR TITLE
fix: add HTTP method check to ticket-activation edge function (closes #1291)

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -7,7 +7,7 @@ const allowedOrigin = Deno.env.get('SITE_URL') ?? 'https://turnidipalco.it';
 const corsHeaders = {
   'Access-Control-Allow-Origin': allowedOrigin,
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
 };
 
 
@@ -39,6 +39,10 @@ serve(async (req: Request) => {
   // Handle CORS
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Metodo non consentito' }, 405);
   }
 
   const supabaseUrl = Deno.env.get('SUPABASE_URL');


### PR DESCRIPTION
Closes #1291

## What
The `ticket-activation` edge function was missing a method guard after the CORS `OPTIONS` handler, allowing non-POST requests (GET, PUT, etc.) to fall through into full business logic.

## How
Added an early `req.method !== 'POST'` check returning a 405 response, matching the pattern used in other edge functions. Also corrected `Access-Control-Allow-Methods` to `POST, OPTIONS` (removing the advertised but unimplemented `GET`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrCBGd2GMDG31aoefdqSMX)_