### PR TITLE
fix: stop deletion loop on first failure in delete-my-account

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -74,21 +74,24 @@ serve(async (req) => {
     { table: 'profiles', key: 'id' },
   ] as const;
 
-  const failedTables: string[] = [];
+  let failedTable: string | null = null;
 
   for (const { table, key } of tablesToDelete) {
     const { error } = await adminClient.from(table).delete().eq(key, userId);
     if (error) {
       console.error(`delete-my-account: error deleting from ${table}`, error.message);
-      failedTables.push(table);
+      failedTable = table;
+      break;
     }
   }
 
-  // Abort before deleting auth user if critical data remains
-  if (failedTables.length > 0) {
-    console.error(`delete-my-account: aborting for user ${userId}, orphaned tables: ${failedTables.join(', ')}`);
+  // Abort before deleting auth user if any table deletion failed.
+  // Stopping at the first failure preserves subsequent tables so the user
+  // can retry without ending up in a worse partial-deletion state.
+  if (failedTable !== null) {
+    console.error(`delete-my-account: aborting for user ${userId}, failed on table: ${failedTable}`);
     return errorResponse(
-      `Cancellazione parziale: dati rimasti in ${failedTables.join(', ')}. L'account non è stato eliminato. Riprova o contatta il supporto.`,
+      `Cancellazione non completata: errore su ${failedTable}. L'account non è stato eliminato. Riprova o contatta il supporto.`,
       500,
     );
   }


### PR DESCRIPTION
Closes #1305

The sequential table-deletion loop was collecting all failures and continuing to delete subsequent tables even after an error. This worsened the inconsistency: tables after the failing one would be deleted while the failing table's data remained, making retry attempts more complex and potentially leaving the account in a worse state.

The fix breaks out of the loop at the first failed deletion. This ensures that on failure, all tables after the failed one are untouched and the auth user is never deleted, so the user can safely retry. The `auth.admin.deleteUser()` call was already correctly placed last (only reached after all table deletions succeed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESzzV1TMMji5tpkH7ghq2T)_