### PR TITLE
fix: return null from fetchSitemapUrls on failure to prevent silent no-op import (#1475)

### DIFF
--- a/supabase/functions/import-spazio-rossellini/index.ts
+++ b/supabase/functions/import-spazio-rossellini/index.ts
@@ -81,12 +81,12 @@ const resolveGenre = (categories: SpazioEvent['categories'] = [], allowedSlugs: 
   return (preferred?.name ?? categories[0]?.name ?? 'Teatro').toString();
 };
 
-const fetchSitemapUrls = async (): Promise<Set<string>> => {
+const fetchSitemapUrls = async (): Promise<Set<string> | null> => {
   try {
     const res = await fetchWithTimeout(SITEMAP_URL);
     if (!res.ok) {
       console.warn('[import-spazio-rossellini] sitemap fetch failed:', res.status);
-      return new Set<string>();
+      return null;
     }
     const xml = await res.text();
     const urls = new Set<string>();
@@ -101,7 +101,7 @@ const fetchSitemapUrls = async (): Promise<Set<string>> => {
     return urls;
   } catch (err) {
     console.warn('[import-spazio-rossellini] fetchSitemapUrls error:', err);
-    return new Set<string>();
+    return null;
   }
 };
 
@@ -268,9 +268,11 @@ serve(async (req) => {
       fetchCategorySlugs(),
       fetchAllEvents(),
     ]);
-    const matched = apiEvents.filter((event) =>
-      sitemapUrls.has(normalizeUrl(event.url ?? ''))
-    );
+    // When sitemapUrls is null the sitemap was unavailable; import all API events
+    // rather than filtering them out, which would produce a silent no-op import.
+    const matched = sitemapUrls === null
+      ? apiEvents
+      : apiEvents.filter((event) => sitemapUrls.has(normalizeUrl(event.url ?? '')));
     const mappedEvents = matched.map((event) => mapEvent(event, categorySlugs));
     const rows = mappedEvents.filter((row): row is NonNullable<typeof row> => row !== null);
     const skippedCount = mappedEvents.length - rows.length;
@@ -282,7 +284,7 @@ serve(async (req) => {
     }
 
     return jsonResponse({
-      sitemapCount: sitemapUrls.size,
+      sitemapCount: sitemapUrls?.size ?? null,
       apiCount: apiEvents.length,
       matchedCount: matched.length,
       upserted: rows.length,


### PR DESCRIPTION
## Summary

- Changed `fetchSitemapUrls` return type from `Promise<Set<string>>` to `Promise<Set<string> | null>` in `import-spazio-rossellini/index.ts`
- Returns `null` on both HTTP error and exception instead of an empty `Set`, which was previously indistinguishable from a genuinely empty sitemap
- In the caller, a `null` sitemap now causes all API events to be imported (fallback to full import) rather than filtering out every event via `.has()` — which caused a silent no-op import when the sitemap was unavailable
- `sitemapCount` in the response is now `null` when the sitemap was unavailable (previously it was `0`, masking the failure)

Closes #1475

## Test plan
- [ ] Simulate sitemap fetch failure (e.g. wrong URL or network block) and verify all API events are upserted
- [ ] Verify normal path (sitemap available) still filters correctly
- [ ] Check that `sitemapCount: null` is returned in the response when sitemap is unavailable

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk8hJ9ENK3rMfrSanwACWS)_