### PR TITLE
fix(narrative): use Italian ROLE_IDS for SAFE_ROLE_IDS — AI was always getting 'sconosciuto'

### DIFF
--- a/apps/mobile/src/gameplay/narrative.ts
+++ b/apps/mobile/src/gameplay/narrative.ts
@@ -1,3 +1,4 @@
+import { ROLE_IDS } from '../state/store';
 import type { RoleId } from '../state/store';
 import type { RoleStats } from './minigames';
 import { resolveAiChatEndpoint } from '../services/ai';
@@ -302,11 +303,8 @@ function sanitizePromptValue(value: string): string {
   return value.replace(/[\r\n]+/g, ' ').trim();
 }
 
-/** Known-safe role IDs accepted by the narrative engine. */
-const SAFE_ROLE_IDS = new Set<string>([
-  'actor', 'director', 'stage_manager', 'technician', 'costume_designer',
-  'set_designer', 'lighting_designer', 'sound_designer', 'producer', 'playwright',
-]);
+/** Known-safe role IDs accepted by the narrative engine — single source of truth from store. */
+const SAFE_ROLE_IDS = new Set<string>(ROLE_IDS);
 
 /** Known-safe flag names (snake_case identifiers only). */
 const SAFE_FLAG_PATTERN = /^[a-z][a-z0-9_]{0,59}$/;


### PR DESCRIPTION
## Summary

Closes #1492.

`SAFE_ROLE_IDS` in `apps/mobile/src/gameplay/narrative.ts` was populated with English role identifiers (`'actor'`, `'director'`, `'stage_manager'`, etc.) but the game uses Italian IDs (`'attore'`, `'luci'`, `'fonico'`, etc.). The `has()` check in `buildSceneGenerationPrompt` therefore always returned `false` for every valid player role, causing the AI prompt to always substitute `'sconosciuto'` — every generated scene was role-agnostic, defeating the purpose of role selection.

## Changes

- `apps/mobile/src/gameplay/narrative.ts`: import `ROLE_IDS` (the canonical Italian role IDs) from `state/store` and build `SAFE_ROLE_IDS` from it, eliminating the mismatch and keeping a single source of truth.

## Test plan

- [ ] Select any role (e.g. `attore`) and trigger a narrative scene generation: the AI prompt should now include the correct Italian role name instead of `'sconosciuto'`
- [ ] Verify TypeScript compiles cleanly (`npm run typecheck:mobile` if available)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsSMqrwwghXh6WoHcbcSgv)_