### PR TITLE
fix: guard SupportChat save effect against stale chatSessions on historyId change

### DIFF
--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -66,6 +66,7 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
   // via useEffect, because effects fire after paint and would leave a stale ref
   // during the transition window (closes #1350).
   const activeSessionIdRef = useRef(activeSessionId);
+  const loadedForHistoryIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     scrollRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
@@ -101,6 +102,7 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
       setActiveSessionId(sessionId);
       setMessages(session.messages);
     }
+    loadedForHistoryIdRef.current = currentHistoryId;
     hasLoadedRef.current = true;
   }, [historyId]);
 
@@ -142,6 +144,7 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
 
   useEffect(() => {
     if (!hasLoadedRef.current || !chatSessions.length) return;
+    if (loadedForHistoryIdRef.current !== historyId) return;
     saveChatHistory(historyId, chatSessions);
   }, [chatSessions, historyId]);
 


### PR DESCRIPTION
## Summary

- Adds `loadedForHistoryIdRef` to track which `historyId` the current `chatSessions` were loaded for.
- Sets `loadedForHistoryIdRef.current = currentHistoryId` in the load effect immediately after sessions are populated, before `hasLoadedRef.current = true`.
- In the save effect, skips `saveChatHistory` if `loadedForHistoryIdRef.current !== historyId`, preventing stale sessions from a previous user being written to the new user's localStorage key during the render cycle gap between the load and save effects.

Closes #1467

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk8hJ9ENK3rMfrSanwACWS)_