### PR TITLE
fix: use ref to stabilize onComplete in OnboardingFirstMission effect (closes #1292)

### DIFF
--- a/apps/mobile/src/components/screens/OnboardingFirstMission.tsx
+++ b/apps/mobile/src/components/screens/OnboardingFirstMission.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Screen } from '../ui/Screen';
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
@@ -22,11 +22,14 @@ export function OnboardingFirstMission({ roleId, onComplete, onSkip }: Onboardin
   const mission = FIRST_MISSIONS[roleId];
   const [phase, setPhase] = useState<Phase>({ kind: 'choosing' });
 
+  const onCompleteRef = useRef(onComplete);
+  useEffect(() => { onCompleteRef.current = onComplete; }, [onComplete]);
+
   useEffect(() => {
     if (phase.kind !== 'outcome') return;
-    const timer = setTimeout(() => onComplete(phase.xpEarned), AUTO_ADVANCE_MS);
+    const timer = setTimeout(() => onCompleteRef.current(phase.xpEarned), AUTO_ADVANCE_MS);
     return () => clearTimeout(timer);
-  }, [phase, onComplete]);
+  }, [phase]);
 
   if (!mission) {
     return (


### PR DESCRIPTION
Closes #1292

## What
`onComplete` was in the auto-advance `useEffect` dependency array, so any parent re-render that passed a new (non-memoized) callback reference would reset the 3500 ms timer repeatedly, and could cause `onComplete` to fire twice (once from the timer, once from the manual button).

## How
Stored `onComplete` in a ref (kept current via a separate sync effect) and removed it from the auto-advance effect's dependency array, so the timer only resets when `phase` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrCBGd2GMDG31aoefdqSMX)_