### PR TITLE
fix: wrap cleanup-events DELETEs in a single transactional RPC

### DIFF
--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -122,16 +122,11 @@ serve(async (req) => {
 
     const eventIds = eventsToDelete.map(e => e.id)
 
-    // Re-verify that the events still exist immediately before deleting child rows
-    // to narrow the TOCTOU window between the initial SELECT and the DELETE pair
-    // (closes #1382). A concurrent cleanup run or manual deletion between the two
-    // steps could otherwise cause ticket_activations to be deleted for events that
-    // a concurrent process already removed — or leave ticket_activations orphaned
-    // if the events DELETE later fails.
-    //
-    // Note: true atomicity requires a PostgreSQL RPC that wraps both DELETEs in a
-    // single transaction. This guard reduces — but does not eliminate — the race
-    // window without requiring a schema change.
+    // Re-verify that the events still exist immediately before deletion to narrow
+    // the TOCTOU window between the initial SELECT and the RPC call (closes #1382).
+    // A concurrent cleanup run could remove some events between the two steps;
+    // operating on the confirmed subset avoids deleting ticket_activations for
+    // events already gone.
     const { data: stillExistingEvents, error: reVerifyError } = await supabaseClient
       .from('events')
       .select('id')
@@ -154,27 +149,15 @@ serve(async (req) => {
       )
     }
 
-    // Delete ticket_activations first: this table references events.id via FK
-    // without ON DELETE CASCADE, so it must be removed before the parent rows
-    // are deleted to avoid a FK violation that would fail the whole batch.
-    // We operate only on the confirmed subset to minimise the blast radius if
-    // the events DELETE subsequently fails.
-    const { error: activationsError } = await supabaseClient
-      .from('ticket_activations')
-      .delete()
-      .in('event_id', confirmedEventIds)
+    // Delete ticket_activations and events atomically via a single PostgreSQL RPC.
+    // The cleanup_expired_events function executes both DELETEs inside one
+    // implicit PL/pgSQL transaction, so a failure in either statement rolls back
+    // the entire operation and avoids leaving the DB in a corrupt state
+    // (closes #1434).
+    const { error: cleanupError } = await supabaseClient
+      .rpc('cleanup_expired_events', { event_ids: confirmedEventIds })
 
-    if (activationsError) throw activationsError
-
-    // Delete events. The planned_participations FK is defined with
-    // ON DELETE CASCADE, so the DB automatically removes those child rows when
-    // the parent event is deleted.
-    const { error: deleteError } = await supabaseClient
-      .from('events')
-      .delete()
-      .in('id', confirmedEventIds)
-
-    if (deleteError) throw deleteError
+    if (cleanupError) throw cleanupError
 
     const confirmedDeleted = eventsToDelete.filter(e => confirmedEventIds.includes(e.id))
     return new Response(

--- a/supabase/migrations/20260711000000_cleanup_events_rpc.sql
+++ b/supabase/migrations/20260711000000_cleanup_events_rpc.sql
@@ -1,0 +1,32 @@
+-- Migration: Add cleanup_expired_events RPC for atomic transactional deletion
+-- Created: 2026-07-11
+-- Closes: #1434
+--
+-- The cleanup-events edge function previously issued two sequential DELETEs
+-- (ticket_activations, then events) as separate Supabase client calls.
+-- If the second DELETE failed after the first committed, the DB was left in a
+-- corrupt state (orphaned ticket_activations rows deleted, events still present).
+-- This RPC wraps both DELETEs inside a single PL/pgSQL function, which
+-- PostgreSQL executes within one implicit transaction, guaranteeing atomicity.
+
+CREATE OR REPLACE FUNCTION public.cleanup_expired_events(event_ids text[])
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Remove child rows first to satisfy the FK constraint on ticket_activations.event_id.
+  -- (ticket_activations also has ON DELETE CASCADE, but we delete explicitly here
+  -- so both operations share the same transaction and any failure rolls back both.)
+  DELETE FROM public.ticket_activations WHERE event_id = ANY(event_ids);
+
+  -- Remove the parent event rows. The planned_participations FK already carries
+  -- ON DELETE CASCADE, so those child rows are handled automatically by Postgres.
+  DELETE FROM public.events WHERE id = ANY(event_ids);
+END;
+$$;
+
+-- Restrict execution to the service role used by edge functions.
+REVOKE ALL ON FUNCTION public.cleanup_expired_events(text[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.cleanup_expired_events(text[]) TO service_role;


### PR DESCRIPTION
Closes #1434

The `cleanup-events` edge function previously issued two sequential Supabase client DELETE calls — one on `ticket_activations`, then one on `events`. If the second DELETE failed after the first had already committed, the database would be left in a corrupt state: ticket activations gone but their parent events still present.

**Fix:**
- Added migration `20260711000000_cleanup_events_rpc.sql` that creates a `cleanup_expired_events(event_ids text[])` PL/pgSQL function. Because it executes inside a single implicit PostgreSQL transaction, either both DELETEs commit or both roll back.
- Updated the edge function to call `supabase.rpc('cleanup_expired_events', { event_ids: confirmedEventIds })` instead of the two sequential client-level DELETEs.
- Updated the stale comment that incorrectly described the operation as non-transactional.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDHCf9H16hDzv43PpubxL8)_