### PR TITLE
feat(signup): age-gate ≥14 (GDPR Art. 8)

### DIFF
--- a/apps/mobile/src/components/screens/Signup.tsx
+++ b/apps/mobile/src/components/screens/Signup.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft } from 'lucide-react';
 import { Screen } from '../ui/Screen';
 import { FormField, FormInput, AuthFormLayout } from '../ui/FormField';
 import { Button } from '../ui/Button';
+import { MIN_SIGNUP_AGE, computeAge } from '../../lib/age';
 
 interface SignupProps {
   onBack: () => void;
@@ -16,6 +17,7 @@ interface SignupProps {
 export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, errorMessage }: SignupProps) {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
+  const [birthDate, setBirthDate] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [acceptTerms, setAcceptTerms] = useState(false);
@@ -28,6 +30,14 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
     const newErrors: Record<string, string> = {};
     if (!name) newErrors.name = 'Nome richiesto';
     if (!email) newErrors.email = 'Email richiesta';
+    // GDPR Art. 8: verifica dell'età. In Italia il consenso digitale è a 14 anni.
+    if (!birthDate) {
+      newErrors.birthDate = 'Data di nascita richiesta';
+    } else {
+      const age = computeAge(birthDate);
+      if (age === null) newErrors.birthDate = 'Inserisci una data di nascita valida';
+      else if (age < MIN_SIGNUP_AGE) newErrors.birthDate = `Devi avere almeno ${MIN_SIGNUP_AGE} anni per registrarti`;
+    }
     if (!password) newErrors.password = 'Password richiesta'; else if (password.length < 8) newErrors.password = 'La password deve avere almeno 8 caratteri';
     if (password !== confirmPassword) newErrors.confirmPassword = 'Le password non corrispondono';
     if (!acceptTerms) newErrors.terms = 'Devi accettare i termini e la privacy';
@@ -69,6 +79,15 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
           <FormField label="Email" error={errors.email}>
             <FormInput type="email" value={email} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
               autoComplete="email" hasError={!!errors.email} placeholder="tuo@email.com" />
+          </FormField>
+
+          <FormField label="Data di nascita" error={errors.birthDate}>
+            <FormInput type="date" value={birthDate} max={new Date().toISOString().slice(0, 10)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setBirthDate(e.target.value)}
+              autoComplete="bday" hasError={!!errors.birthDate} aria-label="Data di nascita" />
+            <p className="mt-2 !mb-0 text-base text-[#9a9697]">
+              Serve solo per verificare che tu abbia almeno {MIN_SIGNUP_AGE} anni. Non viene salvata.
+            </p>
           </FormField>
 
           <div className="flex flex-col gap-4 w-full">

--- a/apps/mobile/src/lib/age.ts
+++ b/apps/mobile/src/lib/age.ts
@@ -1,0 +1,49 @@
+// Age gate per la registrazione (GDPR Art. 8 + tutela minori).
+//
+// In Italia l'età del consenso digitale è 14 anni (D.Lgs. 101/2018): sotto i 14
+// il trattamento richiede il consenso di chi esercita la responsabilità
+// genitoriale. Turni di Palco è pensato per un pubblico 14+, quindi al signup
+// verifichiamo l'età dichiarata e blocchiamo gli under-14.
+//
+// Scelta di minimizzazione dei dati: la data di nascita serve solo a calcolare
+// l'età al momento della registrazione e NON viene persistita.
+
+export const MIN_SIGNUP_AGE = 14;
+
+/**
+ * Calcola l'età in anni compiuti a partire da una data di nascita `YYYY-MM-DD`.
+ * Ritorna `null` se la data è vuota, non valida o nel futuro.
+ * `now` è iniettabile per rendere il calcolo deterministico nei test.
+ */
+export function computeAge(birthDate: string, now: Date = new Date()): number | null {
+  if (!birthDate) return null;
+  // Parse esplicito di YYYY-MM-DD a mezzanotte locale per evitare shift di fuso.
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(birthDate.trim());
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const dob = new Date(year, month - 1, day);
+  // Rifiuta date "rimbalzate" (es. 31/02) e date non reali.
+  if (
+    dob.getFullYear() !== year ||
+    dob.getMonth() !== month - 1 ||
+    dob.getDate() !== day
+  ) {
+    return null;
+  }
+  if (dob.getTime() > now.getTime()) return null;
+
+  let age = now.getFullYear() - dob.getFullYear();
+  const monthDiff = now.getMonth() - dob.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < dob.getDate())) {
+    age -= 1;
+  }
+  return age;
+}
+
+/** True se la data di nascita corrisponde ad almeno `MIN_SIGNUP_AGE` anni compiuti. */
+export function meetsMinAge(birthDate: string, now: Date = new Date()): boolean {
+  const age = computeAge(birthDate, now);
+  return age !== null && age >= MIN_SIGNUP_AGE;
+}

--- a/apps/mobile/src/test/age.test.ts
+++ b/apps/mobile/src/test/age.test.ts
@@ -1,0 +1,42 @@
+// Tests per l'age gate del signup (GDPR Art. 8, età consenso digitale IT = 14).
+
+import { describe, expect, it } from 'vitest';
+import { MIN_SIGNUP_AGE, computeAge, meetsMinAge } from '../lib/age';
+
+const NOW = new Date(2026, 6, 2); // 2 luglio 2026 (mese 0-based → 6 = luglio)
+
+describe('computeAge', () => {
+  it('calcola gli anni compiuti', () => {
+    expect(computeAge('2000-01-01', NOW)).toBe(26);
+    expect(computeAge('2010-07-02', NOW)).toBe(16); // compleanno oggi
+  });
+
+  it('sottrae un anno se il compleanno non è ancora arrivato', () => {
+    expect(computeAge('2010-07-03', NOW)).toBe(15); // compleanno domani
+    expect(computeAge('2010-12-31', NOW)).toBe(15);
+  });
+
+  it('ritorna null per date vuote, non valide, malformate o nel futuro', () => {
+    expect(computeAge('', NOW)).toBeNull();
+    expect(computeAge('non-una-data', NOW)).toBeNull();
+    expect(computeAge('2011-02-31', NOW)).toBeNull(); // 31 febbraio inesistente
+    expect(computeAge('2030-01-01', NOW)).toBeNull(); // futuro
+  });
+});
+
+describe('meetsMinAge', () => {
+  it(`accetta chi ha almeno ${MIN_SIGNUP_AGE} anni`, () => {
+    expect(meetsMinAge('2012-07-02', NOW)).toBe(true); // esattamente 14 oggi
+    expect(meetsMinAge('2000-01-01', NOW)).toBe(true);
+  });
+
+  it('rifiuta gli under-14', () => {
+    expect(meetsMinAge('2012-07-03', NOW)).toBe(false); // 14 anni domani → oggi 13
+    expect(meetsMinAge('2015-01-01', NOW)).toBe(false);
+  });
+
+  it('rifiuta input non validi', () => {
+    expect(meetsMinAge('', NOW)).toBe(false);
+    expect(meetsMinAge('2030-01-01', NOW)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Intento

**Blocco 2/3** della remediation dall'audit legale. L'app dichiara un target **14-17 anni** ma il signup non verificava l'età (GDPR **Art. 8**). In Italia l'età del consenso digitale è **14 anni** (D.Lgs. 101/2018): sotto i 14 il trattamento richiede il consenso di chi esercita la responsabilità genitoriale, quindi blocchiamo gli under-14 alla registrazione.

## Modifiche

- **`lib/age.ts`** (nuova): `MIN_SIGNUP_AGE = 14`, `computeAge(birthDate, now)` e `meetsMinAge(...)`. `now` iniettabile per test deterministici; parsing robusto di `YYYY-MM-DD` (rifiuta date non valide/rimbalzate/future).
- **`Signup.tsx`**: nuovo campo **Data di nascita** (`<input type="date">` con `max=oggi`). In validazione: se mancante/non valida o età `< 14`, blocca l'invio con messaggio chiaro.
- **Nota di trasparenza in UI**: "Serve solo per verificare che tu abbia almeno 14 anni. **Non viene salvata.**"
- **Test** (`test/age.test.ts`): compleanno oggi/domani, under-14, date non valide/future.

## Scelte

- **Coerente con la decisione presa** ("Verifica età ≥14 + avviso"): gate self-dichiarato lato client, senza flusso di consenso genitoriale.
- **Minimizzazione dei dati**: la data di nascita è usata solo per il calcolo dell'età e **non viene persistita** (nessuna modifica a schema DB o alla firma di `onSignup`).

## Verifiche

- `npm run typecheck` → 0 errori
- `npm test` → **149 test** passano (+6 nuovi su `age.ts`)
- `npm run build` → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwDe6YBiuF24EQ6t7nRupT)_