### PR TITLE
fix: prevent false-positive reportCriticalError in mobile watchdog (#1411)

### DIFF
--- a/apps/mobile/src/services/mobile-watchdog.ts
+++ b/apps/mobile/src/services/mobile-watchdog.ts
@@ -42,9 +42,14 @@ export async function withMobileWatchdog<T>(
   { operation, timeoutMs, title, message }: MobileWatchdogOptions
 ): Promise<T> {
   let timeoutId: ReturnType<typeof setTimeout> | number | undefined;
+  // Prevents reportCriticalError from firing after the task already completed
+  // in the narrow race window between the timer callback executing and
+  // clearWatchdogTimeout running in the finally block (closes #1411).
+  let cancelled = false;
 
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = scheduleWatchdogTimeout(() => {
+      if (cancelled) return;
       reportCriticalError({
         title: title ?? DEFAULT_ERROR_TITLE,
         message: message ?? DEFAULT_ERROR_MESSAGE,
@@ -57,6 +62,7 @@ export async function withMobileWatchdog<T>(
   try {
     return await Promise.race([task(), timeoutPromise]);
   } finally {
+    cancelled = true;
     if (timeoutId !== undefined) clearWatchdogTimeout(timeoutId);
   }
 }


### PR DESCRIPTION
## Summary

- Adds a `cancelled` boolean flag to `withMobileWatchdog` that is set to `true` in the `finally` block before `clearWatchdogTimeout` runs
- The timeout callback checks this flag and returns early if the task already completed, preventing `reportCriticalError` from firing for a successful operation

## Changes

`apps/mobile/src/services/mobile-watchdog.ts` — add `cancelled` flag; check it in the timer callback before calling `reportCriticalError`.

## Test plan

- [ ] Task completes just before timeout: no critical error dialog shown
- [ ] Task genuinely times out: `reportCriticalError` is still called correctly

Closes #1411

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXCZdWQrWsLDckZyKrUoHY)_