### PR TITLE
fix: fetchAllEvents catches HTTP/network errors instead of throwing

### DIFF
--- a/supabase/functions/import-spazio-rossellini/index.ts
+++ b/supabase/functions/import-spazio-rossellini/index.ts
@@ -127,36 +127,45 @@ const fetchCategorySlugs = async (): Promise<Set<string>> => {
 
 const MAX_PAGINATION_PAGES = 50;
 
-const fetchAllEvents = async () => {
+const fetchAllEvents = async (): Promise<SpazioEvent[]> => {
   const events: SpazioEvent[] = [];
   let nextUrl: string | null = EVENTS_API_URL;
   const visited = new Set<string>();
-  while (nextUrl && !visited.has(nextUrl) && visited.size < MAX_PAGINATION_PAGES) {
-    visited.add(nextUrl);
-    const page = visited.size;
-    let res: Response;
-    try {
-      res = await fetchWithTimeout(nextUrl);
-    } catch (err) {
-      throw new Error(
-        `Events API network error on page ${page} (url: ${nextUrl}): ${err instanceof Error ? err.message : String(err)}`,
-      );
+  try {
+    while (nextUrl && !visited.has(nextUrl) && visited.size < MAX_PAGINATION_PAGES) {
+      visited.add(nextUrl);
+      const page = visited.size;
+      let res: Response;
+      try {
+        res = await fetchWithTimeout(nextUrl);
+      } catch (err) {
+        console.warn(
+          `[import-spazio-rossellini] fetchAllEvents network error on page ${page} (url: ${nextUrl}):`,
+          err,
+        );
+        break;
+      }
+      if (!res.ok) {
+        console.warn(`[import-spazio-rossellini] fetchAllEvents HTTP error: ${res.status} (page ${page}, url: ${nextUrl})`);
+        break;
+      }
+      let payload: { events?: SpazioEvent[]; next_rest_url?: string };
+      try {
+        payload = await res.json();
+      } catch (err) {
+        console.warn(
+          `[import-spazio-rossellini] fetchAllEvents invalid JSON (url: ${nextUrl}):`,
+          err,
+        );
+        break;
+      }
+      if (Array.isArray(payload.events)) {
+        events.push(...payload.events);
+      }
+      nextUrl = payload.next_rest_url || null;
     }
-    if (!res.ok) throw new Error(`Events API fetch failed: ${res.status} (page ${page}, url: ${nextUrl})`);
-    let payload: { events?: SpazioEvent[]; next_rest_url?: string };
-    try {
-      payload = await res.json();
-    } catch (err) {
-      console.warn(
-        `[import-spazio-rossellini] fetchAllEvents invalid JSON (url: ${nextUrl}):`,
-        err,
-      );
-      break;
-    }
-    if (Array.isArray(payload.events)) {
-      events.push(...payload.events);
-    }
-    nextUrl = payload.next_rest_url || null;
+  } catch (err) {
+    console.warn('[import-spazio-rossellini] fetchAllEvents unexpected error:', err);
   }
   return events;
 };


### PR DESCRIPTION
Closes #1306

`fetchAllEvents` was throwing on non-OK HTTP responses and on network errors, causing `Promise.all` to reject immediately and discard already-fetched sitemap URLs and category slugs.

The fix wraps the pagination loop in a try/catch and converts both HTTP errors (`!res.ok`) and network errors into `console.warn` + `break`, consistent with the graceful-degradation pattern already used by `fetchSitemapUrls` and `fetchCategorySlugs`. On error the function returns whatever events were successfully fetched before the failure (or an empty array on the first-page failure).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESzzV1TMMji5tpkH7ghq2T)_