### PR TITLE
fix: idempotent ticket activation to allow registerTurn retry

### DIFF
--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -550,6 +550,13 @@ export async function activateTicketHash(
   }
 
   if (isTicketHashActivatedInSession(normalizedHash)) {
+    // The ticket was already activated in this session — allow idempotent
+    // re-entry so that a failed registerTurn can be retried without the user
+    // losing their ticket (closes #1300).
+    const existing = localActivationStore.get(normalizedHash);
+    if (existing?.activatedBy === normalizedUserId && existing.eventId) {
+      return { ok: true, eventId: existing.eventId };
+    }
     return { ok: false, error: 'Ticket già attivato in questa sessione.' };
   }
 
@@ -649,6 +656,13 @@ export async function activateTicketByDetails(
   }
   const manualTicketKey = buildManualTicketKey(normalizedEventId, normalizedTicket);
   if (localManualActivationStore.has(manualTicketKey)) {
+    // The ticket was already activated in this session — allow idempotent
+    // re-entry so that a failed registerTurn can be retried without the user
+    // losing their ticket (closes #1300).
+    const existing = localManualActivationStore.get(manualTicketKey);
+    if (existing?.activatedBy === normalizedUserId) {
+      return { ok: true, eventId: existing.eventId };
+    }
     return { ok: false, error: 'Ticket già attivato in questa sessione.' };
   }
 


### PR DESCRIPTION
Closes #1300

## Problem

In `activateTicketHash` and `activateTicketByDetails`, a successful ticket activation followed by a failed `registerTurn` (network error, JWT expiry, 5xx) left the user in an unrecoverable state: the ticket was consumed server-side, but the turn was never recorded. On retry, the in-session dedup check (`isTicketHashActivatedInSession` / `localManualActivationStore.has`) returned an error, blocking any further attempt.

## Fix

Made both activation functions idempotent for same-session, same-user re-calls:

- **`activateTicketHash`**: when the hash is already activated in this session by the same `userId`, return `{ ok: true, eventId }` using the stored record instead of blocking with an error.
- **`activateTicketByDetails`**: when the manual ticket key is already in the session store for the same `userId`, return `{ ok: true, eventId }` from the stored record.

This allows `handleEventConfirm` to naturally retry `registerTurn` after a transient failure without requiring a re-scan or any changes to the caller — `pendingTicketActivation` is already preserved on failure (only cleared on success), so the user hitting "Confirm" again will attempt the turn registration against an idempotent activation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESzzV1TMMji5tpkH7ghq2T)_