### PR TITLE
fix: replace ilike with eq to prevent LIKE wildcard injection in circuit filter (closes #1357)

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -264,7 +264,10 @@ serve(async (req: Request) => {
           if (typeof payload.circuit !== 'string') {
             return jsonResponse({ error: 'Parametro circuit non valido.' }, 400);
           }
-          query = query.ilike('circuit', payload.circuit.trim());
+          // Use case-insensitive exact match (.eq on lowercased value) instead of
+          // .ilike() to prevent SQL LIKE wildcard injection via the circuit field
+          // (closes #1357). ilike() treats % and _ as pattern metacharacters.
+          query = query.eq('circuit', payload.circuit.trim().toLowerCase());
         }
         if (payload.eventID !== undefined && payload.eventID !== null && payload.eventID !== '') {
           if (typeof payload.eventID !== 'string') {


### PR DESCRIPTION
Closes #1357

## Change
Replace `.ilike('circuit', payload.circuit.trim())` with `.eq('circuit', payload.circuit.trim().toLowerCase())` in the `activate_by_ticket_number` action. This eliminates SQL LIKE wildcard injection via the `circuit` field — `%` and `_` are no longer interpreted as pattern metacharacters, enforcing the semantically intended exact (case-insensitive) circuit match.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECePHDuHHTRiLTL7MVPG3K)_