### PR TITLE
fix(dev-access): remove unreachable if/else wrapper around audit-log block

### DIFF
--- a/supabase/functions/dev-access/index.ts
+++ b/supabase/functions/dev-access/index.ts
@@ -126,25 +126,21 @@ serve(async (req) => {
     return jsonResponse({ allowed: true });
   }
 
-  if (serviceRoleKey) {
-    const adminClient = createClient(supabaseUrl, serviceRoleKey, {
-      auth: { autoRefreshToken: false, persistSession: false },
-    });
-    const userRoles = getUserRoles(user as Record<string, unknown>);
-    const auditEntry: DevAccessAudit = {
-      user_id: user.id,
-      user_email: user.email ?? null,
-      user_roles: userRoles,
-      path: payload.path ?? null,
-      reason: 'not_allowed',
-    };
+  const adminClient = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  const userRoles = getUserRoles(user as Record<string, unknown>);
+  const auditEntry: DevAccessAudit = {
+    user_id: user.id,
+    user_email: user.email ?? null,
+    user_roles: userRoles,
+    path: payload.path ?? null,
+    reason: 'not_allowed',
+  };
 
-    const { error: insertError } = await adminClient.from('dev_access_audit').insert(auditEntry);
-    if (insertError) {
-      console.error('Dev access audit insert failed', insertError.message);
-    }
-  } else {
-    console.warn('Missing SUPABASE_SERVICE_ROLE_KEY for dev access audit logging.');
+  const { error: insertError } = await adminClient.from('dev_access_audit').insert(auditEntry);
+  if (insertError) {
+    console.error('Dev access audit insert failed', insertError.message);
   }
 
   return jsonResponse({ allowed: false, reason: 'Accesso non autorizzato.' }, 403);


### PR DESCRIPTION
## Summary

Closes #1497.

In `supabase/functions/dev-access/index.ts`, the early-exit guard at lines 94-97 already returns HTTP 500 if `serviceRoleKey` is falsy. All code that follows it is therefore guaranteed to run with a non-empty `serviceRoleKey`. The `if (serviceRoleKey)` conditional at line 129 was always true — dead code — and its `else` branch (`console.warn(...)`) was unreachable, misleading future developers into thinking there was a code path where the audit block could be skipped.

## Changes

- `supabase/functions/dev-access/index.ts`: remove the `if (serviceRoleKey)` / `else` wrapper; the audit-log block now executes unconditionally, as the early-exit guard already guarantees `serviceRoleKey` is non-empty at that point.

## Test plan

- [ ] Denied access attempt: verify audit entry is still written to `dev_access_audit`
- [ ] Missing `SUPABASE_SERVICE_ROLE_KEY` env: function returns HTTP 500 (unchanged behaviour)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsSMqrwwghXh6WoHcbcSgv)_