### PR TITLE
fix: remove dead 'acutee' typo entry from HTML_ENTITIES map

### DIFF
--- a/supabase/functions/import-atcl-lazio/index.ts
+++ b/supabase/functions/import-atcl-lazio/index.ts
@@ -57,7 +57,7 @@ function parseTime(text: string): string | null {
 
 const HTML_ENTITIES: Record<string, string> = {
   amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',
-  agrave: 'à', aacute: 'á', acutee: 'é', egrave: 'è', eacute: 'é',
+  agrave: 'à', aacute: 'á', egrave: 'è', eacute: 'é',
   igrave: 'ì', iacute: 'í', ograve: 'ò', oacute: 'ó', ugrave: 'ù', uacute: 'ú',
   Agrave: 'À', Aacute: 'Á', Egrave: 'È', Eacute: 'É',
   Igrave: 'Ì', Iacute: 'Í', Ograve: 'Ò', Oacute: 'Ó', Ugrave: 'Ù', Uacute: 'Ú',


### PR DESCRIPTION
Closes #1435

The `HTML_ENTITIES` map in the `import-atcl-lazio` edge function contained a misspelled entry `acutee: 'é'`. The correct HTML entity name for `é` is `eacute`, which was already present in the same map immediately after. The `acutee` key can never be matched by any valid HTML entity reference, making it dead unreachable code.

**Fix:** Remove the `acutee: 'é'` entry. The correct `eacute: 'é'` mapping remains.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDHCf9H16hDzv43PpubxL8)_