### PR TITLE
fix: route email-confirmation success message through authInfo state

### DIFF
--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -164,7 +164,7 @@ export function AppShell() {
   );
 
   // Auth hook
-  const { authError, setAuthError, isDemoMode, handleLogin, handleSignup, handleLogout, markVoluntaryLogout, unmarkVoluntaryLogout } = useAuth(
+  const { authError, setAuthError, authInfo, isDemoMode, handleLogin, handleSignup, handleLogout, markVoluntaryLogout, unmarkVoluntaryLogout } = useAuth(
     state.profile,
     updateProfile,
     (screen, isRecovery) => {
@@ -501,7 +501,7 @@ export function AppShell() {
         return <Login onBack={() => nav.navigate('welcome')} onLogin={handleLogin} onSignup={() => nav.navigate('signup')} onForgotPassword={() => nav.navigate('change-password')} errorMessage={authError} />;
 
       case 'signup':
-        return <Signup onBack={() => nav.navigate('welcome')} onSignup={handleSignup} onLogin={() => nav.navigate('login')} onViewTerms={() => nav.openLegal('terms', 'signup')} onViewPrivacy={() => nav.openLegal('privacy', 'signup')} errorMessage={authError} />;
+        return <Signup onBack={() => nav.navigate('welcome')} onSignup={handleSignup} onLogin={() => nav.navigate('login')} onViewTerms={() => nav.openLegal('terms', 'signup')} onViewPrivacy={() => nav.openLegal('privacy', 'signup')} errorMessage={authError} infoMessage={authInfo} />;
 
       case 'install':
         return <InstallApp onContinue={() => nav.navigate(state.profile.roleId ? 'home' : 'welcome')} onDismiss={() => nav.navigate(state.profile.roleId ? 'home' : 'welcome')} />;

--- a/apps/mobile/src/components/screens/Signup.tsx
+++ b/apps/mobile/src/components/screens/Signup.tsx
@@ -12,9 +12,11 @@ interface SignupProps {
   onViewTerms: () => void;
   onViewPrivacy: () => void;
   errorMessage?: string | null;
+  /** Non-error informational message (e.g. "check your email" after signup). */
+  infoMessage?: string | null;
 }
 
-export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, errorMessage }: SignupProps) {
+export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, errorMessage, infoMessage }: SignupProps) {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [birthDate, setBirthDate] = useState('');
@@ -115,6 +117,9 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
 
           {(errorMessage || submitError) && (
             <p className="text-sm text-[#ff4d4f] text-center">{submitError ?? errorMessage}</p>
+          )}
+          {infoMessage && !errorMessage && !submitError && (
+            <p className="text-sm text-[#52c41a] text-center">{infoMessage}</p>
           )}
 
           <Button type="submit" fullWidth disabled={isSubmitting} className={isSubmitting ? 'opacity-50 pointer-events-none' : ''}>

--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -73,6 +73,7 @@ export function useAuth(
     onLogout: () => void
 ) {
     const [authError, setAuthError] = useState<string | null>(null);
+    const [authInfo, setAuthInfo] = useState<string | null>(null);
     const [isDemoMode, setIsDemoMode] = useState(false);
 
     const handleLogin = useCallback(async (email: string, password: string) => {
@@ -110,6 +111,7 @@ export function useAuth(
 
     const handleSignup = useCallback(async (name: string, email: string, password: string, isMinor = false) => {
         setAuthError(null);
+        setAuthInfo(null);
         if (!isSupabaseConfigured || !supabase) {
             setIsDemoMode(true);
             updateProfile({ name, email });
@@ -134,9 +136,11 @@ export function useAuth(
         }
 
         // When email confirmation is required, data.session is null — the user
-        // has not signed in yet. Show a "check your email" message and stop.
+        // has not signed in yet. Show an informational (non-error) message and
+        // stop. Using setAuthInfo instead of setAuthError prevents this success
+        // message from being rendered with error styling (fixes #1446).
         if (!data.session) {
-            setAuthError('Registrazione quasi completata! Controlla la tua email per confermare l\'account.');
+            setAuthInfo('Registrazione quasi completata! Controlla la tua email per confermare l\'account.');
             return;
         }
 
@@ -302,6 +306,8 @@ export function useAuth(
     return {
         authError,
         setAuthError,
+        authInfo,
+        setAuthInfo,
         isDemoMode,
         handleLogin,
         handleSignup,


### PR DESCRIPTION
Closes #1446

## Summary
- Added `authInfo` / `setAuthInfo` state to `useAuth.ts` alongside the existing `authError` / `setAuthError`.
- In `handleSignup`, when email confirmation is required (no immediate session), the "Registrazione quasi completata!" message is now routed through `setAuthInfo` instead of `setAuthError`, so it no longer renders with error styling.
- `authInfo` is exposed from the hook's return value and destructured in `AppShell.tsx`, which passes it to `<Signup>` as the new `infoMessage` prop.
- `Signup.tsx`: added optional `infoMessage` prop; renders it in green (`text-[#52c41a]`) when no error is active, giving it distinct informational/success styling.

## Test plan
- [ ] Sign up with a new email that requires email confirmation — verify the "Registrazione quasi completata!" banner is displayed in green (not red)
- [ ] Trigger a signup error (e.g. weak password) — verify it still renders in red as before
- [ ] Verify the existing error/success messages on the login screen are unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_0121M8Bt3xCgELTLvvRovtsk)_