### PR TITLE
Fix: guard supabase.getUser() to avoid AuthSessionMissingError

### DIFF
--- a/apps/pwa/src/services/dev-gate.ts
+++ b/apps/pwa/src/services/dev-gate.ts
@@ -115,9 +115,19 @@ export async function requireDevAccess(): Promise<boolean> {
     return false;
   }
 
-  const { data, error: getUserError } = await supabase.auth.getUser();
-  if (getUserError) {
-    console.error("[dev-gate] getUser() failed:", getUserError);
+  // Avoid calling getUser() when no session exists — this can throw AuthSessionMissingError.
+  const sessionRes = await supabase.auth.getSession();
+  const session = sessionRes.data?.session ?? null;
+  let getUserError: any = null;
+  let data: { user: User | null } = { user: null };
+  if (session) {
+    const getUserRes = await supabase.auth.getUser();
+    getUserError = getUserRes.error;
+    data = getUserRes.data ?? { user: null };
+    if (getUserError) {
+      // Only log unexpected errors; missing session is expected and not an application error.
+      console.error("[dev-gate] getUser() failed:", getUserError);
+    }
   }
   if (isUserAllowed(data.user)) return true;
 


### PR DESCRIPTION
This PR guards calls to supabase.auth.getUser() by checking for an existing session first. When no session is present Supabase may throw an AuthSessionMissingError which generated console errors detected by automated console audits. The change avoids noisy console errors and treats missing sessions as unauthenticated flows.

Changes:
- apps/pwa/src/services/dev-gate.ts: check supabase.auth.getSession() before calling getUser(), only log unexpected errors.

Manual testing:
- Verified no type errors locally and pushed branch.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>