### PR TITLE
fix: add ref guard to EventConfirmation.handleConfirm to prevent double turn registration

### DIFF
--- a/apps/mobile/src/components/screens/EventConfirmation.tsx
+++ b/apps/mobile/src/components/screens/EventConfirmation.tsx
@@ -31,6 +31,7 @@ export function EventConfirmation({
   const [confirmResult, setConfirmResult] = useState<Extract<ConfirmTurnResult, { ok: true }> | null>(null);
   const [confirmError, setConfirmError] = useState<string | null>(null);
   const successTimeoutRef = useRef<number | null>(null);
+  const isSubmittingRef = useRef(false);
 
   useEffect(() => {
     return () => {
@@ -53,7 +54,8 @@ export function EventConfirmation({
   const { feedbackTitle, feedbackMessage } = useMemo(() => buildFeedback(confirmResult), [confirmResult]);
 
   const handleConfirm = async () => {
-    if (isSubmitting || isSuccess) return;
+    if (isSubmittingRef.current || isSuccess) return;
+    isSubmittingRef.current = true;
     setIsSubmitting(true);
     setConfirmError(null);
     try {
@@ -65,6 +67,7 @@ export function EventConfirmation({
     } catch (error) {
       setConfirmError(error instanceof Error ? error.message : 'Errore durante la registrazione turno.');
     } finally {
+      isSubmittingRef.current = false;
       setIsSubmitting(false);
     }
   };


### PR DESCRIPTION
Closes #1464

## Summary

- Adds `isSubmittingRef = useRef(false)` in `EventConfirmation` to act as a synchronous concurrency guard alongside the existing `isSubmitting` React state.
- The ref is checked and set **before** any await, so concurrent taps that fire in the same render cycle are dropped immediately — without waiting for a React re-render to propagate the state update.
- The ref is always reset in `finally`, matching the existing `setIsSubmitting(false)` call.

## Test plan

- [ ] Tap "Conferma turno" twice in rapid succession and verify only one `onConfirm` call is made.
- [ ] Verify the button still shows "Conferma in corso..." during the async operation.
- [ ] Verify error and success paths continue to work normally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk8hJ9ENK3rMfrSanwACWS)_