### PR TITLE
fix: treat empty ?limit= query param as absent, defaulting to 50 (closes #1352)

### DIFF
--- a/supabase/functions/public-leaderboard/index.ts
+++ b/supabase/functions/public-leaderboard/index.ts
@@ -56,7 +56,9 @@ serve(async (req) => {
   }
 
   const url = new URL(req.url);
-  const rawLimit = url.searchParams.get('limit');
+  // Treat an empty string the same as absent: `?limit=` should use the default,
+  // not clamp Number('') === 0 to 1 (closes #1352).
+  const rawLimit = url.searchParams.get('limit') || null;
   const parsed = Number(rawLimit ?? DEFAULT_LIMIT);
   const limit = Number.isFinite(parsed)
     ? Math.min(Math.max(Math.trunc(parsed), 1), MAX_LIMIT)


### PR DESCRIPTION
Closes #1352

## Change
Use `|| null` on `searchParams.get('limit')` so an empty string `?limit=` is coerced to `null` before the `?? DEFAULT_LIMIT` fallback, preventing `Number('')` === 0 from being clamped to a limit of 1.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECePHDuHHTRiLTL7MVPG3K)_