### PR TITLE
fix: trim messages before building chat payload to enforce MAX_MESSAGES_PER_SESSION cap

### DIFF
--- a/apps/mobile/src/components/screens/SupportChat.tsx
+++ b/apps/mobile/src/components/screens/SupportChat.tsx
@@ -194,7 +194,7 @@ export function SupportChat({ userName, userId, onBack }: SupportChatProps) {
 
     try {
       const memory = buildMemorySnippet(chatSessions, requestSessionId);
-      const payload = buildChatPayload(nextMessages);
+      const payload = buildChatPayload(trimMessages(nextMessages));
       const reply = await requestAiSupport({ userName: displayName, memory, messages: payload, signal: controller.signal });
       if (controller.signal.aborted || requestIdRef.current !== requestId || activeSessionIdRef.current !== requestSessionId) return;
       const { text, draft } = extractIssueDraft(reply);


### PR DESCRIPTION
## Intent

Fix unbounded growth of the chat history sent to the AI API in `SupportChat`.

## Key Changes

- In `handleSend`, wrap `nextMessages` with `trimMessages()` before passing it to `buildChatPayload()`, so the API payload is always capped at `MAX_MESSAGES_PER_SESSION` (120) messages regardless of how long the in-memory `messages` state has grown.

## Root Cause

`trimMessages()` was only applied inside `updateSessionList()` (which writes to localStorage), never against the in-memory slice used to build the API request. After 120 messages, every subsequent call sent the full unbounded array to the AI, defeating the cap and risking payload failures.

## Testing Performed

- Code inspection confirms `trimMessages` was already defined and correct; only the call site was missing.
- No logic change: sessions with fewer than 120 messages are unaffected (`trimMessages` is a no-op in that case).

Closes #1505

---
_Generated by [Claude Code](https://claude.ai/code/session_01ES7FJKpxiCBKKZXem65Y8i)_