### PR TITLE
fix: remove old localStorage history key after userId migration

### DIFF
--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -77,7 +77,10 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
     // Migrate history from the displayName fallback key when userId becomes available
     if (!stored.length && currentUserId && currentDisplayName !== currentUserId) {
       stored = loadChatHistory(currentDisplayName);
-      if (stored.length) saveChatHistory(currentUserId, stored);
+      if (stored.length) {
+        saveChatHistory(currentUserId, stored);
+        localStorage.removeItem(getHistoryKey(currentDisplayName));
+      }
     }
     if (stored.length) {
       setChatSessions(stored);


### PR DESCRIPTION
Closes #1323

When a user's `userId` becomes available after auth hydration, the component migrated chat history from the `displayName`-keyed localStorage entry to the `userId`-keyed entry but never removed the old key. This caused unbounded localStorage growth — up to `MAX_SESSIONS × MAX_MESSAGES_PER_SESSION` messages duplicated indefinitely. The fix adds a `localStorage.removeItem(getHistoryKey(currentDisplayName))` call immediately after a successful migration write, so the stale display-name key is evicted as soon as the data is safely stored under the userId key.

---
_Generated by [Claude Code](https://claude.ai/code/session_013EdJtTc15k31yKHDpczpSc)_