### PR TITLE
fix(dev-gate): abort in-flight auth controller on cancel (#1461)

### DIFF
--- a/apps/pwa/src/services/dev-gate.ts
+++ b/apps/pwa/src/services/dev-gate.ts
@@ -139,6 +139,10 @@ export async function requireDevAccess(): Promise<boolean> {
   }
 
   return new Promise<boolean>((resolve) => {
+    // Shared ref so onCancel can abort an in-flight auth request. Without this,
+    // a successful sign-in after cancel clears root.innerHTML leaving a blank page.
+    let activeController: AbortController | null = null;
+
     const onSubmit = async (e: Event) => {
       e.preventDefault();
 
@@ -151,6 +155,7 @@ export async function requireDevAccess(): Promise<boolean> {
       setMessage(gate.message, "Verifico le credenziali...", "info");
 
       const controller = new AbortController();
+      activeController = controller;
       const timeoutId = setTimeout(() => controller.abort(new Error("timeout")), 15_000);
       const abortPromise = new Promise<never>((_, reject) => {
         controller.signal.addEventListener("abort", () => reject(controller.signal.reason), { once: true });
@@ -217,6 +222,7 @@ export async function requireDevAccess(): Promise<boolean> {
     };
 
     const onCancel = () => {
+      activeController?.abort(new Error("cancelled"));
       gate.form.removeEventListener("submit", onSubmit);
       gate.cancelButton.removeEventListener("click", onCancel);
       resolve(false);


### PR DESCRIPTION
## Intent

Fix a race condition in `apps/pwa/src/services/dev-gate.ts` where clicking **Annulla** while a sign-in request was in flight could result in a blank page.

Closes #1461.

## Key changes

- Hoist `let activeController: AbortController | null = null` to the `Promise` constructor scope, shared between `onSubmit` and `onCancel`.
- In `onSubmit`, assign `activeController = controller` immediately after the `AbortController` is created.
- In `onCancel`, call `activeController?.abort(new Error("cancelled"))` before resolving the promise with `false`.

The existing `catch` block in `onSubmit` already handles `err.message === "cancelled"` correctly (calls `resetBusy()`, clears the message, does not touch `root.innerHTML`), so no further changes are needed.

## Root cause

`onCancel` previously had no reference to the `AbortController` created inside `onSubmit`. If the user clicked cancel while authentication was in flight, `resolve(false)` fired (caller skipped dashboard render), but the in-flight `Promise.race` kept running. When it eventually resolved successfully, the `try` block reached `root.innerHTML = ""` — clearing the page — with no subsequent `renderDashboard` call, leaving a blank screen.

## Testing

- Trigger the dev gate login form.
- Enter credentials and click **Annulla** immediately before the auth response arrives.
- Previously: blank page if auth succeeded after cancel.
- After fix: cancel aborts the request; catch block resets the form cleanly; caller receives `false` and the gate remains visible (or caller's own cancel handling runs).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcLhfUWaWHZiCuTPf8BKjL)_