### PR TITLE
security(support): redazione PII nelle segnalazioni AI di Maxwell

### DIFF
--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -13,7 +13,7 @@ import {
 } from '../ui/drawer';
 import { Skeleton } from '../ui/skeleton';
 import { useIsMobile } from '../ui/use-mobile';
-import { requestAiIssue, requestAiSupport, type AiChatMessage } from '../../services/ai';
+import { redactPII, requestAiIssue, requestAiSupport, type AiChatMessage } from '../../services/ai';
 import { AI_DISCLOSURE_KEY } from '../../constants/privacy';
 
 type SupportMessage = { id: string; role: 'assistant' | 'user'; content: string; createdAt: number };
@@ -153,12 +153,20 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
 
   const handleIssueDraft = async (draft: IssueDraft) => {
     if (isCreatingIssue) return;
-    const signature = `${draft.title}::${draft.body}`;
+    // La segnalazione diventa una issue GitHub pubblica: redige email, telefoni,
+    // codice fiscale e il nome dell'utente (potenzialmente un minore) dal draft
+    // generato dall'IA prima di inviarlo (tutela minori + GDPR Art. 32).
+    const safeDraft: IssueDraft = {
+      ...draft,
+      title: redactPII(draft.title, [displayName]),
+      body: redactPII(draft.body, [displayName]),
+    };
+    const signature = `${safeDraft.title}::${safeDraft.body}`;
     if (issueTrackerRef.current.has(signature)) return;
     issueTrackerRef.current.add(signature);
     setIsCreatingIssue(true);
     try {
-      await requestAiIssue({ payload: draft });
+      await requestAiIssue({ payload: safeDraft });
     } catch (error) {
       // Log the error to aid debugging and optionally surface a non-blocking message to the user.
       console.error('Failed to create support issue from AI draft:', error);

--- a/apps/mobile/src/services/ai.ts
+++ b/apps/mobile/src/services/ai.ts
@@ -271,6 +271,51 @@ export async function checkAiSupportAvailability({
   });
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Rimuove i dati personali più comuni da un testo prima che finisca in un
+ * canale potenzialmente pubblico (le segnalazioni di Maxwell diventano issue
+ * GitHub sul repo pubblico). Copre email, numeri di telefono e codice fiscale
+ * italiano; `extraTerms` consente di rimuovere termini noti aggiuntivi come il
+ * nome dell'utente. Tutela dei minori + GDPR Art. 32: una segnalazione non deve
+ * esporre PII. La funzione è deterministica e non lancia mai.
+ */
+export function redactPII(text: string, extraTerms: string[] = []): string {
+  if (!text) return text;
+  let out = text;
+  // Email.
+  out = out.replace(
+    /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+    '[email rimossa]',
+  );
+  // Codice fiscale italiano (16 caratteri) — prima dei numeri di telefono.
+  out = out.replace(
+    /\b[A-Za-z]{6}\d{2}[A-Za-z]\d{2}[A-Za-z]\d{3}[A-Za-z]\b/g,
+    '[dato rimosso]',
+  );
+  // Numeri di telefono: prefisso internazionale opzionale e cifre (8–15) con
+  // eventuali separatori. Il filtro sul conteggio cifre evita di rovinare
+  // numeri innocui (es. "livello 100", "score 1500").
+  out = out.replace(
+    /(?:\+|00)?\d[\d\s().-]{6,}\d/g,
+    (match) => {
+      const digits = match.replace(/\D/g, '');
+      return digits.length >= 8 && digits.length <= 15 ? '[telefono rimosso]' : match;
+    },
+  );
+  // Termini noti aggiuntivi (es. il nome utente). Ignora stringhe cortissime
+  // per non redigere in modo troppo aggressivo.
+  for (const term of extraTerms) {
+    const trimmed = term?.trim();
+    if (!trimmed || trimmed.length < 3) continue;
+    out = out.replace(new RegExp(escapeRegExp(trimmed), 'gi'), '[nome rimosso]');
+  }
+  return out;
+}
+
 export async function requestAiIssue({
   payload,
   endpoint,
@@ -278,6 +323,13 @@ export async function requestAiIssue({
   payload: AiSupportIssuePayload;
   endpoint?: string;
 }) {
+  // Rete di sicurezza: redige PII dal draft indipendentemente dal chiamante,
+  // prima che diventi una issue pubblica.
+  const safePayload: AiSupportIssuePayload = {
+    ...payload,
+    title: redactPII(payload.title),
+    body: redactPII(payload.body),
+  };
   // Use a single AbortController driven by withMobileWatchdog's timeout.
   // A redundant window.setTimeout at the same interval would create a race
   // where the outer abort fires after withMobileWatchdog already resolved,
@@ -291,7 +343,7 @@ export async function requestAiIssue({
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(payload),
+        body: JSON.stringify(safePayload),
         signal: controller.signal,
       });
 

--- a/apps/mobile/src/test/ai-redact.test.ts
+++ b/apps/mobile/src/test/ai-redact.test.ts
@@ -1,0 +1,56 @@
+// Tests for redactPII (services/ai.ts) — le segnalazioni di Maxwell diventano
+// issue GitHub pubbliche, quindi il contenuto non deve esporre PII (tutela
+// minori + GDPR Art. 32).
+
+import { describe, expect, it } from 'vitest';
+import { redactPII } from '../services/ai';
+
+describe('redactPII', () => {
+  it('rimuove gli indirizzi email', () => {
+    expect(redactPII('scrivimi a mario.rossi@example.com grazie')).toBe(
+      'scrivimi a [email rimossa] grazie',
+    );
+  });
+
+  it('rimuove i numeri di telefono (con e senza prefisso)', () => {
+    expect(redactPII('chiamami al +39 333 1234567')).toContain('[telefono rimosso]');
+    expect(redactPII('il mio numero è 3331234567')).toContain('[telefono rimosso]');
+    expect(redactPII('numero: 333-123-4567')).toContain('[telefono rimosso]');
+  });
+
+  it('rimuove il codice fiscale italiano', () => {
+    expect(redactPII('CF RSSMRA85M01H501Z')).toBe('CF [dato rimosso]');
+  });
+
+  it('rimuove i termini extra noti (es. nome utente) case-insensitive', () => {
+    expect(redactPII('Ciao sono Giovanni Bianchi', ['Giovanni Bianchi'])).toBe(
+      'Ciao sono [nome rimosso]',
+    );
+    expect(redactPII('firmato giovanni', ['Giovanni'])).toBe('firmato [nome rimosso]');
+  });
+
+  it('NON redige numeri innocui brevi (punteggi, livelli)', () => {
+    expect(redactPII('ho raggiunto il livello 100 con 1500 punti')).toBe(
+      'ho raggiunto il livello 100 con 1500 punti',
+    );
+  });
+
+  it('ignora termini extra troppo corti per evitare over-redaction', () => {
+    expect(redactPII('la mia auto va', ['va'])).toBe('la mia auto va');
+  });
+
+  it('gestisce input vuoto o assente senza lanciare', () => {
+    expect(redactPII('')).toBe('');
+    expect(redactPII('testo pulito', [''])).toBe('testo pulito');
+  });
+
+  it('redige più occorrenze e più tipi nello stesso testo', () => {
+    const input = 'Sono Anna, email anna@test.it tel 3391112223';
+    const out = redactPII(input, ['Anna']);
+    expect(out).not.toContain('anna@test.it');
+    expect(out).not.toContain('3391112223');
+    expect(out).toContain('[email rimossa]');
+    expect(out).toContain('[telefono rimosso]');
+    expect(out).toContain('[nome rimosso]');
+  });
+});


### PR DESCRIPTION
## Intento

**Blocco 1/3** della remediation dall'audit legale. L'assistente **Maxwell** può creare automaticamente **issue GitHub sul repo pubblico** a partire dalla chat di supporto. Il contenuto della segnalazione — scritto da utenti **potenzialmente minorenni** — veniva inviato senza alcun filtro, con rischio di esporre dati personali in un repository pubblico (tutela minori + GDPR Art. 32).

## Modifiche

- **`redactPII(text, extraTerms)`** (nuova, in `services/ai.ts`): rimuove email, numeri di telefono, codice fiscale italiano e termini noti aggiuntivi (il nome dell'utente). Deterministica, non lancia mai, con filtro sul conteggio cifre per non rovinare numeri innocui (livelli/punteggi).
- **`SupportChat.handleIssueDraft`**: redige `title`/`body` del draft (passando anche il `displayName` dell'utente) **prima** di creare la issue.
- **`requestAiIssue`**: applica `redactPII` come rete di sicurezza lato invio, indipendentemente dal chiamante.
- **Test unitari** (`test/ai-redact.test.ts`): email, telefoni (con/senza prefisso, separatori), codice fiscale, nome utente, non-redazione di numeri innocui, multi-occorrenza.

## Cosa NON fa (per scelta)

Coerente con la decisione presa: si è optato per la **sola redazione PII automatica**. Non vengono cambiati il flusso di autonomia dell'IA né la destinazione (repo pubblico) né l'invio dello userName al backend chat. Restano valutabili in futuro (tracker privato, conferma esplicita, pseudonimizzazione userName).

## Verifiche

- `npm run typecheck` → 0 errori
- `npm test` → **143 test passano** (di cui 8 nuovi su `redactPII`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwDe6YBiuF24EQ6t7nRupT)_