### PR TITLE
fix(event-links): validate roleId against known allowlist in create_deep_link

### DIFF
--- a/supabase/functions/event-links/index.ts
+++ b/supabase/functions/event-links/index.ts
@@ -12,6 +12,8 @@ const corsHeaders = {
 
 const EVENT_ID_PATTERN = /\b([A-Za-z]{2,10}-\d{1,6})\b/;
 
+const VALID_ROLE_IDS = new Set(['attore', 'luci', 'fonico', 'attrezzista', 'palco', 'rspp', 'dramaturg']);
+
 type EventRow = {
   id: string;
   name: string;
@@ -161,12 +163,17 @@ serve(async (req) => {
 
   if (action === 'create_deep_link') {
     const eventId = normalizeEventId(String(body.eventId ?? ''));
-    const roleId = String(body.roleId ?? '').trim() || null;
+    const rawRoleId = String(body.roleId ?? '').trim() || null;
     const baseUrl = sanitizeBaseUrl(String(body.baseUrl ?? DEFAULT_BASE_URL));
 
     if (!eventId) {
       return json({ error: 'eventId obbligatorio' }, 400);
     }
+
+    if (rawRoleId !== null && !VALID_ROLE_IDS.has(rawRoleId)) {
+      return json({ error: 'roleId non valido' }, 400);
+    }
+    const roleId = rawRoleId;
 
     // @ts-ignore
     const { data, error } = await supabase


### PR DESCRIPTION
## Summary

Closes #1496.

The `create_deep_link` action in `supabase/functions/event-links/index.ts` embedded the caller-supplied `roleId` directly into the deep link URL without validating it against the set of known game role IDs. Any authenticated user could inject an arbitrary string as `role_id` in the returned URL, which the mobile app would then forward to the turn registration RPC.

## Changes

- `supabase/functions/event-links/index.ts`: add `VALID_ROLE_IDS` allowlist (`attore`, `luci`, `fonico`, `attrezzista`, `palco`, `rspp`, `dramaturg`) and return HTTP 400 if the supplied `roleId` is not in the set.

## Test plan

- [ ] Call `create_deep_link` with a valid `roleId` (e.g. `"attore"`): should succeed and return a deep link
- [ ] Call with an invalid `roleId` (e.g. `"admin"`, `"../etc"`): should return `{"error":"roleId non valido"}` with status 400
- [ ] Call with no `roleId`: should succeed (null is allowed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsSMqrwwghXh6WoHcbcSgv)_