### PR TITLE
fix: do not retry 401/403 auth errors in offline sync queue

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -1731,7 +1731,13 @@ function shouldRetrySyncError(error: unknown) {
   if (isNavigatorOffline()) return true;
   const status = getSyncErrorStatus(error);
   if (status != null) {
-    if (status === 0 || status === 401 || status === 403 || status === 408 || status === 429) {
+    // 401 and 403 are permanent authentication/authorization failures — the
+    // same token will still be invalid on every retry, so re-sending the
+    // request wastes the entire backoff budget and may trigger server-side rate
+    // limiting. These should be surfaced as dead-letter failures immediately
+    // rather than retried (closes #1314).
+    if (status === 401 || status === 403) return false;
+    if (status === 0 || status === 408 || status === 429) {
       return true;
     }
     if (status >= 500) return true;


### PR DESCRIPTION
Closes #1314

## Problem
`shouldRetrySyncError` treated HTTP 401 and 403 as retryable, causing the offline sync queue to burn all 12 retry slots with exponential backoff on permanent authentication failures. The token is still invalid on every attempt, the queue is blocked, and repeated requests risk server-side rate limiting.

## Fix
Return `false` immediately for status 401 and 403 in `shouldRetrySyncError`. These codes are permanent failures that require re-authentication — not transient errors that benefit from retry. The dead-letter path is the correct outcome for these items.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESzzV1TMMji5tpkH7ghq2T)_