### PR TITLE
fix: add ref guard to NarrativeScene.handleChoose to prevent double choice submission

### DIFF
--- a/apps/mobile/src/components/screens/NarrativeScene.tsx
+++ b/apps/mobile/src/components/screens/NarrativeScene.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Screen } from '../ui/Screen';
 import {
   applyChoice,
@@ -89,6 +89,7 @@ export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }
   const prevSceneIdRef = React.useRef(sceneId);
   const prevRoleIdRef = React.useRef(roleId);
   const prevRoleStatsRef = React.useRef(roleStats);
+  const isSubmittingChoiceRef = useRef(false);
   useEffect(() => {
     const prevStats = prevRoleStatsRef.current;
     const statsChanged = roleStats !== prevStats && (
@@ -269,54 +270,59 @@ export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }
   const ctx = makeCtx(roleId, roleStats, run.flags);
 
   const handleChoose = async (choice: NarrativeChoice) => {
-    if (submitting) return;
-    if (!evaluateChoice(choice, ctx).available) return;
-
-    setLocal({ phase: 'submitting', run, scene: activeScene, choiceId: choice.id });
-
-    let nextRun: NarrativeRunState;
-    let outcome: NarrativeOutcome;
-    let finished: boolean;
+    if (isSubmittingChoiceRef.current || local.phase === 'submitting') return;
+    isSubmittingChoiceRef.current = true;
     try {
-      const result = applyChoice(run, activeScene, choice.id, ctx);
-      nextRun = result.state;
-      outcome = result.outcome;
-      finished = result.finished;
-    } catch (error) {
-      setLocal({ phase: 'error', message: error instanceof Error ? error.message : 'Errore sconosciuto' });
-      return;
-    }
+      if (!evaluateChoice(choice, ctx).available) return;
 
-    let submitResult: { ok: boolean; rewards?: Rewards; error?: string };
-    try {
-      submitResult = await onSubmit({
-        sceneId: activeScene.id,
-        choiceId: choice.id,
-        rewards: outcome.rewards,
-        setFlags: outcome.setFlags,
+      setLocal({ phase: 'submitting', run, scene: activeScene, choiceId: choice.id });
+
+      let nextRun: NarrativeRunState;
+      let outcome: NarrativeOutcome;
+      let finished: boolean;
+      try {
+        const result = applyChoice(run, activeScene, choice.id, ctx);
+        nextRun = result.state;
+        outcome = result.outcome;
+        finished = result.finished;
+      } catch (error) {
+        setLocal({ phase: 'error', message: error instanceof Error ? error.message : 'Errore sconosciuto' });
+        return;
+      }
+
+      let submitResult: { ok: boolean; rewards?: Rewards; error?: string };
+      try {
+        submitResult = await onSubmit({
+          sceneId: activeScene.id,
+          choiceId: choice.id,
+          rewards: outcome.rewards,
+          setFlags: outcome.setFlags,
+        });
+      } catch (error) {
+        setLocal({ phase: 'error', message: error instanceof Error ? error.message : 'Errore nel salvataggio della scelta' });
+        return;
+      }
+
+      if (!submitResult.ok) {
+        setLocal({ phase: 'error', message: submitResult.error ?? 'Errore nel salvataggio della scelta' });
+        return;
+      }
+
+      if (finished && sceneId.startsWith(MAXWELL_ID_PREFIX)) {
+        markDailySceneCompleted(makeCtx(roleId, roleStats, new Set()));
+      }
+
+      setLocal({
+        phase: 'outcome',
+        run: nextRun,
+        scene: activeScene,
+        outcome,
+        rewards: submitResult.rewards ?? { xp: 0, cachet: 0, reputation: 0 },
+        finished,
       });
-    } catch (error) {
-      setLocal({ phase: 'error', message: error instanceof Error ? error.message : 'Errore nel salvataggio della scelta' });
-      return;
+    } finally {
+      isSubmittingChoiceRef.current = false;
     }
-
-    if (!submitResult.ok) {
-      setLocal({ phase: 'error', message: submitResult.error ?? 'Errore nel salvataggio della scelta' });
-      return;
-    }
-
-    if (finished && sceneId.startsWith(MAXWELL_ID_PREFIX)) {
-      markDailySceneCompleted(makeCtx(roleId, roleStats, new Set()));
-    }
-
-    setLocal({
-      phase: 'outcome',
-      run: nextRun,
-      scene: activeScene,
-      outcome,
-      rewards: submitResult.rewards ?? { xp: 0, cachet: 0, reputation: 0 },
-      finished,
-    });
   };
 
   return (


### PR DESCRIPTION
Closes #1466

## Summary

- Adds `isSubmittingChoiceRef = useRef(false)` in `NarrativeScene` as a synchronous concurrency guard alongside the existing `local.phase === 'submitting'` React state check.
- The ref is checked and set **before** any state update or await, so rapid double-taps on a choice button are dropped immediately — without waiting for a React re-render.
- Wraps the `handleChoose` body in an outer `try/finally` block so `isSubmittingChoiceRef.current` is always reset to `false` on every exit path (early return, error, or success).
- Also adds `useRef` to the named React import (was absent; existing code used `React.useRef` directly).

## Test plan

- [ ] Tap a narrative choice twice in rapid succession and verify only one `onSubmit` call is made.
- [ ] Verify the in-progress indicator appears while the choice is being submitted.
- [ ] Verify that error and outcome states display correctly after a single submission.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk8hJ9ENK3rMfrSanwACWS)_