### PR TITLE
fix: add activated_by IS NULL filter to reserved_by ticket deletion

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -84,7 +84,14 @@ serve(async (req) => {
   let failedTable: string | null = null;
 
   for (const { table, key } of tablesToDelete) {
-    const { error } = await adminClient.from(table).delete().eq(key, userId);
+    // For the reserved_by pass, skip rows already activated by another user so
+    // their attendance record is preserved (fixes #1444).
+    const baseQuery = adminClient.from(table).delete().eq(key, userId);
+    const deleteQuery =
+      table === 'ticket_activations' && key === 'reserved_by'
+        ? baseQuery.is('activated_by', null)
+        : baseQuery;
+    const { error } = await deleteQuery;
     if (error) {
       console.error(`delete-my-account: error deleting from ${table} (key: ${key})`, error.message);
       failedTable = `${table}.${key}`;


### PR DESCRIPTION
Closes #1444

## Summary
- In `supabase/functions/delete-my-account/index.ts`, the `reserved_by` deletion step previously deleted all `ticket_activations` rows where `reserved_by = userId`, including rows where another user had already activated the ticket.
- Added `.is('activated_by', null)` filter to the `reserved_by` pass, so only unactivated tickets are removed. Rows activated by other users are preserved, protecting their attendance records.

## Test plan
- [ ] Verify that deleting an account removes unactivated tickets reserved by that user
- [ ] Verify that tickets already activated by another user are NOT deleted when the reserving admin's account is removed

---
_Generated by [Claude Code](https://claude.ai/code/session_0121M8Bt3xCgELTLvvRovtsk)_