### PR TITLE
fix: clamp cachet to 0 in startCourse setState updater (#1410)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -5222,7 +5222,10 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         const pCompletedCourses = p.completedCourses ?? {};
         const next: PlayerProfile = {
           ...p,
-          cachet: p.cachet - course.costCachet,
+          // Clamp to 0: the guard above uses the render-time snapshot, so a
+          // concurrent mutation could reduce prev.cachet below costCachet before
+          // this updater runs, causing a negative balance (closes #1410).
+          cachet: Math.max(0, p.cachet - course.costCachet),
           skills: pSkills,
           completedCourses: pCompletedCourses,
           activeCourses: {


### PR DESCRIPTION
## Summary

- Wraps the cachet subtraction in the `startCourse` `setState` updater with `Math.max(0, ...)`
- The render-time guard checks `profile.cachet >= course.costCachet` using a snapshot; a concurrent mutation (e.g. Realtime subscription) could reduce `prev.cachet` below the cost before the updater runs, producing a negative balance
- Clamping to 0 prevents the invariant violation without changing the external API

## Changes

`apps/mobile/src/state/store.tsx` — `cachet: Math.max(0, p.cachet - course.costCachet)` in the `setState` updater inside `startCourse`.

## Test plan

- [ ] Normal course start: cachet is deducted correctly
- [ ] Concurrent mutation scenario: cachet never goes below 0

Closes #1410

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXCZdWQrWsLDckZyKrUoHY)_