### PR TITLE
fix: truncate reflected action field in error response

### DIFF
--- a/supabase/functions/event-links/index.ts
+++ b/supabase/functions/event-links/index.ts
@@ -227,5 +227,5 @@ serve(async (req) => {
     return json({ resolved: true, eventId, roleId, event: data });
   }
 
-  return json({ error: `Azione non supportata: ${action}` }, 400);
+  return json({ error: `Azione non supportata: ${action.slice(0, 100)}` }, 400);
 });


### PR DESCRIPTION
Closes #1333

The `action` field from user-supplied JSON was reflected verbatim in the error response at line 230 of `supabase/functions/event-links/index.ts` with no length limit. This mirrors the fix already applied to `mobile-logs`: truncate the value with `.slice(0, 100)` before embedding it in the response body.

---
_Generated by [Claude Code](https://claude.ai/code/session_012sUkB79zfhKzj8B4qS262r)_