### PR TITLE
fix: warn when import-atcl-lazio hits MAX_PAGES with posts remaining (#1416)

### DIFF
--- a/supabase/functions/import-atcl-lazio/index.ts
+++ b/supabase/functions/import-atcl-lazio/index.ts
@@ -191,6 +191,14 @@ async function fetchShowPosts(categoryId: number, modifiedAfter: string): Promis
     if (!Array.isArray(batch) || batch.length === 0) break;
     posts.push(...batch);
     if (batch.length < POSTS_PER_PAGE) break;
+    if (page === MAX_PAGES) {
+      // The last page was full — there may be additional posts beyond the cap.
+      // Log so operators know results were truncated (closes #1416).
+      console.warn(
+        `[import-atcl-lazio] fetchShowPosts reached MAX_PAGES=${MAX_PAGES} with a full batch; ` +
+        `posts beyond page ${MAX_PAGES} × ${POSTS_PER_PAGE} = ${MAX_PAGES * POSTS_PER_PAGE} were silently dropped.`,
+      );
+    }
   }
   return posts;
 }


### PR DESCRIPTION
## Summary

- Adds a `console.warn` when `fetchShowPosts` exits the loop because it reached `MAX_PAGES` with a full batch still in hand
- Previously the truncation was silent; operators had no way to know posts beyond page 20 × 50 = 1000 were dropped
- The warning includes the cap values so the operator knows exactly how many posts may be missing

## Changes

`supabase/functions/import-atcl-lazio/index.ts` — add warning log inside the `page === MAX_PAGES` branch when the last batch was full.

## Test plan

- [ ] < 1000 posts available: loop exits normally with no warning
- [ ] ≥ 1000 posts available: warning is logged on the final full-batch page; no crash

Closes #1416

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXCZdWQrWsLDckZyKrUoHY)_