### PR TITLE
fix: reset showBadge when new badges arrive after dismiss (closes #1349)

### DIFF
--- a/apps/mobile/src/components/screens/Home.tsx
+++ b/apps/mobile/src/components/screens/Home.tsx
@@ -229,6 +229,9 @@ function HomeHeader({
 
   React.useEffect(() => {
     if (!hasNewBadges) { setAnimateBadges(false); return; }
+    // Reset showBadge so a newly-arrived badge is always surfaced to the user,
+    // even if they had previously dismissed an earlier badge notification.
+    setShowBadge(true);
     setAnimateBadges(false);
     const raf = requestAnimationFrame(() => setAnimateBadges(true));
     const timer = setTimeout(() => setAnimateBadges(false), 600);


### PR DESCRIPTION
Closes #1349

## Change
In the `HomeHeader` badge effect, add `setShowBadge(true)` when `hasNewBadges` is true, so subsequent badge awards re-surface the notification popover after a user dismisses an earlier one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECePHDuHHTRiLTL7MVPG3K)_