### PR TITLE
fix: guard QRScanner resume timeout with mounted-ref to prevent setState after unmount

### DIFF
--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -65,11 +65,11 @@ export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
       if (isAuthErrorMessage(message)) { stopCamera(); shouldResume = false; }
     } finally {
       if (!shouldResume) { setIsHandlingScan(false); }
-      else {
-        // Guard: if the component unmounted while handleScanAttempt was in
-        // flight, do not schedule a new timeout — it would never be cleared
-        // and would call setState on an unmounted component (closes #1436).
-        if (!isMountedRef.current) return;
+      else if (isMountedRef.current) {
+        // Only schedule the resume timeout when the component is still mounted.
+        // If it has already unmounted, skipping this prevents a leaked timeout
+        // that would never be cleared and would call setState on an unmounted
+        // component (closes #1436).
         if (resumeTimeoutRef.current != null) { window.clearTimeout(resumeTimeoutRef.current); resumeTimeoutRef.current = null; }
         resumeTimeoutRef.current = window.setTimeout(() => {
           if (!isMountedRef.current) return;

--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -30,9 +30,15 @@ export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
   const resumeScanRef = useRef<(() => void) | null>(null);
   const onScanRef = useRef(onScan);
   const isScanningRef = useRef(isScanning);
+  // Tracks whether the component is still mounted. Checked before scheduling
+  // the resume timeout in handleScanAttempt's finally block so that a timeout
+  // created while an async scan was in-flight cannot call setState after the
+  // component has unmounted (closes #1436).
+  const isMountedRef = useRef(true);
 
   useEffect(() => { onScanRef.current = onScan; }, [onScan]);
   useEffect(() => { isScanningRef.current = isScanning; }, [isScanning]);
+  useEffect(() => { return () => { isMountedRef.current = false; }; }, []);
 
   const stopCamera = () => {
     if (scanTimeoutRef.current) clearTimeout(scanTimeoutRef.current); scanTimeoutRef.current = null;
@@ -60,8 +66,13 @@ export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
     } finally {
       if (!shouldResume) { setIsHandlingScan(false); }
       else {
+        // Guard: if the component unmounted while handleScanAttempt was in
+        // flight, do not schedule a new timeout — it would never be cleared
+        // and would call setState on an unmounted component (closes #1436).
+        if (!isMountedRef.current) return;
         if (resumeTimeoutRef.current != null) { window.clearTimeout(resumeTimeoutRef.current); resumeTimeoutRef.current = null; }
         resumeTimeoutRef.current = window.setTimeout(() => {
+          if (!isMountedRef.current) return;
           setIsHandlingScan(false);
           if (isScanningRef.current) { setScanError(null); hasHandledScanRef.current = false; resumeScanRef.current?.(); }
         }, 1200);


### PR DESCRIPTION
Closes #1436

If the `QRScanner` component unmounted while `handleScanAttempt` was awaiting its async `onScan` call, the `finally` block would unconditionally schedule a `window.setTimeout`. Because cleanup (`stopCamera`) had already run at that point, the timeout was never cleared and would fire later — calling `setIsHandlingScan`, `setScanError`, etc. on an unmounted component.

**Fix:**
- Added `isMountedRef = useRef(true)` to track mount state.
- Added a cleanup `useEffect` that sets `isMountedRef.current = false` on unmount.
- In the `finally` block, added an early-return guard (`if (!isMountedRef.current) return`) before scheduling the resume timeout.
- Added a second guard inside the timeout callback so that even if the timeout fires in a narrow race window it will not call any setState.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDHCf9H16hDzv43PpubxL8)_