### PR TITLE
fix: use independent storage timeouts for list and remove operations (closes #1351)

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -97,19 +97,22 @@ serve(async (req) => {
   }
 
   // 2. Delete profile image from storage (non-fatal, with timeout guard)
-  const storageTimeout = new Promise<never>((_, reject) =>
-    setTimeout(() => reject(new Error('storage timeout')), 10_000),
-  );
+  // Each operation gets its own independent timeout promise so that a slow
+  // list() call does not shrink the effective timeout for remove() (closes #1351).
+  const makeStorageTimeout = () =>
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('storage timeout')), 10_000),
+    );
   try {
     const { data: files } = await Promise.race([
       adminClient.storage.from('profile-images').list(userId),
-      storageTimeout,
+      makeStorageTimeout(),
     ]);
     if (files && files.length > 0) {
       const paths = files.map((f: { name: string }) => `${userId}/${f.name}`);
       await Promise.race([
         adminClient.storage.from('profile-images').remove(paths),
-        storageTimeout,
+        makeStorageTimeout(),
       ]);
     }
   } catch (storageError) {


### PR DESCRIPTION
Closes #1351

## Change
Replace the single shared `storageTimeout` promise with a `makeStorageTimeout()` factory so each `Promise.race()` call gets its own independent 10-second timer. This prevents a slow `list()` call from consuming the remove() timeout, ensuring GDPR Art. 17 profile image erasure can always run for the full allotted time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECePHDuHHTRiLTL7MVPG3K)_