### PR TITLE
fix: use catalogRolesRef in updateProfile setState updater to avoid stale closure

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -2386,10 +2386,12 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   // without being recreated on every shop purchase.
   const extraActivitySlotsRef = useRef(state.profile.extraActivitySlots);
   const catalogEventsRef = useRef(catalog.events);
+  const catalogRolesRef = useRef(catalog.roles);
   const profileRoleIdRef = useRef(state.profile.roleId);
   useEffect(() => { eventPlansRef.current = state.eventPlans; }, [state.eventPlans]);
   useEffect(() => { extraActivitySlotsRef.current = state.profile.extraActivitySlots; }, [state.profile.extraActivitySlots]);
   useEffect(() => { catalogEventsRef.current = catalog.events; }, [catalog.events]);
+  useEffect(() => { catalogRolesRef.current = catalog.roles; }, [catalog.roles]);
   useEffect(() => { profileRoleIdRef.current = state.profile.roleId; }, [state.profile.roleId]);
 
   const syncLocalEventPlanning = useCallback(
@@ -4349,7 +4351,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       const nextProfileRef: { current: PlayerProfile | null } = { current: null };
       setState((prev: GameState) => {
         const nextRole =
-          updates.roleId && catalog.roles.some((role: Role) => role.id === updates.roleId)
+          updates.roleId && catalogRolesRef.current.some((role: Role) => role.id === updates.roleId)
             ? updates.roleId
             : prev.profile.roleId;
         const next: PlayerProfile = { ...prev.profile, ...updates, roleId: nextRole ?? prev.profile.roleId };
@@ -4358,7 +4360,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       });
       if (nextProfileRef.current) persistProfile(nextProfileRef.current);
     },
-    [catalog.roles, persistProfile]
+    [persistProfile]
   );
 
   const registerTurn = useCallback(


### PR DESCRIPTION
Closes #1427

## Problem

In `updateProfile`, `catalog.roles` was captured from the outer scope inside the `setState` updater callback. If the catalog refreshed concurrently (e.g., a remote catalog reload completes while the user updates their profile), the role validation inside `setState` would use the stale `catalog.roles` from the closure rather than the up-to-date roles list.

## Fix

Added a `catalogRolesRef` (a `useRef` kept in sync with `catalog.roles` via a `useEffect`), following the exact same pattern already used for `catalogEventsRef`. The `setState` updater in `updateProfile` now reads `catalogRolesRef.current` instead of the outer `catalog.roles` variable. The `useCallback` dependency array is simplified to remove `catalog.roles` since the ref eliminates the need to recreate the callback when roles change.

## Testing

- Role validation in `updateProfile` now uses the latest roles list even under concurrent catalog refreshes
- The `updateProfile` callback is no longer recreated on every catalog refresh, reducing unnecessary re-renders

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQbAJwQpACHqSYAoWpeULr)_