### PR TITLE
fix(security): validate next_rest_url origin to prevent SSRF (#1409)

### DIFF
--- a/supabase/functions/import-spazio-rossellini/index.ts
+++ b/supabase/functions/import-spazio-rossellini/index.ts
@@ -162,7 +162,25 @@ const fetchAllEvents = async (): Promise<SpazioEvent[]> => {
       if (Array.isArray(payload.events)) {
         events.push(...payload.events);
       }
-      nextUrl = payload.next_rest_url || null;
+      // Validate next_rest_url origin before using it to prevent SSRF via a
+      // crafted API response redirecting requests to an internal host (closes #1409).
+      const rawNext = typeof payload.next_rest_url === 'string' ? payload.next_rest_url.trim() : null;
+      if (rawNext) {
+        try {
+          const parsedNext = new URL(rawNext);
+          const allowedOrigin = new URL(EVENTS_API_URL).origin;
+          nextUrl = parsedNext.origin === allowedOrigin ? rawNext : null;
+          if (!nextUrl) {
+            console.warn(
+              `[import-spazio-rossellini] fetchAllEvents rejected next_rest_url with unexpected origin: ${parsedNext.origin}`,
+            );
+          }
+        } catch {
+          nextUrl = null;
+        }
+      } else {
+        nextUrl = null;
+      }
     }
   } catch (err) {
     console.warn('[import-spazio-rossellini] fetchAllEvents unexpected error:', err);


### PR DESCRIPTION
## Summary

- Validates the `next_rest_url` field returned by the Spazio Rossellini API before using it as the next pagination URL
- Rejects any URL whose origin does not match `https://www.spaziorossellini.it` and logs a warning
- Prevents a crafted API response from redirecting server-side fetch requests to internal hosts (SSRF)

## Changes

`supabase/functions/import-spazio-rossellini/index.ts` — replace bare `payload.next_rest_url || null` assignment with origin-validation logic using `new URL()`.

## Test plan

- [ ] Normal pagination: `next_rest_url` pointing to `https://www.spaziorossellini.it/...` is followed as before
- [ ] Malicious URL: `next_rest_url` with a different origin (e.g. `http://169.254.169.254/`) is rejected and a warning is logged; pagination stops
- [ ] Missing/null `next_rest_url`: pagination stops cleanly with no error

Closes #1409

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXCZdWQrWsLDckZyKrUoHY)_