### PR TITLE
fix: log and surface getUser() network errors in dev-gate

### DIFF
--- a/apps/pwa/src/services/dev-gate.ts
+++ b/apps/pwa/src/services/dev-gate.ts
@@ -115,11 +115,18 @@ export async function requireDevAccess(): Promise<boolean> {
     return false;
   }
 
-  const { data } = await supabase.auth.getUser();
+  const { data, error: getUserError } = await supabase.auth.getUser();
+  if (getUserError) {
+    console.error("[dev-gate] getUser() failed:", getUserError);
+  }
   if (isUserAllowed(data.user)) return true;
 
   const gate = renderGate(root);
-  if (data.user) setMessage(gate.message, "Account non autorizzato per la dev dashboard.", "error");
+  if (getUserError) {
+    setMessage(gate.message, "Errore di rete: impossibile verificare la sessione. Riprova.", "error");
+  } else if (data.user) {
+    setMessage(gate.message, "Account non autorizzato per la dev dashboard.", "error");
+  }
 
   return new Promise<boolean>((resolve) => {
     const onSubmit = async (e: Event) => {


### PR DESCRIPTION
Closes #1428

## Problem

In `requireDevAccess` (dev-gate.ts), the `error` return value from `supabase.auth.getUser()` was ignored entirely. When a network error occurred, the function silently returned `false`, locking valid developers out of the dev dashboard with no indication of what went wrong — indistinguishable from a legitimately unauthorized session.

## Fix

- Destructured `error` from the `getUser()` result
- Added `console.error` logging so the error is visible in DevTools
- Added a distinct user-facing message in the gate UI distinguishing between network errors ("Errore di rete: impossibile verificare la sessione. Riprova.") and unauthorized accounts ("Account non autorizzato per la dev dashboard.")

The function still returns `false` in both cases (preserving the security invariant that access is denied on any failure), but the error is now surfaced rather than swallowed.

## Testing

- Network error during `getUser()`: gate shown with retry message; error logged to console
- Unauthorized account: gate shown with authorization error message (unchanged behavior)
- Authorized account: immediate access granted (unchanged behavior)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQbAJwQpACHqSYAoWpeULr)_