### PR TITLE
fix: add ref guard to Shop.handlePurchase to prevent double purchase

### DIFF
--- a/apps/mobile/src/components/screens/Shop.tsx
+++ b/apps/mobile/src/components/screens/Shop.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { AlertCircle, Coins, ShoppingBag, Sparkles } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
@@ -27,6 +27,7 @@ export function Shop({
 }: ShopProps) {
   const [selectedTheatre, setSelectedTheatre] = useState<string>(theatreOptions[0]?.theatre ?? '');
   const [busyItemCode, setBusyItemCode] = useState<string | null>(null);
+  const busyItemRef = useRef<string | null>(null);
   const [feedback, setFeedback] = useState<{ type: 'ok' | 'error'; message: string } | null>(null);
 
   useEffect(() => {
@@ -37,6 +38,8 @@ export function Shop({
   }, [selectedTheatre, theatreOptions]);
 
   const handlePurchase = async (item: ShopCatalogItem) => {
+    if (busyItemRef.current !== null) return;
+    busyItemRef.current = item.code;
     setBusyItemCode(item.code);
     setFeedback(null);
     try {
@@ -49,6 +52,7 @@ export function Shop({
     } catch (err) {
       setFeedback({ type: 'error', message: err instanceof Error ? err.message : 'Errore durante l\'acquisto. Riprova.' });
     } finally {
+      busyItemRef.current = null;
       setBusyItemCode(null);
     }
   };


### PR DESCRIPTION
Closes #1465

## Summary

- Adds `busyItemRef = useRef<string | null>(null)` in `Shop` as a synchronous concurrency guard alongside the existing `busyItemCode` React state.
- The ref is checked and set **before** any await, so rapid double-taps on the same (or any) purchase button are dropped immediately — before a React re-render can propagate the state update.
- Also adds `useRef` to the React import (was missing).
- The ref is always reset in `finally`, matching the existing `setBusyItemCode(null)` call.

## Test plan

- [ ] Tap "Acquista" twice in rapid succession and verify only one `onPurchase` call is made.
- [ ] Verify that tapping a different item while one purchase is in-flight is also blocked.
- [ ] Verify success and error feedback display correctly after a single purchase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk8hJ9ENK3rMfrSanwACWS)_