### PR TITLE
fix: wrap localStorage.removeItem in try/catch for private browsing

### DIFF
--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -79,7 +79,7 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
       stored = loadChatHistory(currentDisplayName);
       if (stored.length) {
         saveChatHistory(currentUserId, stored);
-        localStorage.removeItem(getHistoryKey(currentDisplayName));
+        try { localStorage.removeItem(getHistoryKey(currentDisplayName)); } catch { /* SecurityError in private browsing */ }
       }
     }
     if (stored.length) {


### PR DESCRIPTION
Closes #1334

In `apps/mobile/src/components/screens/SupportChat.tsx`, the history migration path calls `localStorage.removeItem()` outside any try/catch. In private browsing mode (Safari, Firefox) this throws a `SecurityError` that would crash the effect. The call is now wrapped in a try/catch that silently ignores the error, matching the defensive pattern used by `saveChatHistory` in the same file.

---
_Generated by [Claude Code](https://claude.ai/code/session_012sUkB79zfhKzj8B4qS262r)_