### PR TITLE
fix: remove unreachable null guard on localTurnRecord in registerTurn (#1412)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4496,9 +4496,6 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           };
         });
         const localSyncStatus: TurnSyncStatus = boostRequested && !localBoostApplied ? 'failed_boost_fallback' : 'synced';
-        if (!localTurnRecord) {
-          return { ok: false, error: 'Impossibile registrare il turno in locale.' };
-        }
         setTurnSyncFeedback({
           syncStatus: localSyncStatus,
           boostRequested,


### PR DESCRIPTION
## Summary

- Removes the dead-code `if (!localTurnRecord)` check in the offline path of `registerTurn`
- `localTurnRecord` is declared as `TurnRecord` (non-nullable) and initialised by `buildTurnRecordFromPayload`; the null check can never be true and was misleading future readers about the function's possible return values

## Changes

`apps/mobile/src/state/store.tsx` — delete the unreachable `if (!localTurnRecord) return { ok: false, ... }` block.

## Test plan

- [ ] Offline turn registration succeeds and returns `{ ok: true }` as before (no regression)

Closes #1412

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXCZdWQrWsLDckZyKrUoHY)_