### PR TITLE
fix: abort delete-my-account on nullifyError to prevent GDPR Art. 17 gap (#1474)

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -112,8 +112,10 @@ serve(async (req) => {
       .not('activated_by', 'is', null);
     if (nullifyError) {
       console.error('delete-my-account: failed to nullify reserved_by on activated tickets', nullifyError.message);
-      // Non-fatal: the attendance records for other users must be preserved.
-      // Log and continue so that the auth user is still deleted.
+      return errorResponse(
+        'Account deletion aborted: could not nullify reserved ticket references. Please retry.',
+        500,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

- In `delete-my-account/index.ts`, the UPDATE that nullifies `reserved_by` on `ticket_activations` rows (where another user activated the ticket) was previously non-fatal: a failure was logged and execution continued, deleting the auth user anyway
- This left the deleted user's UUID in `reserved_by` on activated tickets — a GDPR Art. 17 compliance gap
- The fix returns a `500` error response (using the function's existing `errorResponse` helper) when `nullifyError` is set, aborting the deletion so the user can retry

Closes #1474

## Test plan
- [ ] Simulate a DB error on the `UPDATE ticket_activations SET reserved_by = null` step and verify the function returns HTTP 500 without deleting the auth user
- [ ] Verify normal deletion path (no nullify error) still completes successfully

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk8hJ9ENK3rMfrSanwACWS)_