### PR TITLE
fix: compute nextProfile before setState to ensure persistProfile is always called

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4289,53 +4289,41 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   const completeOnboarding = useCallback(
     (variant: 'full' | 'skipped_qr' | 'skipped_manual', xpReward?: number) => {
       const completedAt = new Date().toISOString();
-      // Use a ref to capture the committed profile value from inside the updater.
-      // A plain `let` variable is unreliable under React 18 concurrent rendering
-      // because the updater may run more than once (StrictMode, concurrent re-renders),
-      // and the value from a discarded run would be passed to persistProfile.
-      const capturedProfileRef: { current: PlayerProfile | null } = { current: null };
-      setState((prev: GameState) => {
-        let profile: PlayerProfile = {
-          ...prev.profile,
-          onboardingCompletedAt: completedAt,
-          onboardingVariant: variant,
-        };
-        if (xpReward && xpReward > 0) {
-          profile = applyRewards(profile, { xp: xpReward, cachet: 0, reputation: 0 }, 'activity');
-        }
-        capturedProfileRef.current = profile;
-        return { ...prev, profile };
-      });
-      if (capturedProfileRef.current !== null) {
-        persistProfile(capturedProfileRef.current);
+      // Compute the next profile value before calling setState so we can pass it
+      // directly to persistProfile. The capturedProfileRef pattern is unreliable
+      // under React 18 concurrent rendering because the setState updater is not
+      // guaranteed to run synchronously — capturedProfileRef.current is always null
+      // at the check site (closes #1312).
+      let nextProfile: PlayerProfile = {
+        ...state.profile,
+        onboardingCompletedAt: completedAt,
+        onboardingVariant: variant,
+      };
+      if (xpReward && xpReward > 0) {
+        nextProfile = applyRewards(nextProfile, { xp: xpReward, cachet: 0, reputation: 0 }, 'activity');
       }
+      setState((prev: GameState) => ({ ...prev, profile: nextProfile }));
+      persistProfile(nextProfile);
     },
-    [persistProfile],
+    [persistProfile, state.profile],
   );
 
   const updateProfile = useCallback(
     (updates: Partial<Pick<PlayerProfile, 'name' | 'email' | 'roleId' | 'profileImage' | 'leaderboardVisible'>>) => {
-      // Use a ref object to capture the committed profile value from inside the
-      // setState updater. A plain `let` variable is unreliable under React 18
-      // concurrent rendering because the updater may run more than once
-      // (StrictMode, concurrent re-renders), and the value from a discarded run
-      // could be passed to persistProfile — same safe pattern used by
-      // completeOnboarding/startCourse/completeCourse (closes #1237).
-      const capturedProfileRef: { current: PlayerProfile | null } = { current: null };
-      setState((prev: GameState) => {
-        const nextRole =
-          updates.roleId && catalog.roles.some((role: Role) => role.id === updates.roleId)
-            ? updates.roleId
-            : prev.profile.roleId;
-        const profile: PlayerProfile = { ...prev.profile, ...updates, roleId: nextRole ?? prev.profile.roleId };
-        capturedProfileRef.current = profile;
-        return { ...prev, profile };
-      });
-      if (capturedProfileRef.current !== null) {
-        persistProfile(capturedProfileRef.current);
-      }
+      // Compute the next profile value before calling setState so we can pass it
+      // directly to persistProfile. The capturedProfileRef pattern is unreliable
+      // under React 18 concurrent rendering because the setState updater is not
+      // guaranteed to run synchronously — capturedProfileRef.current is always null
+      // at the check site (closes #1312).
+      const nextRole =
+        updates.roleId && catalog.roles.some((role: Role) => role.id === updates.roleId)
+          ? updates.roleId
+          : state.profile.roleId;
+      const nextProfile: PlayerProfile = { ...state.profile, ...updates, roleId: nextRole ?? state.profile.roleId };
+      setState((prev: GameState) => ({ ...prev, profile: nextProfile }));
+      persistProfile(nextProfile);
     },
-    [catalog.roles, persistProfile]
+    [catalog.roles, persistProfile, state.profile]
   );
 
   const registerTurn = useCallback(
@@ -4889,25 +4877,17 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       };
 
       // 1. Apply rewards locally — visible immediately in Home/profile.
-      // Use a ref object to capture the committed profile value from inside the
-      // setState updater. A plain `let` variable is unreliable under React 18
-      // concurrent rendering because the updater may run more than once
-      // (StrictMode, concurrent re-renders), and the value from a discarded run
-      // could be passed to persistProfile — same safe pattern used by
-      // completeOnboarding and updateProfile (closes #1259).
-      const capturedProfileRef: { current: PlayerProfile | null } = { current: null };
-      setState((prev: GameState) => {
-        const nextProfile = applyRewards(prev.profile, rewards, 'activity');
-        capturedProfileRef.current = nextProfile;
-        return { ...prev, profile: nextProfile };
-      });
+      // Compute the next profile value before calling setState so we can pass it
+      // directly to persistProfile. The capturedProfileRef pattern is unreliable
+      // under React 18 concurrent rendering because the setState updater is not
+      // guaranteed to run synchronously — capturedProfileRef.current is always null
+      // at the check site (closes #1312).
+      const nextProfile = applyRewards(state.profile, rewards, 'activity');
+      setState((prev: GameState) => ({ ...prev, profile: nextProfile }));
 
       // 1b. Persist updated profile to server so XP/cachet/reputation survive
-      // a page reload (closes #1200). capturedProfileRef.current is non-null
-      // when the committed updater run assigned it.
-      if (capturedProfileRef.current !== null) {
-        persistProfile(capturedProfileRef.current);
-      }
+      // a page reload (closes #1200).
+      persistProfile(nextProfile);
 
       // 2. Persist to narrative_history (append-only, RLS-scoped to user).
       // Best-effort: a failed insert does not roll back local rewards. Without
@@ -4932,7 +4912,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
       return { ok: true, rewards };
     },
-    [authUserId, persistProfile]
+    [authUserId, persistProfile, state.profile]
   );
 
   const resetProgress = useCallback(async () => {


### PR DESCRIPTION
Closes #1312

## Problem
`completeOnboarding`, `updateProfile`, and `completeNarrativeChoice` used a `capturedProfileRef` pattern to capture the new profile inside a `setState` updater and then call `persistProfile` afterwards. Under React 18 concurrent rendering, the updater is not guaranteed to run synchronously before `setState` returns, so `capturedProfileRef.current` is always `null` at the check site — meaning `persistProfile` was never called and profile changes silently never reached the server.

## Fix
Pre-compute `nextProfile` from the current `state.profile` snapshot before calling `setState`, then pass the same pre-computed value to both `setState` (via functional updater) and `persistProfile` directly. This eliminates the race and ensures the server write always happens.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESzzV1TMMji5tpkH7ghq2T)_