### PR TITLE
fix: guard NarrativeScene handleChoose/handleContinue against setState after unmount

### DIFF
--- a/apps/mobile/src/components/screens/NarrativeScene.tsx
+++ b/apps/mobile/src/components/screens/NarrativeScene.tsx
@@ -89,6 +89,11 @@ export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }
   const prevSceneIdRef = React.useRef(sceneId);
   const prevRoleIdRef = React.useRef(roleId);
   const prevRoleStatsRef = React.useRef(roleStats);
+  const isMountedRef = React.useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => { isMountedRef.current = false; };
+  }, []);
   useEffect(() => {
     const prevStats = prevRoleStatsRef.current;
     const statsChanged = roleStats !== prevStats && (
@@ -227,10 +232,12 @@ export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }
         try {
           await ensureTheaterScenesLoaded();
         } catch {
+          if (!isMountedRef.current) return;
           setLocal({ phase: 'error', message: `Scenario "${nextSceneId}" non disponibile al momento.` });
           return;
         }
       }
+      if (!isMountedRef.current) return;
       const nextScene = loadScene(nextSceneId);
       if (!nextScene) {
         setLocal({ phase: 'error', message: `Scenario "${nextSceneId}" non trovato.` });
@@ -296,10 +303,12 @@ export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }
         setFlags: outcome.setFlags,
       });
     } catch (error) {
+      if (!isMountedRef.current) return;
       setLocal({ phase: 'error', message: error instanceof Error ? error.message : 'Errore nel salvataggio della scelta' });
       return;
     }
 
+    if (!isMountedRef.current) return;
     if (!submitResult.ok) {
       setLocal({ phase: 'error', message: submitResult.error ?? 'Errore nel salvataggio della scelta' });
       return;
@@ -309,6 +318,7 @@ export function NarrativeScene({ sceneId, roleId, roleStats, onSubmit, onClose }
       markDailySceneCompleted(makeCtx(roleId, roleStats, new Set()));
     }
 
+    if (!isMountedRef.current) return;
     setLocal({
       phase: 'outcome',
       run: nextRun,


### PR DESCRIPTION
## Summary

- Adds `isMountedRef` (initialized to `true`, set to `false` on cleanup) via a dedicated `useEffect` in `NarrativeScene`.
- In `handleContinue`: guards the `setLocal` call in the `catch` block (after `await ensureTheaterScenesLoaded()`), and adds a single guard immediately after the theater-load block to cover all subsequent `setLocal` calls in that code path.
- In `handleChoose`: guards the `setLocal` call in the `onSubmit` `catch` block, plus two guards covering the `submitResult.ok` check and the final `phase: 'outcome'` transition — all of which follow `await onSubmit(...)`.

Closes #1469

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk8hJ9ENK3rMfrSanwACWS)_