### PR TITLE
fix(AppShell): use refreshSession() after getUser() for analytics token — avoid stale cached token (#1380)

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -342,14 +342,21 @@ export function AppShell() {
 
     // Seed with the current session immediately (handles page reloads where the
     // user is already signed in before this effect runs).
-    // Use getUser() first to verify the token with the server before reading
-    // the locally cached session, so revoked or expired tokens are rejected.
+    //
+    // We call getUser() — which validates the token server-side — and then
+    // refreshSession() to obtain a guaranteed-fresh access token. Using a
+    // separate getSession() call after getUser() was unsafe: getSession()
+    // returns the locally-cached value from localStorage, which could be stale
+    // or already revoked even if getUser() just succeeded (closes #1380, same
+    // anti-pattern fixed in useAuth.ts via #1326).
     supabase.auth.getUser()
       .then(({ data: { user }, error }) => {
-        if (error || !user) return undefined;
-        return supabase!.auth.getSession();
+        if (error || !user) return null;
+        return supabase!.auth.refreshSession();
       })
       .then((result) => {
+        // refreshSession() returns null when called with no active session;
+        // the access_token from the refreshed session is always server-issued.
         setAnalyticsAuthToken(result?.data?.session?.access_token ?? null);
       })
       .catch(() => undefined);


### PR DESCRIPTION
## Summary

Fixes #1380.

The analytics auth token seeding effect called `getUser()` to verify the session server-side, then `getSession()` to read the access token. The problem: `getSession()` returns the **locally-cached** value from localStorage and never validates with the server. In a narrow timing window a revoked token could pass `getUser()` while `getSession()` still returned the stale cached value. Analytics events would carry a revoked JWT, causing 401 responses from `pseudonymize-user-id` and dropping `userHash` on affected events.

This is the same anti-pattern fixed in `useAuth.ts` via #1326.

**Fix:** Replace `getSession()` with `refreshSession()` — which always obtains a server-issued token — so the analytics module always receives a fresh, validated access token.

## Changes

- `apps/mobile/src/components/AppShell.tsx`: replace `supabase.auth.getSession()` with `supabase.auth.refreshSession()` in the analytics token seeding effect

---
_Generated by [Claude Code](https://claude.ai/code/session_0183wvwXkscPhW2cbYTkEK3F)_