### PR TITLE
fix: classify server-error RPC responses correctly in purchaseShopItem (closes #1355)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4717,6 +4717,16 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         );
 
         if (!rpcResponse.purchase_applied) {
+          // Distinguish server-side errors (transient, retryable) from business-rule
+          // rejections (role mismatch, insufficient balance, etc.) so the UI can
+          // present the correct message and allow retry when appropriate (closes #1355).
+          if (rpcResponse.status === 'error') {
+            return {
+              ok: false,
+              status: 'error',
+              error: rpcResponse.rejection_reason ?? 'Errore server durante l\'acquisto.',
+            };
+          }
           return {
             ok: false,
             status: 'rejected',


### PR DESCRIPTION
Closes #1355

## Change
Check `rpcResponse.status === 'error'` before returning `'rejected'` — server errors (transient DB failures, timeouts, rate limits) now return `{ ok: false, status: 'error' }` so the UI can present a retryable-error message rather than incorrectly telling the user their purchase was refused by business logic.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECePHDuHHTRiLTL7MVPG3K)_