### PR TITLE
fix(gdpr): include ticket_activations in GDPR Art. 15/20 export (#1407)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -5440,17 +5440,22 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     // Fix #1231: also fetch activity_completions, narrative_history, and
     // shop_purchases in parallel — all tables deleted by delete-my-account must
     // be present in the Art. 15/20 export.
+    // Fix #1407: include ticket_activations — deleted by delete-my-account under
+    // both activated_by and reserved_by, so it qualifies as personal data and
+    // must be exportable under Art. 15/20 symmetrically with deletion (Art. 17).
     // Fall back to state.turns only when Supabase is unavailable (e.g. offline).
     let allTurns: TurnRecord[] = state.turns;
     let activityCompletions: unknown[] = [];
     let narrativeHistory: unknown[] = [];
     let shopPurchases: unknown[] = [];
+    let ticketActivations: unknown[] = [];
     if (isSupabaseConfigured && supabase && authUserId) {
       const [
         { data: turnsData, error: turnsError },
         { data: activityData, error: activityError },
         { data: narrativeData, error: narrativeError },
         { data: shopData, error: shopError },
+        { data: ticketActivatedData, error: ticketActivatedError },
       ] = await Promise.all([
         supabase
           .from('turns')
@@ -5476,6 +5481,12 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           .eq('user_id', authUserId)
           .order('created_at', { ascending: false })
           .limit(10000),
+        supabase
+          .from('ticket_activations')
+          .select('*')
+          .eq('activated_by', authUserId)
+          .order('created_at', { ascending: false })
+          .limit(10000),
       ]);
       // Fail loudly if any query errors so the user is not shown a silently
       // incomplete GDPR export (fixes #1253).
@@ -5484,6 +5495,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       if (activityError) queryErrors.push({ table: 'activity_completions', error: activityError });
       if (narrativeError) queryErrors.push({ table: 'narrative_history', error: narrativeError });
       if (shopError) queryErrors.push({ table: 'shop_purchases', error: shopError });
+      if (ticketActivatedError) queryErrors.push({ table: 'ticket_activations', error: ticketActivatedError });
       if (queryErrors.length > 0) {
         const tables = queryErrors.map((e) => e.table).join(', ');
         notifyCriticalError(
@@ -5518,6 +5530,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       if (Array.isArray(shopData)) {
         shopPurchases = shopData;
       }
+      if (Array.isArray(ticketActivatedData)) {
+        ticketActivations = ticketActivatedData;
+      }
     }
 
     const data = {
@@ -5548,6 +5563,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       activityCompletions,
       narrativeHistory,
       shopPurchases,
+      ticketActivations,
       badges,
       theatreReputation,
       plannedEvents: eventPlans,

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -5448,7 +5448,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     let activityCompletions: unknown[] = [];
     let narrativeHistory: unknown[] = [];
     let shopPurchases: unknown[] = [];
-    let ticketActivations: unknown[] = [];
+    let ticketActivationsActivated: unknown[] = [];
+    let ticketActivationsReserved: unknown[] = [];
     if (isSupabaseConfigured && supabase && authUserId) {
       const [
         { data: turnsData, error: turnsError },
@@ -5456,6 +5457,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         { data: narrativeData, error: narrativeError },
         { data: shopData, error: shopError },
         { data: ticketActivatedData, error: ticketActivatedError },
+        { data: ticketReservedData, error: ticketReservedError },
       ] = await Promise.all([
         supabase
           .from('turns')
@@ -5481,10 +5483,20 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           .eq('user_id', authUserId)
           .order('created_at', { ascending: false })
           .limit(10000),
+        // Tickets this user activated by scanning a QR code.
         supabase
           .from('ticket_activations')
           .select('*')
           .eq('activated_by', authUserId)
+          .order('activated_at', { ascending: false })
+          .limit(10000),
+        // Tickets this user generated as an admin (reserved_by), including
+        // unactivated ones (activated_by IS NULL). Mirrors the reserved_by
+        // deletion in delete-my-account (GDPR Art. 17 ↔ Art. 15/20 symmetry).
+        supabase
+          .from('ticket_activations')
+          .select('*')
+          .eq('reserved_by', authUserId)
           .order('created_at', { ascending: false })
           .limit(10000),
       ]);
@@ -5495,7 +5507,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       if (activityError) queryErrors.push({ table: 'activity_completions', error: activityError });
       if (narrativeError) queryErrors.push({ table: 'narrative_history', error: narrativeError });
       if (shopError) queryErrors.push({ table: 'shop_purchases', error: shopError });
-      if (ticketActivatedError) queryErrors.push({ table: 'ticket_activations', error: ticketActivatedError });
+      if (ticketActivatedError) queryErrors.push({ table: 'ticket_activations(activated_by)', error: ticketActivatedError });
+      if (ticketReservedError) queryErrors.push({ table: 'ticket_activations(reserved_by)', error: ticketReservedError });
       if (queryErrors.length > 0) {
         const tables = queryErrors.map((e) => e.table).join(', ');
         notifyCriticalError(
@@ -5531,7 +5544,10 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         shopPurchases = shopData;
       }
       if (Array.isArray(ticketActivatedData)) {
-        ticketActivations = ticketActivatedData;
+        ticketActivationsActivated = ticketActivatedData;
+      }
+      if (Array.isArray(ticketReservedData)) {
+        ticketActivationsReserved = ticketReservedData;
       }
     }
 
@@ -5563,7 +5579,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       activityCompletions,
       narrativeHistory,
       shopPurchases,
-      ticketActivations,
+      ticketActivationsActivated,
+      ticketActivationsReserved,
       badges,
       theatreReputation,
       plannedEvents: eventPlans,


### PR DESCRIPTION
## Summary

Fixes #1407 — `exportUserData` omitted `ticket_activations` from the GDPR Art. 15/20 data export despite `delete-my-account` deleting those records (by both `activated_by` and `reserved_by`), creating an Art. 17 ↔ Art. 15/20 asymmetry.

## Key changes

- Added two `ticket_activations` queries to the `Promise.all` block in `exportUserData` (`apps/mobile/src/state/store.tsx`):
  - `activated_by = authUserId` — tickets the user scanned/activated
  - `reserved_by = authUserId` — QR tickets generated by the user as admin (including unactivated ones with `activated_by IS NULL`)
- Both query errors are wired into the existing fail-loud `queryErrors` path (same pattern as #1253), so a failed fetch surfaces to the user rather than silently omitting data.
- Downloaded JSON now includes `ticketActivationsActivated` and `ticketActivationsReserved` keys, mirroring the deletion logic in `delete-my-account` exactly.

## Testing

1. Activate one or more event tickets in the app.
2. Go to profile → "Scarica i miei dati".
3. Open the downloaded JSON — `ticketActivationsActivated` key should be present with activated ticket records.
4. As an admin, generate QR tickets, then export — `ticketActivationsReserved` should contain those records.