### PR TITLE
fix: re-read localStorage before each write in flushQueuedSupabaseMutations (#1476)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -2898,7 +2898,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
         const result = await executeQueuedSupabaseMutation(queuedMutation);
         if (result.status === 'applied' || result.status === 'discard') {
-          queue = queue.filter((entry) => entry.id !== queuedMutation.id);
+          const latestQueue = readQueuedSupabaseMutations();
+          queue = latestQueue.filter((entry) => entry.id !== queuedMutation.id);
           writeQueuedSupabaseMutations(queue);
           refreshPendingBoostRequests(queue);
           logOfflineSync(
@@ -2936,7 +2937,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           continue;
         }
 
-        queue = queue.map((entry) =>
+        const latestQueueForRetry = readQueuedSupabaseMutations();
+        queue = latestQueueForRetry.map((entry) =>
           entry.id === queuedMutation.id
             ? {
               ...entry,
@@ -2957,7 +2959,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           updatedMutation &&
           updatedMutation.attempts >= OFFLINE_SYNC_MAX_ATTEMPTS
         ) {
-          queue = queue.filter((entry) => entry.id !== queuedMutation.id);
+          const latestQueueForDrop = readQueuedSupabaseMutations();
+          queue = latestQueueForDrop.filter((entry) => entry.id !== queuedMutation.id);
           writeQueuedSupabaseMutations(queue);
           refreshPendingBoostRequests(queue);
           logOfflineSync('Mutation dropped after max retry attempts', {


### PR DESCRIPTION
## Summary

- In `flushQueuedSupabaseMutations` (`apps/mobile/src/state/store.tsx`), the mutation queue was read once at the top of the function and then written back in the loop without re-reading
- A concurrent tab that added mutations between the initial read and a write would have those additions overwritten (non-atomic read-modify-write)
- The fix adds a fresh `readQueuedSupabaseMutations()` call immediately before each `writeQueuedSupabaseMutations()` inside the loop, covering all three write sites:
  1. `applied/discard` path — mutation successfully processed or permanently dropped
  2. Retry path — mutation attempt counter incremented
  3. Max-retry drop path — mutation dropped after exceeding `OFFLINE_SYNC_MAX_ATTEMPTS`

Closes #1476

## Test plan
- [ ] Open app in two tabs simultaneously; trigger offline mutations in one tab while flushing in the other and verify neither tab loses queued mutations from the other
- [ ] Verify normal single-tab flush flow still processes and removes mutations correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk8hJ9ENK3rMfrSanwACWS)_