### PR TITLE
fix(privacy): re-check GDPR consent after async getUserHash in track() (#1413)

### DIFF
--- a/apps/mobile/src/services/analytics.ts
+++ b/apps/mobile/src/services/analytics.ts
@@ -349,6 +349,11 @@ export async function track(
   if (!readConsent()) return;
 
   const userHash = await getUserHash(options?.userId ?? null);
+
+  // Re-check consent after the async pseudonymization call (up to 8 s) — the
+  // user may have revoked consent while it was in-flight (closes #1413).
+  if (!readConsent()) return;
+
   const payload: AnalyticsEventPayload = {
     event,
     userHash,


### PR DESCRIPTION
## Summary

- Adds a second `readConsent()` check immediately after `getUserHash()` returns in `track()`
- `getUserHash()` can take up to 8 seconds (HTTP timeout); if the user revokes analytics consent during that window, the event was previously sent anyway
- The re-check ensures consent is honoured at the point of dispatch, not just at call time

## Changes

`apps/mobile/src/services/analytics.ts` — add `if (!readConsent()) return;` after the `getUserHash` `await`.

## Test plan

- [ ] Consent granted throughout: events reach the sink normally
- [ ] Consent revoked while `getUserHash` is in-flight: event is dropped, sink not called
- [ ] Consent never granted: first check still blocks immediately (no regression)

Closes #1413

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXCZdWQrWsLDckZyKrUoHY)_