### PR TITLE
fix: add date filter to cleanup-events re-verify query (#1473)

### DIFF
--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -131,6 +131,7 @@ serve(async (req) => {
       .from('events')
       .select('id')
       .in('id', eventIds)
+      .lt('event_date', cutoffDateStr)
 
     if (reVerifyError) throw reVerifyError
 


### PR DESCRIPTION
## Summary

- Adds `.lt('event_date', cutoffDateStr)` to the re-verify SELECT in `cleanup-events/index.ts`
- Without this filter, a rescheduled event (date moved forward past the cutoff) could still appear in the re-verify result and be passed to `cleanup_expired_events` for deletion
- The fix ensures only events that are still old enough are confirmed for deletion, preventing accidental removal of rescheduled events

Closes #1473

## Test plan
- [ ] Deploy function to staging and verify that events rescheduled beyond the cutoff date are excluded from the re-verify set
- [ ] Verify that events still before the cutoff are correctly included and deleted

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk8hJ9ENK3rMfrSanwACWS)_