### PR TITLE
fix: delete ticket_activations before events to prevent FK violation

### DIFF
--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -115,12 +115,19 @@ serve(async (req) => {
 
     const eventIds = eventsToDelete.map(e => e.id)
 
-    // Delete events first. The planned_participations FK is defined with
-    // ON DELETE CASCADE, so the DB automatically removes child rows when
-    // the parent event is deleted. This order is safer than deleting
-    // participations first: if the events delete fails nothing is lost,
-    // whereas the previous order could leave parent rows without their
-    // child participation records on a partial failure (fixes #1254).
+    // Delete ticket_activations first: this table references events.id via FK
+    // without ON DELETE CASCADE, so it must be removed before the parent rows
+    // are deleted to avoid a FK violation that would silently fail the whole batch.
+    const { error: activationsError } = await supabaseClient
+      .from('ticket_activations')
+      .delete()
+      .in('event_id', eventIds)
+
+    if (activationsError) throw activationsError
+
+    // Delete events. The planned_participations FK is defined with
+    // ON DELETE CASCADE, so the DB automatically removes those child rows when
+    // the parent event is deleted.
     const { error: deleteError } = await supabaseClient
       .from('events')
       .delete()


### PR DESCRIPTION
Closes #1325

`cleanup-events` was deleting events directly in a batch, relying on `ON DELETE CASCADE` for `planned_participations`. However, `ticket_activations.event_id` references `events.id` without `ON DELETE CASCADE`, meaning the batch DELETE would throw a FK violation whenever any event had associated ticket activation rows. The outer `try/catch` caught this as a generic 500, silently skipping the entire batch of up to 1000 events. The fix adds an explicit `DELETE FROM ticket_activations WHERE event_id IN (...)` step before the events deletion, handling the FK constraint correctly without requiring a schema migration.

---
_Generated by [Claude Code](https://claude.ai/code/session_013EdJtTc15k31yKHDpczpSc)_