### PR TITLE
fix(ticket-activation): normalize circuit to lowercase on insert so activate_by_ticket_number lookup always matches (#1384)

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -127,7 +127,12 @@ serve(async (req: Request) => {
         date?: unknown;
       };
 
-      const circuit = String(normalizedPayload.circuit ?? '').trim();
+      // Lowercase circuit on write so it matches the lowercase comparison used by
+      // activate_by_ticket_number (.eq('circuit', payload.circuit.toLowerCase())).
+      // Storing the original case caused case-sensitive PostgreSQL `=` queries to
+      // return zero rows whenever the circuit name contained uppercase characters
+      // (closes #1384).
+      const circuit = String(normalizedPayload.circuit ?? '').trim().toLowerCase();
       const eventName = String(normalizedPayload.eventName ?? '').trim();
       const eventId = String(normalizedPayload.eventID ?? '').trim();
       const ticketNumber = String(normalizedPayload.ticketNumber ?? '').trim();


### PR DESCRIPTION
## Summary

Fixes #1384.

`activate_by_ticket_number` lowercases `payload.circuit` before the `.eq()` query (added in #1357 to prevent SQL wildcard injection). However, `reserve_hash` stored the `circuit` value with its original case. PostgreSQL's `=` operator is case-sensitive on `text` columns, so any circuit name with uppercase characters (e.g. `"ATCL Lazio"`) stored by `reserve_hash` was never matched by `activate_by_ticket_number`'s lowercase query — returning `{ ok: false, error: 'Ticket non trovato.' }` even when the ticket existed.

**Fix:** Add `.toLowerCase()` to the `circuit` extraction in `reserve_hash` so all stored values use the same normalisation as the read path.

## Changes

- `supabase/functions/ticket-activation/index.ts`: `reserve_hash` — apply `.toLowerCase()` to `circuit` before inserting into `ticket_activations`

---
_Generated by [Claude Code](https://claude.ai/code/session_0183wvwXkscPhW2cbYTkEK3F)_