### PR TITLE
fix(storage): match profile image file extension to MIME type, prevent orphan objects

### DIFF
--- a/apps/mobile/src/services/storage.ts
+++ b/apps/mobile/src/services/storage.ts
@@ -33,12 +33,9 @@ export async function uploadProfileImage(userId: string, file: File): Promise<st
 
     // Remove any pre-existing profile images with a different extension to
     // prevent orphan objects when the user switches upload format.
+    const profileBucket = supabase.storage.from('profile-images');
     const otherExts = Object.values(mimeToExt).filter(e => e !== ext);
-    await Promise.all(
-      otherExts.map(e =>
-        supabase.storage.from('profile-images').remove([`${userId}/profile.${e}`])
-      )
-    );
+    await Promise.all(otherExts.map(e => profileBucket.remove([`${userId}/profile.${e}`])));
 
     const { error } = await supabase.storage
       .from('profile-images')

--- a/apps/mobile/src/services/storage.ts
+++ b/apps/mobile/src/services/storage.ts
@@ -22,9 +22,23 @@ export async function uploadProfileImage(userId: string, file: File): Promise<st
       throw new Error('Immagine troppo grande (max 5MB)');
     }
 
-    // Always use a fixed path so upsert truly overwrites the previous image
-    // regardless of the source file extension, preventing orphan objects.
-    const fileName = `${userId}/profile.jpg`;
+    const mimeToExt: Record<string, string> = {
+      'image/jpeg': 'jpg',
+      'image/png': 'png',
+      'image/webp': 'webp',
+      'image/gif': 'gif',
+    };
+    const ext = mimeToExt[file.type] ?? 'jpg';
+    const fileName = `${userId}/profile.${ext}`;
+
+    // Remove any pre-existing profile images with a different extension to
+    // prevent orphan objects when the user switches upload format.
+    const otherExts = Object.values(mimeToExt).filter(e => e !== ext);
+    await Promise.all(
+      otherExts.map(e =>
+        supabase.storage.from('profile-images').remove([`${userId}/profile.${e}`])
+      )
+    );
 
     const { error } = await supabase.storage
       .from('profile-images')


### PR DESCRIPTION
## Summary

Closes #1493.

`uploadProfileImage` was hardcoding `profile.jpg` as the filename regardless of the actual MIME type, causing a content-type/extension mismatch for PNG and WebP uploads. Additionally, changing image format on a subsequent upload would leave orphan objects in storage.

## Changes

- `apps/mobile/src/services/storage.ts`: derive the file extension from `file.type` (jpeg→jpg, png→png, webp→webp, gif→gif), use it in the storage path, and remove any pre-existing profile images with a different extension before uploading to prevent orphan objects.

## Test plan

- [ ] Upload a PNG as profile image: verify it's stored at `profile.png` with correct `Content-Type: image/png`
- [ ] Then upload a JPEG: verify old `profile.png` is removed and new file at `profile.jpg`
- [ ] Verify TypeScript compiles cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsSMqrwwghXh6WoHcbcSgv)_