### PR TITLE
fix(store): check isNavigatorOffline() per-iteration to prevent spurious retry increments mid-flush (#1379)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -2897,6 +2897,19 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
     try {
       for (const queuedMutation of [...queue]) {
+        // Re-check connectivity at the start of each iteration so that a
+        // mid-flush connectivity drop does not increment the attempts counter
+        // for all remaining mutations — spurious attempt increments can push
+        // near-max-retry entries over the discard threshold, permanently
+        // losing valid queued mutations on a transient network blip (closes #1379).
+        if (isNavigatorOffline()) {
+          logOfflineSync('Flush aborted mid-loop: browser went offline', {
+            authUserId,
+            remainingForUser: queue.filter((entry) => entry.userId === authUserId).length,
+          }, 'warn');
+          break;
+        }
+
         if (queuedMutation.userId !== authUserId) continue;
         if (!queue.some((entry) => entry.id === queuedMutation.id)) continue;
         logOfflineSync('Processing queued mutation', summarizeQueuedMutation(queuedMutation));


### PR DESCRIPTION
## Summary

Fixes #1379.

`flushQueuedSupabaseMutations` checked `isNavigatorOffline()` once before the loop but not per-iteration. If the device went offline mid-flush, every remaining mutation in the queue made a network call, failed, and had its `attempts` counter incremented. Mutations already near `OFFLINE_SYNC_MAX_ATTEMPTS` could reach the discard threshold from a single interrupted flush session, permanently losing locally-recorded player progress on a transient connectivity blip — the primary mobile use scenario.

**Fix:** Add an `isNavigatorOffline()` check at the top of each loop iteration. If the browser has gone offline, the loop breaks early with a warning log, leaving all remaining mutations' attempt counters untouched.

## Changes

- `apps/mobile/src/state/store.tsx`: add per-iteration `isNavigatorOffline()` guard with `break` inside `flushQueuedSupabaseMutations`

---
_Generated by [Claude Code](https://claude.ai/code/session_0183wvwXkscPhW2cbYTkEK3F)_