### PR TITLE
fix(event-links): validate role_id in resolve_deep_link against VALID_ROLE_IDS

### DIFF
--- a/supabase/functions/event-links/index.ts
+++ b/supabase/functions/event-links/index.ts
@@ -210,7 +210,10 @@ serve(async (req) => {
     const eventId = normalizeEventId(url.searchParams.get('event_id') ?? url.searchParams.get('eid'));
     // URLSearchParams.get() returns null when absent, which is correct.
     // Normalise with || null so an empty string also becomes null, not "".
-    const roleId = url.searchParams.get('role_id') || null;
+    // Validate against VALID_ROLE_IDS: reject unknown role IDs rather than
+    // reflecting attacker-controlled strings back to the caller (closes #1503).
+    const rawRoleId = url.searchParams.get('role_id') || null;
+    const roleId = (rawRoleId !== null && VALID_ROLE_IDS.has(rawRoleId)) ? rawRoleId : null;
     if (!eventId) {
       return json({ error: 'event_id mancante' }, 400);
     }


### PR DESCRIPTION
## Summary

- The `resolve_deep_link` action in `supabase/functions/event-links/index.ts` was reflecting the raw `role_id` URL parameter back to the caller without any validation, allowing an attacker to pass arbitrary strings (e.g. `role_id=admin`) and receive them back as a trusted `roleId` field.
- This is inconsistent with `create_deep_link`, which already validates `roleId` against `VALID_ROLE_IDS` (fixed in #1496).
- Fix: extract `rawRoleId` and coerce it to `null` if it is not present in `VALID_ROLE_IDS` before returning, mirroring the existing guard in `create_deep_link`.

Closes #1503.

## Key change

```typescript
// Before
const roleId = url.searchParams.get('role_id') || null;

// After
const rawRoleId = url.searchParams.get('role_id') || null;
const roleId = (rawRoleId !== null && VALID_ROLE_IDS.has(rawRoleId)) ? rawRoleId : null;
```

## Test plan

- [ ] `resolve_deep_link` with a valid `role_id` (e.g. `attore`) returns the correct `roleId` in the response.
- [ ] `resolve_deep_link` with an unknown `role_id` (e.g. `admin`, `superuser`) returns `roleId: null`.
- [ ] `resolve_deep_link` with no `role_id` parameter returns `roleId: null` (unchanged behaviour).
- [ ] `create_deep_link` and `validate_qr` actions are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_013jC5PTQDsgXQE2dVMbcDoe)_