### PR TITLE
docs(legal): data retention accurata (GDPR Art. 13)

### DIFF
--- a/apps/mobile/src/components/screens/PrivacyPolicy.tsx
+++ b/apps/mobile/src/components/screens/PrivacyPolicy.tsx
@@ -213,10 +213,27 @@ export function PrivacyPolicy({ onBack }: PrivacyPolicyProps) {
         {/* Conservazione — GDPR Art. 5.1.e */}
         <LegalSection icon={Clock} title="Per quanto tempo li conserviamo">
           <p className="text-[13px] leading-[19px] text-[#b8b2b3]">
-            Conserviamo i dati per il tempo necessario alle finalità indicate e agli obblighi di legge.
-            I dati del tuo account e quelli associati vengono cancellati quando ne richiedi l'eliminazione
-            o dopo un periodo prolungato di inattività dell'account.
+            Conserviamo i dati personali solo per il tempo necessario alle finalità indicate e agli
+            obblighi di legge:
           </p>
+          <ul className="flex flex-col gap-2 text-[13px] leading-[19px] text-[#b8b2b3]">
+            <Bullet>
+              <b className="text-[#f5f5f5] font-medium">Dati account e di gioco</b>: per tutta la durata
+              dell'account; vengono eliminati quando richiedi la cancellazione dell'account.
+            </Bullet>
+            <Bullet>
+              <b className="text-[#f5f5f5] font-medium">Geolocalizzazione</b>: <span className="text-[#f5f5f5]">non viene conservata</span>.
+              È usata solo in tempo reale per verificare la presenza al turno e non viene salvata nei nostri archivi.
+            </Bullet>
+            <Bullet>
+              <b className="text-[#f5f5f5] font-medium">Statistiche d'uso</b>: raccolte in forma
+              pseudonimizzata e conservate per un periodo limitato.
+            </Bullet>
+            <Bullet>
+              <b className="text-[#f5f5f5] font-medium">Log tecnici</b>: gestiti a fini di sicurezza e
+              diagnostica dai nostri fornitori per un periodo limitato.
+            </Bullet>
+          </ul>
         </LegalSection>
 
         {/* Minori — GDPR Art. 8 */}


### PR DESCRIPTION
## Intento

**Follow-up C/3.** L'obiettivo iniziale era aggiungere TTL espliciti per la data retention. Investigando il modello dati è emerso che **non c'è dato transitorio persistito da purgare**:

- **Geolocalizzazione**: NON viene salvata. `checkin_latitude/longitude` sono solo *parametri* della RPC di registrazione turno, usati in tempo reale per il geofence; la tabella `turns` non ha colonne di coordinate.
- **Analytics**: nessuna tabella di eventi persistiti (il sink di default è `console.debug`, pseudonimizzato quando attivo).
- **Log mobile**: la edge function `mobile-logs` non scrive su tabella — logga sull'osservabilità di piattaforma (retention gestita dal provider).

Di conseguenza un job pg_cron di purge non avrebbe nulla di significativo da cancellare, e le uniche tabelle che si accumulano sono log di audit/sicurezza (che è preferibile conservare). La scelta condivisa è stata quindi: **rendere accurata la sezione retention** invece di aggiungere un job inutile.

## Modifiche (`PrivacyPolicy.tsx`)

Sezione "Per quanto tempo li conserviamo" resa concreta e veritiera (GDPR Art. 13):
- Dati account/gioco → fino alla cancellazione dell'account
- **Geolocalizzazione → non conservata** (solo in tempo reale)
- Statistiche d'uso → pseudonimizzate, periodo limitato
- Log tecnici → gestiti dai fornitori per un periodo limitato

## Verifiche

- `npm run typecheck` → 0 errori · `npm run build` → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwDe6YBiuF24EQ6t7nRupT)_