### PR TITLE
fix: add timeout guard to storage operations in delete-my-account

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -96,13 +96,24 @@ serve(async (req) => {
     );
   }
 
-  // 2. Delete profile image from storage (non-fatal)
-  const { data: files } = await adminClient.storage
-    .from('profile-images')
-    .list(userId);
-  if (files && files.length > 0) {
-    const paths = files.map((f: { name: string }) => `${userId}/${f.name}`);
-    await adminClient.storage.from('profile-images').remove(paths);
+  // 2. Delete profile image from storage (non-fatal, with timeout guard)
+  const storageTimeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error('storage timeout')), 10_000),
+  );
+  try {
+    const { data: files } = await Promise.race([
+      adminClient.storage.from('profile-images').list(userId),
+      storageTimeout,
+    ]);
+    if (files && files.length > 0) {
+      const paths = files.map((f: { name: string }) => `${userId}/${f.name}`);
+      await Promise.race([
+        adminClient.storage.from('profile-images').remove(paths),
+        storageTimeout,
+      ]);
+    }
+  } catch (storageError) {
+    console.error('delete-my-account: storage cleanup timed out or failed (non-fatal)', storageError);
   }
 
   // 3. Delete the auth user (must be last — only reached if all data was cleaned)


### PR DESCRIPTION
Closes #1324

The storage `list` and `remove` calls in `delete-my-account` had no timeout or abort mechanism. If the Supabase storage service hung, the edge function would run indefinitely, leaving the account in a partial-deletion state (all DB rows deleted, auth user still alive). The fix wraps both storage operations in a `Promise.race` against a 10-second timeout. If the deadline is exceeded, the error is caught and logged as non-fatal, and execution continues to delete the auth user. Since storage cleanup is already non-blocking (no abort before the data rows are touched), this approach prevents indefinite hangs without changing the deletion ordering guarantees.

---
_Generated by [Claude Code](https://claude.ai/code/session_013EdJtTc15k31yKHDpczpSc)_