### PR TITLE
fix(privacy): clear COOKIE_CONSENT_KEY on account deletion (#1414)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -5391,6 +5391,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         STORAGE_KEY,
         OFFLINE_SYNC_QUEUE_KEY,
         GEO_CONSENT_KEY,
+        // Explicit: prevents a subsequent user on the same device from inheriting
+        // this account's cookie consent decision (GDPR — closes #1414).
+        COOKIE_CONSENT_KEY,
       ].forEach((k) => { try { window.localStorage.removeItem(k); } catch { /* ignore */ } });
       // Also clear any remaining tdp-* and sb-*-auth-token keys
       for (let i = window.localStorage.length - 1; i >= 0; i--) {


### PR DESCRIPTION
## Summary

- Adds `COOKIE_CONSENT_KEY` to the explicit localStorage cleanup list in `deleteAccount`
- Without this, the cookie consent decision (`tdp-cookie-consent-v1`) could persist on shared devices after account deletion, causing a subsequent user to inherit the prior user's consent state
- The key was previously caught by the `tdp-*` prefix loop; this change makes the intent explicit and provides a safety net if the loop is ever modified

## Changes

`apps/mobile/src/state/store.tsx` — add `COOKIE_CONSENT_KEY` to the `forEach` cleanup array in `deleteAccount`.

## Test plan

- [ ] After `deleteAccount`, `localStorage.getItem('tdp-cookie-consent-v1')` returns `null`
- [ ] Other session keys (auth tokens, game state) are also cleared (no regression)

Closes #1414

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXCZdWQrWsLDckZyKrUoHY)_