### PR TITLE
fix: allow manual ticket activation when event not in local cache

### DIFF
--- a/apps/mobile/src/handlers/useQrHandlers.ts
+++ b/apps/mobile/src/handlers/useQrHandlers.ts
@@ -108,10 +108,10 @@ export function useQrHandlers(deps: QrHandlerDeps) {
         return { ok: false as const, error: 'Biglietto già registrato in questa sessione.' };
       }
 
+      // Do not reject if the event is absent from the local cache: the server-side
+      // activation call in handleEventConfirm will perform its own lookup and return
+      // a proper error if the event truly does not exist (closes #1342).
       const matchedEvent = events.find(event => event.id === normalizedEventId);
-      if (!matchedEvent) {
-        return { ok: false as const, error: 'Evento non presente nel calendario.' };
-      }
 
       setPendingTicketActivation({ mode: 'manual', eventId: normalizedEventId, ticketNumber: normalizedTicketNumber });
       setConfirmationEventOverride(mapActivatedEvent(normalizedEventId, events) ?? null);


### PR DESCRIPTION
Closes #1342

Previously, manual ticket activation (QR codes with `manual-ticket:` prefix) would immediately return "Evento non presente nel calendario" if the event ID was not found in the local client-side cache. This blocked valid activations for events not currently loaded in the catalog.

The fix removes the early client-only rejection. The flow now proceeds to navigate to the confirmation screen and lets `activateTicketByDetails` (called in `handleEventConfirm`) perform the server-side lookup. If the event truly doesn't exist, the server will return an appropriate error at that stage instead of a premature client-side rejection.

---
_Generated by [Claude Code](https://claude.ai/code/session_012sUkB79zfhKzj8B4qS262r)_