### PR TITLE
fix: clear localActivationStores on logout to prevent cross-user ticket data bleed

### DIFF
--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -713,3 +713,14 @@ export async function activateTicketByDetails(
 export function listLocalTicketRecords(): TicketActivationRecord[] {
   return Array.from(localActivationStore.values()).sort((a, b) => a.hash.localeCompare(b.hash));
 }
+
+/**
+ * Clear all in-memory ticket activation records.
+ * Must be called on user logout to prevent cross-user data bleed: if User A
+ * activates tickets and then logs out, User B must not see those activations
+ * as already-used in their session (closes #1313).
+ */
+export function clearLocalActivationStores(): void {
+  localActivationStore.clear();
+  localManualActivationStore.clear();
+}

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -10,6 +10,7 @@ import {
 import { resolveDisplayName } from '../lib/profile-utils';
 import { COOKIE_CONSENT_KEY, GEO_CONSENT_KEY } from '../constants/privacy';
 import { formatErrorDetails, reportCriticalError } from '../services/error-handler';
+import { clearLocalActivationStores } from '../services/ticket-activation';
 import {
   getXpToNextLevel,
   getStatMultiplier,
@@ -5326,6 +5327,10 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     // Clear the narrative idempotency guard so that replaying scenes after a
     // progress reset in the same session yields rewards correctly (closes #1130).
     appliedNarrativeChoicesRef.current = new Set();
+    // Clear in-memory ticket activation caches so that a new user logging in on
+    // the same browser tab does not inherit the previous user's activated-ticket
+    // records (closes #1313).
+    clearLocalActivationStores();
     // Reset hydration flag so persistProfile's guard re-arms and does not sync
     // blank default state to the DB if called before the next remote hydration
     // completes (closes #1132).


### PR DESCRIPTION
Closes #1313

## Problem
`localActivationStore` and `localManualActivationStore` in `ticket-activation.ts` are module-level singletons that were never cleared on user logout. If User A activated tickets and then logged out, User B logging in on the same browser tab would see those hashes as already activated, blocking legitimate scans with "Ticket già attivato in questa sessione."

## Fix
- Export `clearLocalActivationStores()` from `ticket-activation.ts` that clears both Maps.
- Import and call it from `resetState` in `store.tsx`, alongside the existing `appliedNarrativeChoicesRef.current = new Set()` reset, so activation memory is wiped on every logout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESzzV1TMMji5tpkH7ghq2T)_