### PR TITLE
fix: apply MAX_TURNS cap to initial remote turn fetch in loadRemoteState

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3986,7 +3986,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
                 completedCourses: profileRow.completed_courses ?? prev.profile.completedCourses,
               },
               eventPlans: prev.eventPlans,
-              turns: remoteTurns,
+              turns: remoteTurns.slice(0, MAX_TURNS),
             }));
           }
 


### PR DESCRIPTION
Closes #1426

## Problem

In `loadRemoteState` (store.tsx), up to 500 turns were fetched from Supabase and stored directly into state via `setState` without applying the `MAX_TURNS=20` cap. This caused inconsistent stats and unbounded state growth on long-running devices, since subsequent incremental updates correctly cap to 20 but the initial hydration did not.

## Fix

Applied `remoteTurns.slice(0, MAX_TURNS)` before storing the fetched turns in state, consistent with how the cap is applied elsewhere in the store.

## Testing

- On first load, state.turns is bounded to at most 20 entries
- Stats computed from turns (totalTurns, turnsThisMonth, etc.) are consistent between initial load and subsequent updates

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQbAJwQpACHqSYAoWpeULr)_