### PR TITLE
fix: use getUser() before getSession() for analytics token seed

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -342,9 +342,17 @@ export function AppShell() {
 
     // Seed with the current session immediately (handles page reloads where the
     // user is already signed in before this effect runs).
-    supabase.auth.getSession().then(({ data }) => {
-      setAnalyticsAuthToken(data.session?.access_token ?? null);
-    }).catch(() => undefined);
+    // Use getUser() first to verify the token with the server before reading
+    // the locally cached session, so revoked or expired tokens are rejected.
+    supabase.auth.getUser()
+      .then(({ data: { user }, error }) => {
+        if (error || !user) return undefined;
+        return supabase!.auth.getSession();
+      })
+      .then((result) => {
+        setAnalyticsAuthToken(result?.data?.session?.access_token ?? null);
+      })
+      .catch(() => undefined);
 
     const { data: authListener } = supabase.auth.onAuthStateChange((_event, session) => {
       setAnalyticsAuthToken(session?.access_token ?? null);


### PR DESCRIPTION
Closes #1326

`AppShell` was seeding the analytics auth token by calling `supabase.auth.getSession()` directly, which only reads the locally cached session without contacting the server. A token revoked server-side (e.g., after forced sign-out from another device or a JWT secret rotation) would still be returned, causing all subsequent analytics events to lack `userHash` silently. The fix follows the same two-step pattern already established in `ticket-activation.ts`: first call `getUser()` (which verifies with the server), and only if that succeeds read the token from `getSession()`. This ensures stale or revoked tokens are rejected before being passed to the `pseudonymize-user-id` edge function.

---
_Generated by [Claude Code](https://claude.ai/code/session_013EdJtTc15k31yKHDpczpSc)_