### PR TITLE
chore(security): pre-commit hook gitleaks (blocco segreti in locale)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+# Pre-commit secret scan (gitleaks).
+# Anticipa in locale il controllo che gira in CI (.github/workflows/security.yml):
+# scansiona SOLO le modifiche staged e blocca il commit se trova un segreto.
+# Il gate obbligatorio resta la CI; questo hook evita che un segreto entri
+# nella history già dal commit locale (le fughe passate venivano da automazioni).
+
+set -e
+
+run_gitleaks() {
+  if command -v gitleaks >/dev/null 2>&1; then
+    gitleaks git --staged --redact --no-banner --config=.gitleaks.toml
+    return $?
+  fi
+  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    docker run --rm -v "$(pwd):/repo" ghcr.io/gitleaks/gitleaks:v8.21.2 \
+      git --staged --redact --no-banner --source=/repo --config=/repo/.gitleaks.toml
+    return $?
+  fi
+  return 127
+}
+
+set +e
+run_gitleaks
+status=$?
+set -e
+
+if [ "$status" -eq 127 ]; then
+  echo "⚠️  gitleaks non trovato: secret-scan locale saltato."
+  echo "    Installa gitleaks (https://github.com/gitleaks/gitleaks#installing) per il controllo pre-commit."
+  echo "    Il controllo obbligatorio resta comunque attivo in CI."
+  exit 0
+fi
+
+if [ "$status" -ne 0 ]; then
+  echo ""
+  echo "🛑 Commit bloccato: gitleaks ha rilevato un possibile segreto nei file staged."
+  echo "   • Rimuovi il valore e usa una variabile d'ambiente / un file gitignored."
+  echo "   • Falso positivo? Aggiorna l'allowlist in .gitleaks.toml."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Intento

Difesa-in-profondità sui segreti: dopo il secret-scan in CI (già in `main`), aggiungere un **hook pre-commit gitleaks** che blocca i segreti **in locale**, prima ancora che entrino nella history. Le due fughe recenti (token Render, config Codex con PAT personali) erano partite da automazioni il cui working tree è finito in un commit poi squash-mergiato fuori dalla diff di review; questo hook le ferma sul nascere.

## Modifiche

- **`.husky/pre-commit`**: scansiona solo le modifiche *staged* con `gitleaks git --staged` usando `.gitleaks.toml`. Se rileva un segreto, **blocca il commit** con un messaggio d'aiuto. Se `gitleaks` non è installato, avvisa e prosegue (il gate obbligatorio resta la CI). Fallback su Docker se il binario non è su PATH.

Husky (v9) è già dipendenza con lo script `prepare: husky`, quindi l'hook si attiva automaticamente dopo `npm install`. La cartella interna `.husky/_/` è auto-gitignorata.

## Verifiche effettuate

- `gitleaks git --staged` validato su repo usa-e-getta: staged pulito → exit 0; token `rnd_…` staged → exit 1.
- Test **end-to-end reale**: `git commit` con un file contenente un token finto → **bloccato dall'hook** (commit non eseguito); staged pulito → hook passa.
- Attivazione husky verificata (`core.hooksPath=.husky/_`, `.husky/_/` gitignorata, si versiona solo `.husky/pre-commit`).

## Note

Perché l'hook *blocchi* (e non solo avvisi) serve `gitleaks` installato sulla macchina dello sviluppatore/agente. In assenza, l'hook fa skip non bloccante e resta valido il controllo obbligatorio in CI (`.github/workflows/security.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwDe6YBiuF24EQ6t7nRupT)_