### PR TITLE
fix: add second isMounted guard after async calls in restoreSession (closes #1354)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3123,6 +3123,11 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             }
           }
 
+          // Guard again after the async getUser/signOut calls — the component
+          // may have unmounted (e.g. StrictMode double-mount) while they were in
+          // flight (closes #1354).
+          if (!isMounted) return;
+
           persistStoredSession(stableSession);
           setAuthUserId(stableSession?.user.id ?? null);
           setAuthReady(true);


### PR DESCRIPTION
Closes #1354

## Change
Add a second `if (!isMounted) return;` check immediately before the state-setter calls in `restoreSession`, after the async `getUser()` and `signOut()` operations. This prevents setState from firing on an unmounted component in React StrictMode double-mount scenarios or during rapid navigation at app startup.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECePHDuHHTRiLTL7MVPG3K)_