### PR TITLE
fix: add HTTP method guard to cleanup-events function

### DIFF
--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -15,6 +15,13 @@ serve(async (req) => {
     return new Response('ok', { headers: corsHeaders })
   }
 
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 405,
+    })
+  }
+
   try {
     const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? ''
     const anonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? ''


### PR DESCRIPTION
Closes #1425

## Problem

The `cleanup-events` edge function had no HTTP method guard after the CORS preflight check. This meant any authenticated admin could trigger bulk event deletion via a GET request (or any other HTTP method), which is unsafe — only POST should trigger the destructive cleanup operation.

## Fix

Added an explicit method check immediately after the OPTIONS/CORS handler. Any request that is not `POST` receives a `405 Method Not Allowed` response before any authentication or deletion logic is executed.

## Testing

- POST requests by authenticated admins: continue to work as before
- GET/DELETE/PUT/PATCH requests (even by admins): receive 405 before touching any data
- OPTIONS preflight: unaffected (handled before the method guard)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQbAJwQpACHqSYAoWpeULr)_