### PR TITLE
fix: add onAuthChange to handleLogin useCallback deps to prevent stale closure

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -107,7 +107,7 @@ export function useAuth(
         updateProfile(shouldSetName ? { name: displayName, email } : { email });
         // Navigation to 'home' is handled by the onAuthStateChange SIGNED_IN listener;
         // calling onAuthChange here as well would fire it twice on every successful login.
-    }, [profile.name, updateProfile]);
+    }, [profile.name, updateProfile, onAuthChange]);
 
     const handleSignup = useCallback(async (name: string, email: string, password: string, isMinor = false) => {
         setAuthError(null);


### PR DESCRIPTION
## Summary

- `handleLogin` calls `onAuthChange('home')` in the demo-mode branch (`!isSupabaseConfigured || !supabase`), but `onAuthChange` was missing from the `useCallback` dependency array.
- This caused a stale closure: if `onAuthChange` changed identity between renders, `handleLogin` would still hold a reference to the old version.
- One-line fix: added `onAuthChange` to the deps array `[profile.name, updateProfile, onAuthChange]`.

Closes #1472

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk8hJ9ENK3rMfrSanwACWS)_