### PR TITLE
fix: replace window.setTimeout/clearTimeout with globals in checkAiSupportAvailability

### DIFF
--- a/apps/mobile/src/services/ai.ts
+++ b/apps/mobile/src/services/ai.ts
@@ -249,7 +249,7 @@ export async function checkAiSupportAvailability({
   return withMobileWatchdog(async () => {
     const target = resolveHealthEndpoint(resolveEndpoint(endpoint));
     const controller = new AbortController();
-    const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
       const response = await fetch(target, {
@@ -261,7 +261,7 @@ export async function checkAiSupportAvailability({
     } catch {
       return 'unknown';
     } finally {
-      window.clearTimeout(timeout);
+      clearTimeout(timeout);
     }
   }, {
     operation: 'checkAiSupportAvailability',


### PR DESCRIPTION
## Summary

- Replaces `window.setTimeout` / `window.clearTimeout` with the global `setTimeout` / `clearTimeout` in `checkAiSupportAvailability` (`apps/mobile/src/services/ai.ts`)
- The global equivalents are available in browser, Node, Deno, and Capacitor pre-init contexts; `window.*` variants throw `ReferenceError` in any non-browser environment

Closes #1454

---
_Generated by [Claude Code](https://claude.ai/code/session_019tdYPisipW91h7sXcjnV42)_