### PR TITLE
fix: remove external abort listener after request completes to prevent memory leak

### DIFF
--- a/apps/mobile/src/services/ai.ts
+++ b/apps/mobile/src/services/ai.ts
@@ -183,6 +183,9 @@ export async function requestAiSupport({
   const controller = new AbortController();
 
   // Combine the watchdog controller signal with any externally supplied signal.
+  // cleanupExternalAbort removes the listener we register on the caller-supplied signal
+  // so it is not retained after the request completes (success or failure).
+  let cleanupExternalAbort: (() => void) | null = null;
   const combinedSignal = (() => {
     if (!signal) return controller.signal;
     const merged = new AbortController();
@@ -192,6 +195,7 @@ export async function requestAiSupport({
       const abort = () => merged.abort();
       controller.signal.addEventListener('abort', abort, { once: true });
       signal.addEventListener('abort', abort, { once: true });
+      cleanupExternalAbort = () => signal.removeEventListener('abort', abort);
     }
     return merged.signal;
   })();
@@ -235,6 +239,8 @@ export async function requestAiSupport({
   } catch (error) {
     controller.abort();
     throw error;
+  } finally {
+    cleanupExternalAbort?.();
   }
 }
 


### PR DESCRIPTION
## Summary

- In `requestAiSupport`, when an external `signal` is provided, a merged `AbortController` is set up that listens on both the internal watchdog `controller.signal` and the external `signal`.
- The listener on `controller.signal` uses `{ once: true }` and is auto-removed when the internal controller aborts (on error). However, the listener on the external `signal` was never removed after the request completed — leaving a dangling event listener that prevents the `abort` closure and `merged` controller from being garbage-collected.
- Fix: introduced `cleanupExternalAbort` that captures `signal.removeEventListener('abort', abort)` and calls it in a new `finally` block, ensuring the external listener is removed on both success and failure paths.

Closes #1477

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk8hJ9ENK3rMfrSanwACWS)_