### PR TITLE
fix: correct missing accent in Italian error strings

### DIFF
--- a/apps/mobile/src/handlers/useQrHandlers.ts
+++ b/apps/mobile/src/handlers/useQrHandlers.ts
@@ -183,7 +183,7 @@ export function useQrHandlers(deps: QrHandlerDeps) {
         boostRequested,
       });
       if (!turnResult.ok) {
-        return { ok: false, error: turnResult.error || 'Ticket attivato, ma non e stato possibile registrare il turno.' };
+        return { ok: false, error: turnResult.error || 'Ticket attivato, ma non è stato possibile registrare il turno.' };
       }
 
       setPendingTicketActivation(null);
@@ -209,7 +209,7 @@ export function useQrHandlers(deps: QrHandlerDeps) {
         boostRequested,
       });
       if (!turnResult.ok) {
-        return { ok: false, error: turnResult.error || 'Ticket attivato, ma non e stato possibile registrare il turno.' };
+        return { ok: false, error: turnResult.error || 'Ticket attivato, ma non è stato possibile registrare il turno.' };
       }
 
       setPendingTicketActivation(null);


### PR DESCRIPTION
Closes #1343

Corrects two occurrences of `'non e stato possibile'` → `'non è stato possibile'` in `apps/mobile/src/handlers/useQrHandlers.ts`.

Both error strings appear in `handleEventConfirm`: one in the `hash` mode fallback and one in the `manual` mode fallback, triggered when `registerTurn` fails after successful ticket activation.

---
_Generated by [Claude Code](https://claude.ai/code/session_012sUkB79zfhKzj8B4qS262r)_