### PR TITLE
KPI audience development + prima baseline (#321)

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -19,4 +19,6 @@ jobs:
       uses: pozil/auto-assign-issue@v1
       with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # 'numOfAssignee' rimosso: input non valido per l'action (veniva
+          # ignorato con un warning); con un solo assignee assegna Heartran.
           assignees: Heartran

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    # pozil/auto-assign-issue opera solo sul contesto di una issue: su un evento
+    # pull_request fallisce con "Couldn't find issue info in current context".
+    # Limitiamo il job alle issue; sui PR viene saltato (check verde).
+    if: github.event_name == 'issues'
     permissions:
       issues: write
       pull-requests: write
@@ -16,4 +20,3 @@ jobs:
       with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: Heartran
-          numOfAssignee: 1

--- a/TECHNICAL_NOTES.md
+++ b/TECHNICAL_NOTES.md
@@ -248,3 +248,87 @@ Obiettivo: introdurre un nuovo ruolo di gioco con esperienza dedicata senza fram
   - **Mitigazione:** playlist per ruolo con gating progressivo e test qualitativi rapidi.
 - **Rischio:** regressioni su utenti attuali.
   - **Mitigazione:** feature flags + fallback default + rollout progressivo.
+
+## Audience development — KPI & baseline (#321 / parent #164)
+
+Obiettivo: rendere l'audience development *misurabile*. Questa sezione definisce
+i KPI in modo univoco e fissa la **prima baseline** raccolta dallo stato reale
+del database. Script ripetibile: `tools/kpi-baseline.sql`.
+
+### Definizioni KPI (univoche)
+
+| KPI | Definizione operativa | Fonte |
+|---|---|---|
+| **Iscritti** | Righe in `auth.users`. | `auth.users` |
+| **Email confermate** | Iscritti con `email_confirmed_at` non nullo. | `auth.users` |
+| **Activation — ruolo** | % iscritti con `profiles.role_id` non nullo. | `profiles` |
+| **Activation — onboarding** | % iscritti con `profiles.onboarding_completed_at` non nullo. | `profiles` |
+| **Activation — prima attività** | % iscritti con ≥1 riga in `activity_completions`. | `activity_completions` |
+| **Activation — primo turno** | % iscritti con ≥1 riga in `turns`. | `turns` |
+| **Retention D1+ (proxy)** | % iscritti con `last_sign_in_at::date > created_at::date` (accesso in un giorno successivo all'iscrizione). | `auth.users` |
+| **Attivi 30g** | Iscritti con `profiles.last_activity_at` negli ultimi 30 giorni. | `profiles` |
+| **Engagement** | Media attività completate per utente; turni totali. | `activity_completions`, `turns` |
+| **Copertura eventi** | Ticket QR attivati; teatri con ≥1 turno; eventi a calendario. | `ticket_activations`, `turns`, `events` |
+| **Referral** | *Non misurabile dallo stato attuale*: richiede l'evento `share_clicked` persistito (vedi "Passo operativo" sotto). | — |
+
+> Nota: la **retention D1+** qui è un proxy basato sull'ultimo accesso, non una
+> coorte D1/D7 completa. La coorte richiede lo storico degli accessi, ottenibile
+> solo con l'event-stream (`session_start`) una volta persistito in produzione.
+
+### Baseline — 2026-06-22
+
+Estratta con `tools/kpi-baseline.sql` sul progetto di produzione.
+
+| KPI | Valore |
+|---|---|
+| Iscritti totali | 5 |
+| Email confermate | 4 |
+| Almeno un accesso | 4 |
+| Activation — ruolo scelto | 5 / 5 |
+| Activation — onboarding completato | **0 / 5** |
+| Activation — ≥1 attività | 3 / 5 |
+| Activation — ≥1 turno | 1 / 5 |
+| Retention D1+ (proxy) | 2 / 5 |
+| Attivi ultimi 30g | **0 / 5** |
+| Iscritti ultimi 30g | 0 |
+| Media attività / utente | 8.8 |
+| Turni certificati totali | 4 |
+| Ticket QR attivati (con utente reale) | 1 (0) |
+| Ruoli distinti in uso | 2 / 7 (`attore`, `fonico`) |
+| Teatri con ≥1 turno | 2 |
+| Eventi a calendario | 31 |
+
+### Lettura della baseline
+
+- **Acquisizione organica ≈ 0.** I 5 iscritti sono tutti interni (team/ATCL/servizio
+  civile) o di test; nessuna acquisizione organica esterna in ~6 mesi. La
+  promozione al Festival dei Giovani (Latina) non ha prodotto iscrizioni.
+- **Collo di bottiglia n.1 — onboarding: 0/5 completato.** Nessun utente — nemmeno
+  interno — ha terminato il primo avvio. È il primo punto da strumentare e
+  sistemare prima di qualsiasi spinta sull'acquisizione: portare traffico su un
+  funnel che perde tutti all'onboarding amplifica solo lo spreco.
+- **Retention 30g = 0.** Nessun ritorno recente: il loop non dà ancora un motivo
+  per tornare il giorno dopo.
+- **Contenuti sottoutilizzati:** 5 ruoli su 7 mai provati, 2 teatri su 25+ con un
+  turno. La quantità di contenuto costruito eccede di gran lunga l'uso reale.
+
+Implicazione per la v1.0: il valore della telemetria *non* è raccogliere più
+dati, ma **chiudere prima il funnel di onboarding** — l'unica metrica che, a
+questa baseline, può cambiare di segno con poco lavoro.
+
+### Passo operativo rimanente (fuori dal repo)
+
+I KPI di acquisizione/attivazione/retention sopra sono già misurabili (baseline
+fatta). Per i KPI a eventi (referral `share_clicked`, coorti D1/D7 reali,
+conversione step-by-step dell'onboarding) serve persistere l'event-stream:
+
+1. deploy della tabella `analytics_events` + Edge Function `ingest-analytics`
+   (infrastruttura già progettata; client `apps/mobile/src/services/analytics.ts`
+   pronto, sink di default su `console.debug` finché non si registra quello di
+   produzione con `setAnalyticsSink`);
+2. secret `ANALYTICS_SALT` su Supabase (pseudonimizzazione, già usata da
+   `pseudonymize-user-id`);
+3. ~2–4 settimane di raccolta per la prima coorte D1/D7 reale.
+
+Finché (1)–(3) non sono completati, la baseline valida resta quella derivata
+dallo stato del DB e rigenerabile con `tools/kpi-baseline.sql`.

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -3874,17 +3874,17 @@
       "license": "ISC"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4049,9 +4049,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5719,9 +5719,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/apps/mobile/src/test/analytics.test.ts
+++ b/apps/mobile/src/test/analytics.test.ts
@@ -67,6 +67,8 @@ describe('getUserHash — Edge Function fetch', () => {
 
     // Provide VITE_SUPABASE_URL via import.meta.env simulation
     setAnalyticsSupabaseUrl('https://test.supabase.co');
+    // Un JWT è necessario: senza, il client salta del tutto la richiesta (#1284).
+    setAnalyticsAuthToken('test-token');
 
     const result = await getUserHash('user-uuid-1');
     expect(result).toBe('abc123');
@@ -89,18 +91,21 @@ describe('getUserHash — Edge Function fetch', () => {
     expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer my-jwt-token');
   });
 
-  it('omits Authorization header when no auth token is set', async () => {
-    const mockFetch = vi.fn().mockResolvedValueOnce(makeSuccessResponse('cafebabe'));
+  it('skips the request and returns undefined when no auth token is set', async () => {
+    // Issue #1284: senza JWT la Edge Function risponderebbe 401, quindi il
+    // client salta del tutto la richiesta e degrada a userHash undefined.
+    const mockFetch = vi.fn();
     vi.stubGlobal('fetch', mockFetch);
     setAnalyticsSupabaseUrl('https://test.supabase.co');
 
-    await getUserHash('user-uuid-3');
+    const result = await getUserHash('user-uuid-3');
 
-    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect((init.headers as Record<string, string>)['Authorization']).toBeUndefined();
+    expect(result).toBeUndefined();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('returns undefined when fetch throws (network error)', async () => {
+    setAnalyticsAuthToken('test-token');
     vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('Network error')));
     setAnalyticsSupabaseUrl('https://test.supabase.co');
 
@@ -109,6 +114,7 @@ describe('getUserHash — Edge Function fetch', () => {
   });
 
   it('returns undefined when the Edge Function returns a non-200 status', async () => {
+    setAnalyticsAuthToken('test-token');
     vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(makeErrorResponse(401)));
     setAnalyticsSupabaseUrl('https://test.supabase.co');
 
@@ -117,6 +123,7 @@ describe('getUserHash — Edge Function fetch', () => {
   });
 
   it('returns undefined when the response body has no hash field', async () => {
+    setAnalyticsAuthToken('test-token');
     vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(
       new Response(JSON.stringify({ error: 'missing salt' }), { status: 200 }),
     ));
@@ -136,6 +143,7 @@ describe('getUserHash — caching', () => {
     const mockFetch = vi.fn().mockResolvedValue(makeSuccessResponse('cached-hash'));
     vi.stubGlobal('fetch', mockFetch);
     setAnalyticsSupabaseUrl('https://test.supabase.co');
+    setAnalyticsAuthToken('test-token');
 
     const [r1, r2] = await Promise.all([
       getUserHash('user-uuid-cache'),
@@ -155,6 +163,7 @@ describe('getUserHash — caching', () => {
       .mockResolvedValueOnce(makeSuccessResponse('second-hash'));
     vi.stubGlobal('fetch', mockFetch);
     setAnalyticsSupabaseUrl('https://test.supabase.co');
+    setAnalyticsAuthToken('test-token');
 
     const first = await getUserHash('user-uuid-clear');
     expect(first).toBe('first-hash');
@@ -194,17 +203,17 @@ describe('setAnalyticsAuthToken', () => {
     expect(call2Headers['Authorization']).toBe('Bearer token-v2');
   });
 
-  it('removes the Authorization header when set to null', async () => {
+  it('skips the request and returns undefined when the token is set to null', async () => {
     setAnalyticsAuthToken('token-before');
 
-    const mockFetch = vi.fn().mockResolvedValue(makeSuccessResponse('any-hash'));
+    const mockFetch = vi.fn();
     vi.stubGlobal('fetch', mockFetch);
     setAnalyticsSupabaseUrl('https://test.supabase.co');
 
     setAnalyticsAuthToken(null);
-    await getUserHash('user-b');
+    const result = await getUserHash('user-b');
 
-    const callHeaders = mockFetch.mock.calls[0][1].headers as Record<string, string>;
-    expect(callHeaders['Authorization']).toBeUndefined();
+    expect(result).toBeUndefined();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6049,15 +6049,17 @@
       "license": "ISC"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -6259,7 +6261,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8713,9 +8717,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8899,9 +8903,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/tools/kpi-baseline.sql
+++ b/tools/kpi-baseline.sql
@@ -1,0 +1,65 @@
+-- KPI baseline — Audience development (#321 / parent #164)
+--
+-- Report ripetibile: rigenera i KPI di audience development di Turni di Palco
+-- leggendo lo stato reale del database (nessuno stream di eventi richiesto).
+-- I KPI di acquisizione, attivazione, retention ed engagement sono derivabili
+-- direttamente dalle tabelle esistenti, quindi la baseline e' raccoglibile in
+-- qualsiasi momento, senza attendere una finestra di telemetria.
+--
+-- Uso (read-only):
+--   psql "$SUPABASE_DB_URL" -f tools/kpi-baseline.sql
+-- oppure via Supabase SQL editor / MCP execute_sql.
+--
+-- Le definizioni univoche dei KPI sono in TECHNICAL_NOTES.md
+-- ("Audience development — KPI & baseline").
+
+-- 1) Funnel di acquisizione -> attivazione + retention -------------------------
+with u as (
+  select
+    au.id,
+    au.created_at,
+    au.email_confirmed_at,
+    au.last_sign_in_at,
+    p.role_id,
+    p.onboarding_completed_at,
+    p.last_activity_at,
+    (select count(*) from public.activity_completions ac where ac.user_id = au.id) as activities,
+    (select count(*) from public.turns t where t.user_id = au.id) as turns
+  from auth.users au
+  left join public.profiles p on p.id = au.id
+)
+select
+  'funnel'                                                                          as report,
+  count(*)                                                                          as iscritti_totali,
+  count(*) filter (where email_confirmed_at is not null)                            as email_confermate,
+  count(*) filter (where last_sign_in_at is not null)                              as almeno_un_accesso,
+  count(*) filter (where role_id is not null)                                       as ruolo_scelto,
+  count(*) filter (where onboarding_completed_at is not null)                       as onboarding_completato,
+  count(*) filter (where activities > 0)                                            as almeno_una_attivita,
+  count(*) filter (where turns > 0)                                                 as almeno_un_turno,
+  count(*) filter (where last_sign_in_at is not null
+                     and last_sign_in_at::date > created_at::date)                  as ritornati_giorno_diverso, -- proxy retention D1+
+  count(*) filter (where last_activity_at > now() - interval '30 days')             as attivi_ultimi_30g,
+  count(*) filter (where created_at > now() - interval '30 days')                   as iscritti_ultimi_30g,
+  round(avg(activities), 1)                                                         as media_attivita_per_utente,
+  sum(turns)                                                                        as turni_totali,
+  sum(activities)                                                                   as attivita_totali
+from u;
+
+-- 2) Engagement eventi reali + copertura contenuti -----------------------------
+select
+  'engagement'                                                                      as report,
+  (select count(*) from public.ticket_activations)                                  as ticket_attivati_totali,
+  (select count(distinct activated_by)
+     from public.ticket_activations where activated_by is not null)                 as utenti_con_ticket,
+  (select count(*) from public.events)                                              as eventi_calendario,
+  (select count(distinct role_id) from public.profiles where role_id is not null)   as ruoli_distinti_in_uso,
+  (select count(distinct theatre) from public.turns)                                as teatri_con_almeno_un_turno;
+
+-- 3) Acquisizione per mese -----------------------------------------------------
+select
+  to_char(date_trunc('month', created_at), 'YYYY-MM') as mese,
+  count(*)                                            as iscritti
+from auth.users
+group by 1
+order by 1;

--- a/tools/kpi-baseline.sql
+++ b/tools/kpi-baseline.sql
@@ -57,6 +57,8 @@ select
   (select count(distinct theatre) from public.turns)                                as teatri_con_almeno_un_turno;
 
 -- 3) Acquisizione per mese -----------------------------------------------------
+-- NB: legge direttamente da auth.users -> richiede ruolo postgres/service_role
+-- (bypassa RLS per design, come le query 1-2).
 select
   to_char(date_trunc('month', created_at), 'YYYY-MM') as mese,
   count(*)                                            as iscritti

--- a/tools/kpi-baseline.sql
+++ b/tools/kpi-baseline.sql
@@ -10,6 +10,10 @@
 --   psql "$SUPABASE_DB_URL" -f tools/kpi-baseline.sql
 -- oppure via Supabase SQL editor / MCP execute_sql.
 --
+-- Permessi: tutti e tre i blocchi leggono direttamente da auth.users ->
+-- richiedono ruolo postgres/service_role (bypassano RLS per design). Eseguiti
+-- con un ruolo privo di accesso, restituiscono vuoto o un errore di permessi.
+--
 -- Le definizioni univoche dei KPI sono in TECHNICAL_NOTES.md
 -- ("Audience development — KPI & baseline").
 
@@ -37,8 +41,7 @@ select
   count(*) filter (where onboarding_completed_at is not null)                       as onboarding_completato,
   count(*) filter (where activities > 0)                                            as almeno_una_attivita,
   count(*) filter (where turns > 0)                                                 as almeno_un_turno,
-  count(*) filter (where last_sign_in_at is not null
-                     and last_sign_in_at::date > created_at::date)                  as ritornati_giorno_diverso, -- proxy retention D1+
+  count(*) filter (where last_sign_in_at::date > created_at::date)                  as ritornati_giorno_diverso, -- proxy retention D1+ (NULL last_sign_in_at -> escluso dal FILTER)
   count(*) filter (where last_activity_at > now() - interval '30 days')             as attivi_ultimi_30g,
   count(*) filter (where created_at > now() - interval '30 days')                   as iscritti_ultimi_30g,
   round(avg(activities), 1)                                                         as media_attivita_per_utente,
@@ -57,8 +60,6 @@ select
   (select count(distinct theatre) from public.turns)                                as teatri_con_almeno_un_turno;
 
 -- 3) Acquisizione per mese -----------------------------------------------------
--- NB: legge direttamente da auth.users -> richiede ruolo postgres/service_role
--- (bypassa RLS per design, come le query 1-2).
 select
   to_char(date_trunc('month', created_at), 'YYYY-MM') as mese,
   count(*)                                            as iscritti


### PR DESCRIPTION
## Intento

Rendere l'audience development **misurabile** e fissare la **prima baseline** — chiudendo la parte della #321 che non richiede deploy o finestre di raccolta.

Intuizione chiave: i KPI di **acquisizione, attivazione, retention ed engagement** sono già derivabili dallo stato del database. Non serve attendere 2–4 settimane di event-stream per avere una baseline reale: basta leggere `auth.users`, `profiles`, `turns`, `activity_completions`, `ticket_activations`.

## Modifiche

- **`tools/kpi-baseline.sql`** — report read-only ripetibile (funnel + engagement + acquisizione per mese).
- **`TECHNICAL_NOTES.md` → "Audience development — KPI & baseline"** — definizioni KPI univoche, baseline datata 2026-06-22, lettura dei dati e passo operativo rimanente.

## Baseline 2026-06-22 (estratto)

| KPI | Valore |
|---|---|
| Iscritti totali | 5 (tutti interni/test, 0 organici) |
| **Onboarding completato** | **0 / 5** |
| ≥1 attività | 3 / 5 |
| ≥1 turno | 1 / 5 |
| Attivi ultimi 30g | 0 / 5 |
| Ruoli usati | 2 / 7 |

**Finding principale:** il collo di bottiglia n.1 non è l'acquisizione ma **l'onboarding — 0/5 lo completa**. Strumentare e sistemare quel funnel viene prima di qualsiasi spinta sul traffico.

## Acceptance criteria #321

- [x] KPI documentati con definizione univoca
- [x] Prima baseline raccolta e condivisa (da stato DB, rigenerabile)
- [ ] Eventi tracking in produzione — richiede deploy `analytics_events` + `ingest-analytics` + secret `ANALYTICS_SALT` (passo operativo documentato, fuori dal repo)

La issue resta da chiudere a mano dopo il punto operativo, oppure si può chiudere ora la parte misurabile e scorporare il tracking a eventi in una issue dedicata — a tua scelta.

## Testing

Query validate su progetto di produzione via Supabase (read-only); numeri della baseline riprodotti da `tools/kpi-baseline.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DV6xmQFnRAV9ZJe9E58TN9)_