### PR TITLE
fix: return clear error from invokeTicketActivation when Supabase unconfigured (#1415)

### DIFF
--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -280,7 +280,10 @@ async function getAccessTokenForFunctions(): Promise<string> {
 
 async function invokeTicketActivation(body: Record<string, unknown>) {
   if (!supabase || !isSupabaseConfigured) {
-    return { data: null, error: null };
+    // Return a descriptive error rather than { data: null, error: null }, which
+    // callers would misinterpret as a successful call with no reservation and
+    // could surface a misleading "ticket già presente" error (closes #1415).
+    return { data: null, error: new Error('Supabase non configurato') };
   }
 
   const token = await getAccessTokenForFunctions();


### PR DESCRIPTION
## Summary

- Changes `invokeTicketActivation` to return `{ data: null, error: new Error('Supabase non configurato') }` instead of `{ data: null, error: null }` when Supabase is not configured
- The previous `{ error: null }` response was indistinguishable from a successful call that returned no data; callers could misinterpret `data: null` as `reserved: false` and surface a misleading "ticket già presente" error
- The explicit error propagates a clear message to any caller that reaches this path without its own guard

## Changes

`apps/mobile/src/services/ticket-activation.ts` — replace silent `{ data: null, error: null }` with `{ data: null, error: new Error('Supabase non configurato') }`.

## Test plan

- [ ] Supabase configured: `invokeTicketActivation` behaves as before
- [ ] Supabase unconfigured: callers receive an `Error` rather than silently treating `data: null` as a failed reservation

Closes #1415

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXCZdWQrWsLDckZyKrUoHY)_