### PR TITLE
fix: always use 'sconosciuto' fallback for non-allowlisted roleId in Maxwell prompt

### DIFF
--- a/apps/mobile/src/gameplay/narrative.ts
+++ b/apps/mobile/src/gameplay/narrative.ts
@@ -308,7 +308,7 @@ const SAFE_FLAG_PATTERN = /^[a-z][a-z0-9_]{0,59}$/;
 
 function buildSceneGenerationPrompt(ctx: NarrativeContext): string {
   const role = sanitizePromptValue(
-    (ctx.roleId && SAFE_ROLE_IDS.has(ctx.roleId)) ? ctx.roleId : (ctx.roleId ?? 'sconosciuto'),
+    (ctx.roleId && SAFE_ROLE_IDS.has(ctx.roleId)) ? ctx.roleId : 'sconosciuto',
   );
   const stats = ctx.stats
     ? `presenza=${ctx.stats.presence}, precisione=${ctx.stats.precision}, leadership=${ctx.stats.leadership}, creatività=${ctx.stats.creativity}`


### PR DESCRIPTION
## Summary

- Fixes an incomplete prompt-injection guard in `buildSceneGenerationPrompt` (`apps/mobile/src/gameplay/narrative.ts`)
- The previous ternary fell back to `(ctx.roleId ?? 'sconosciuto')` which, when `ctx.roleId` is non-null but not in `SAFE_ROLE_IDS`, evaluated to the raw `ctx.roleId` value — bypassing sanitization and embedding it verbatim in the Maxwell LLM prompt
- Fix: remove the `ctx.roleId ??` prefix so the fallback is always the safe literal `'sconosciuto'`

Closes #1452

---
_Generated by [Claude Code](https://claude.ai/code/session_019tdYPisipW91h7sXcjnV42)_