### PR TITLE
fix(EarnedTitles): call onViewed once on mount, not on every callback identity change

### DIFF
--- a/apps/mobile/src/components/screens/EarnedTitles.tsx
+++ b/apps/mobile/src/components/screens/EarnedTitles.tsx
@@ -52,9 +52,9 @@ function getBadgeProgressMeta(badge: Badge, turnStats: TurnStats) {
 }
 
 export function EarnedTitles({ badges, turnStats, onBack, onViewed }: EarnedTitlesProps) {
-  React.useEffect(() => {
-    onViewed?.();
-  }, [onViewed]);
+  const onViewedRef = React.useRef(onViewed);
+  React.useEffect(() => { onViewedRef.current = onViewed; });
+  React.useEffect(() => { onViewedRef.current?.(); }, []);
 
   const visibleBadges = React.useMemo(
     () =>


### PR DESCRIPTION
## Summary

Closes #1495.

`EarnedTitles` had `onViewed` in the `useEffect` dependency array. Because `onViewed` (`markBadgesSeen`) is a `useCallback` whose identity changes whenever auth/Supabase context re-computes, the effect re-fired on every such change while the screen was visible — queuing redundant `mark_my_badges_seen` RPC calls.

## Changes

- `apps/mobile/src/components/screens/EarnedTitles.tsx`: replace `[onViewed]` dep with a ref pattern — always call the latest `onViewed`, but only fire it once on mount.

## Test plan

- [ ] Open EarnedTitles screen; verify `markBadgesSeen` fires exactly once
- [ ] Trigger a Realtime badge event while on the screen; verify no second RPC call is made

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsSMqrwwghXh6WoHcbcSgv)_