### PR TITLE
fix(mobile-logs): replace invalid JSON truncation with structured wrapper in sanitizeLogDetails (#1381)

### DIFF
--- a/supabase/functions/mobile-logs/index.ts
+++ b/supabase/functions/mobile-logs/index.ts
@@ -57,9 +57,12 @@ function sanitizeLogDetails(value: unknown): unknown {
   }
   try {
     const serialized = JSON.stringify(value);
-    // Cap serialized object size before re-parsing to avoid large object graphs.
+    // Slicing JSON at an arbitrary byte offset produces malformed JSON that
+    // JSON.parse() always rejects — the catch block then returns "[object Object]",
+    // silently discarding all structure (closes #1381). Return a structured
+    // wrapper object instead so the details field remains inspectable.
     if (serialized.length > MAX_DETAILS_JSON_LENGTH) {
-      return JSON.parse(serialized.slice(0, MAX_DETAILS_JSON_LENGTH) + '"[truncated]"}');
+      return { _truncated: true, _originalBytes: serialized.length, preview: serialized.slice(0, MAX_DETAILS_JSON_LENGTH) };
     }
     return JSON.parse(serialized);
   } catch {


### PR DESCRIPTION
## Summary

Fixes #1381.

`sanitizeLogDetails` tried to truncate large object payloads by slicing their JSON serialization at `MAX_DETAILS_JSON_LENGTH` bytes and appending `'"[truncated]"}'`. Slicing JSON at an arbitrary byte offset produces malformed JSON — mid-key, mid-value, or unclosed brackets. `JSON.parse()` would throw, the `catch` block ran `String(value)` → `"[object Object]"`, and log entries with large `details` objects silently lost all structure. The issue was invisible at the API level (HTTP 200 returned).

**Fix:** Replace the slice-and-append approach with a programmatically constructed wrapper object `{ _truncated: true, _originalBytes: N, preview: "..." }`. This is always valid JSON, always preserved as a structured object in the log entry, and gives operators enough context (original size + a readable prefix) to diagnose the event.

## Changes

- `supabase/functions/mobile-logs/index.ts`: replace `JSON.parse(serialized.slice(...) + suffix)` with `{ _truncated: true, _originalBytes: serialized.length, preview: serialized.slice(0, MAX_DETAILS_JSON_LENGTH) }`

---
_Generated by [Claude Code](https://claude.ai/code/session_0183wvwXkscPhW2cbYTkEK3F)_