### PR TITLE
fix: move supabase-js import to top level in app-version function

### DIFF
--- a/supabase/functions/app-version/index.ts
+++ b/supabase/functions/app-version/index.ts
@@ -1,5 +1,6 @@
 /// <reference path="../@types/deno.d.ts" />
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.48.0';
 
 const allowedOrigin = Deno.env.get('SITE_URL') ?? 'https://turnidipalco.it';
 
@@ -53,7 +54,6 @@ serve(async (req) => {
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return errorResponse('Autenticazione richiesta', 401);
   }
-  const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2.48.0');
   const userClient = createClient(supabaseUrl, anonKey, {
     global: { headers: { Authorization: authHeader } },
     auth: { autoRefreshToken: false, persistSession: false },


### PR DESCRIPTION
Closes #1405

## Explanation

The `supabase/functions/app-version/index.ts` file was using a dynamic `await import()` of `@supabase/supabase-js` inside the `serve` handler (line 56), without any surrounding try/catch. If `esm.sh` was unreachable or returned a non-module response, the import would throw an unhandled exception, crashing the entire request with no structured JSON error response.

The fix moves the import to the module top level (consistent with all other edge functions in this repo):

```typescript
import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.48.0';
```

This ensures:
- Module-load failures surface at cold-start time with a clear deploy error rather than silently crashing individual requests
- The handler no longer has an unguarded async operation before any try/catch
- Consistent style with all other Supabase edge functions in this repository

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcM8dLqQ4TmY7WjFc2FcrG)_