### PR TITLE
fix: nullify reserved_by UUID in activated tickets on account deletion (GDPR Art. 17)

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -99,6 +99,24 @@ serve(async (req) => {
     }
   }
 
+  // Nullify reserved_by in ticket_activations rows that were preserved because
+  // another user activated the ticket. The delete pass above only removes rows
+  // where activated_by IS NULL; rows with activated_by set are kept so the
+  // activating user's attendance record survives, but they still contain the
+  // deleted user's UUID in reserved_by — a GDPR Art. 17 compliance gap.
+  if (failedTable === null) {
+    const { error: nullifyError } = await adminClient
+      .from('ticket_activations')
+      .update({ reserved_by: null })
+      .eq('reserved_by', userId)
+      .not('activated_by', 'is', null);
+    if (nullifyError) {
+      console.error('delete-my-account: failed to nullify reserved_by on activated tickets', nullifyError.message);
+      // Non-fatal: the attendance records for other users must be preserved.
+      // Log and continue so that the auth user is still deleted.
+    }
+  }
+
   // Abort before deleting auth user if any table deletion failed.
   // Stopping at the first failure preserves subsequent tables so the user
   // can retry without ending up in a worse partial-deletion state.


### PR DESCRIPTION
## Summary

- After the existing `DELETE` loop in `delete-my-account`, adds a non-fatal `UPDATE` pass that sets `reserved_by = null` for `ticket_activations` rows where `activated_by IS NOT NULL`
- These rows are intentionally preserved (to keep the activating user's attendance record) but previously still contained the deleted user's UUID in `reserved_by` — a GDPR Art. 17 compliance gap
- The nullify step is non-fatal: if it fails, the error is logged but account deletion proceeds so the auth user is still removed

Closes #1451

---
_Generated by [Claude Code](https://claude.ai/code/session_019tdYPisipW91h7sXcjnV42)_