### PR TITLE
fix: override clientUserId with verified JWT identity in mobile-logs

### DIFF
--- a/supabase/functions/mobile-logs/index.ts
+++ b/supabase/functions/mobile-logs/index.ts
@@ -160,9 +160,9 @@ serve(async (req: Request) => {
     const duplicatePolicy = typeof body.duplicatePolicy === 'string' && body.duplicatePolicy.trim()
       ? body.duplicatePolicy.trim().slice(0, 80)
       : 'include';
-    const clientUserId = typeof body.clientUserId === 'string' && body.clientUserId.trim()
-      ? body.clientUserId.trim().slice(0, 200)
-      : null;
+    // Always use the verified JWT identity; ignore any caller-supplied value to
+    // prevent false log attribution (IDOR — closes #1301).
+    const clientUserId = requesterUserIdFromAuth;
 
     const rawLogs = Array.isArray(body.logs) ? body.logs.slice(0, 100) : [];
     const normalizedLogs = rawLogs


### PR DESCRIPTION
Closes #1301

## Problem

`supabase/functions/mobile-logs/index.ts` read `clientUserId` directly from the caller-controlled request body and wrote it verbatim into every log entry. Although `requesterUserId` was derived from the verified JWT, `clientUserId` was never validated against it, allowing any authenticated user to forge log entries attributed to another user's ID (IDOR / audit integrity violation).

## Fix

Replace the caller-supplied `clientUserId` with `requesterUserIdFromAuth` — the identity already verified from the JWT. The body field is now ignored entirely. All log entries are attributed to the authenticated caller, making it impossible to submit logs under a different user's ID.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESzzV1TMMji5tpkH7ghq2T)_