### PR TITLE
feat(privacy): classifica pubblica opt-in per i minori

### DIFF
--- a/apps/mobile/src/components/screens/AccountSettings.tsx
+++ b/apps/mobile/src/components/screens/AccountSettings.tsx
@@ -738,6 +738,7 @@ function GdprPrivacyCard({
           <div className="flex-1">
             <p className="text-[16px] leading-[25.6px] text-white !m-0">Visibile in classifica</p>
             <p className="text-[12px] leading-[18px] text-[#b8b2b3] !m-0">Il tuo profilo appare nella classifica pubblica</p>
+            <p className="text-[12px] leading-[18px] text-[#9a9697] !m-0 mt-1">Se sei minorenne è nascosto per impostazione predefinita: puoi renderti visibile da qui.</p>
           </div>
           <Switch checked={leaderboardVisible} onCheckedChange={onToggleLeaderboard} />
         </div>

--- a/apps/mobile/src/components/screens/Signup.tsx
+++ b/apps/mobile/src/components/screens/Signup.tsx
@@ -3,11 +3,11 @@ import { ArrowLeft } from 'lucide-react';
 import { Screen } from '../ui/Screen';
 import { FormField, FormInput, AuthFormLayout } from '../ui/FormField';
 import { Button } from '../ui/Button';
-import { MIN_SIGNUP_AGE, computeAge } from '../../lib/age';
+import { MIN_SIGNUP_AGE, computeAge, isMinor } from '../../lib/age';
 
 interface SignupProps {
   onBack: () => void;
-  onSignup: (name: string, email: string, password: string) => void | Promise<void>;
+  onSignup: (name: string, email: string, password: string, isMinor: boolean) => void | Promise<void>;
   onLogin: () => void;
   onViewTerms: () => void;
   onViewPrivacy: () => void;
@@ -45,7 +45,9 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
     setSubmitError(null);
     setIsSubmitting(true);
     try {
-      await onSignup(name, email.trim().toLowerCase(), password);
+      // Passa il flag "minorenne" (età < 18) per applicare le tutele aggiuntive
+      // lato server (es. classifica pubblica opt-in). La data non viene inviata.
+      await onSignup(name, email.trim().toLowerCase(), password, isMinor(birthDate));
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : 'Errore durante la registrazione. Riprova.');
     } finally {

--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -108,7 +108,7 @@ export function useAuth(
         // calling onAuthChange here as well would fire it twice on every successful login.
     }, [profile.name, updateProfile]);
 
-    const handleSignup = useCallback(async (name: string, email: string, password: string) => {
+    const handleSignup = useCallback(async (name: string, email: string, password: string, isMinor = false) => {
         setAuthError(null);
         if (!isSupabaseConfigured || !supabase) {
             setIsDemoMode(true);
@@ -122,7 +122,9 @@ export function useAuth(
             email,
             password,
             options: {
-                data: { name },
+                // is_minor viene letto dal trigger handle_new_user che, per i
+                // minorenni, imposta leaderboard_visible=false (classifica opt-in).
+                data: { name, is_minor: isMinor },
                 ...(redirectTo ? { emailRedirectTo: redirectTo } : {}),
             },
         });

--- a/apps/mobile/src/lib/age.ts
+++ b/apps/mobile/src/lib/age.ts
@@ -9,6 +9,7 @@
 // l'età al momento della registrazione e NON viene persistita.
 
 export const MIN_SIGNUP_AGE = 14;
+export const ADULT_AGE = 18;
 
 /**
  * Calcola l'età in anni compiuti a partire da una data di nascita `YYYY-MM-DD`.
@@ -46,4 +47,14 @@ export function computeAge(birthDate: string, now: Date = new Date()): number | 
 export function meetsMinAge(birthDate: string, now: Date = new Date()): boolean {
   const age = computeAge(birthDate, now);
   return age !== null && age >= MIN_SIGNUP_AGE;
+}
+
+/**
+ * True se l'utente è minorenne (età < 18) in base alla data di nascita.
+ * Usato per applicare tutele aggiuntive (es. classifica pubblica opt-in).
+ * Una data non valida è prudenzialmente trattata come minorenne (true).
+ */
+export function isMinor(birthDate: string, now: Date = new Date()): boolean {
+  const age = computeAge(birthDate, now);
+  return age === null || age < ADULT_AGE;
 }

--- a/apps/mobile/src/test/age.test.ts
+++ b/apps/mobile/src/test/age.test.ts
@@ -1,7 +1,7 @@
 // Tests per l'age gate del signup (GDPR Art. 8, età consenso digitale IT = 14).
 
 import { describe, expect, it } from 'vitest';
-import { MIN_SIGNUP_AGE, computeAge, meetsMinAge } from '../lib/age';
+import { MIN_SIGNUP_AGE, computeAge, meetsMinAge, isMinor } from '../lib/age';
 
 const NOW = new Date(2026, 6, 2); // 2 luglio 2026 (mese 0-based → 6 = luglio)
 
@@ -38,5 +38,22 @@ describe('meetsMinAge', () => {
   it('rifiuta input non validi', () => {
     expect(meetsMinAge('', NOW)).toBe(false);
     expect(meetsMinAge('2030-01-01', NOW)).toBe(false);
+  });
+});
+
+describe('isMinor', () => {
+  it('è true per gli under-18', () => {
+    expect(isMinor('2010-01-01', NOW)).toBe(true); // 16 anni
+    expect(isMinor('2008-07-03', NOW)).toBe(true); // 18 domani → oggi 17
+  });
+
+  it('è false per i maggiorenni', () => {
+    expect(isMinor('2008-07-02', NOW)).toBe(false); // esattamente 18 oggi
+    expect(isMinor('1990-01-01', NOW)).toBe(false);
+  });
+
+  it('tratta prudenzialmente le date non valide come minorenne', () => {
+    expect(isMinor('', NOW)).toBe(true);
+    expect(isMinor('non-valida', NOW)).toBe(true);
   });
 });

--- a/supabase/migrations/20260702000000_leaderboard_minor_optin.sql
+++ b/supabase/migrations/20260702000000_leaderboard_minor_optin.sql
@@ -1,0 +1,38 @@
+-- Tutela minori: la classifica pubblica diventa OPT-IN per i minorenni.
+--
+-- Finora leaderboard_visible aveva default true per tutti (opt-out). Per i
+-- minorenni (target dell'app: 14-17) l'esposizione pubblica di nickname, foto e
+-- statistiche non deve essere l'impostazione predefinita: partono nascosti e
+-- possono rendersi visibili esplicitamente da "Gestisci account → Privacy".
+--
+-- Il flag `is_minor` è calcolato al signup (età < 18) e propagato tramite i
+-- metadati utente; non memorizziamo la data di nascita.
+
+alter table public.profiles
+  add column if not exists is_minor boolean not null default false;
+
+-- Aggiorna il trigger di creazione profilo: legge is_minor dai metadati e, per i
+-- minorenni, imposta leaderboard_visible = false (classifica opt-in). Per i
+-- maggiorenni il comportamento resta invariato (visibile per default).
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_is_minor boolean := coalesce((new.raw_user_meta_data->>'is_minor')::boolean, false);
+begin
+  insert into public.profiles (id, name, email, role_id, is_minor, leaderboard_visible)
+  values (
+    new.id,
+    coalesce(new.raw_user_meta_data->>'name', split_part(new.email, '@', 1), 'Player'),
+    new.email,
+    'attore',
+    v_is_minor,
+    not v_is_minor
+  )
+  on conflict (id) do nothing;
+  return new;
+end;
+$$;


### PR DESCRIPTION
## Intento

**Follow-up B/3.** La classifica pubblica espone nickname, foto e statistiche. Per i **minorenni** questa esposizione non deve essere l'impostazione predefinita: passano da **opt-out** a **opt-in** (partono nascosti, possono rendersi visibili esplicitamente).

## Come funziona

1. **`lib/age.ts`**: aggiunge `ADULT_AGE = 18` e `isMinor(birthDate)` (età < 18; data non valida → prudenzialmente minore).
2. **`Signup.tsx`**: calcola `isMinor` dalla data di nascita e lo passa a `onSignup` (la data **non** viene inviata né salvata).
3. **`useAuth.ts`**: `handleSignup` inoltra `is_minor` nei metadati utente (`options.data`).
4. **Migration `20260702000000_leaderboard_minor_optin.sql`**: aggiunge `profiles.is_minor` e aggiorna il trigger `handle_new_user` per impostare `leaderboard_visible = NOT is_minor`. I maggiorenni restano invariati (visibili di default).
5. **`AccountSettings.tsx`**: nota sotto il toggle classifica che spiega ai minori l'impostazione predefinita.

Le RPC `get_leaderboard` e `get_public_leaderboard` filtrano già su `leaderboard_visible = true`, quindi i minori restano esclusi finché non attivano la visibilità — **nessuna modifica alle RPC necessaria**.

## Verifiche

- `npm run typecheck` → 0 errori · `npm test` → **152 test** (+3 su `isMinor`) · `npm run build` → ok

## Nota operativa

La migration va applicata al progetto Supabase con il normale flusso (non l'ho applicata alla produzione). Riguarda solo i **nuovi** signup; per gli utenti minorenni già esistenti si può eventualmente eseguire un update mirato una tantum, se desiderato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwDe6YBiuF24EQ6t7nRupT)_