### PR TITLE
fix: remove GET from Access-Control-Allow-Methods in cleanup-events

### DIFF
--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -7,7 +7,7 @@ const allowedOrigin = Deno.env.get('SITE_URL') ?? 'https://turnidipalco.it';
 const corsHeaders = {
   'Access-Control-Allow-Origin': allowedOrigin,
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
 }
 
 serve(async (req) => {


### PR DESCRIPTION
Closes #1443

## Summary
- Removed `GET` from the `Access-Control-Allow-Methods` CORS header in `supabase/functions/cleanup-events/index.ts`.
- The function already rejects non-POST requests with a 405, so advertising GET in the preflight response was misleading and caused browsers to attempt GET requests that would always fail.

## Test plan
- [ ] Manually verify that OPTIONS preflight no longer lists GET
- [ ] Verify that POST requests still work correctly
- [ ] Verify that GET requests receive 405 (not a CORS failure)

---
_Generated by [Claude Code](https://claude.ai/code/session_0121M8Bt3xCgELTLvvRovtsk)_