### PR TITLE
fix: guard getUser() navigation with hasNavigatedRef to prevent forced home redirect on every mount

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -220,14 +220,22 @@ export function useAuth(
     const onLogoutRef = useRef(onLogout);
     useEffect(() => { onLogoutRef.current = onLogout; }, [onLogout]);
 
+    // Guard: only navigate to 'home' on the very first successful getUser()
+    // resolution (the auth-unknown → authenticated transition). Subsequent
+    // calls (hot-reload, StrictMode double-mount, component remount) must NOT
+    // redirect the user away from their current screen (closes #1315).
+    const hasNavigatedRef = useRef(false);
+
     useEffect(() => {
         if (!supabase) return;
         let mounted = true;
 
         supabase.auth.getUser().then(({ data, error }) => {
             if (!mounted || error || !data.user) return;
+            const navigateTo = hasNavigatedRef.current ? undefined : 'home';
+            hasNavigatedRef.current = true;
             applyUserProfileRef.current(data.user, {
-                navigateTo: 'home',
+                navigateTo,
             });
         }).catch(() => undefined);
 


### PR DESCRIPTION
Closes #1315

## Problem
`supabase.auth.getUser()` in `useAuth.ts` resolved on every app mount, hot-reload, and component remount with a valid session, and unconditionally called `applyUserProfileRef.current(user, { navigateTo: 'home' })`. This silently redirected users away from deep-linked screens, refreshed pages, or screens they were on when the app was backgrounded and resumed.

## Fix
Add a `hasNavigatedRef = useRef(false)` guard. The `getUser()` callback only passes `navigateTo: 'home'` on the first resolution (the auth-unknown→authenticated transition). After that, `hasNavigatedRef.current` is `true` and subsequent resolutions omit `navigateTo`, leaving the user's current screen undisturbed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESzzV1TMMji5tpkH7ghq2T)_