### PR TITLE
fix: pin @supabase/supabase-js to exact version in cleanup-events and dev-access

### DIFF
--- a/supabase/functions/cleanup-events/index.ts
+++ b/supabase/functions/cleanup-events/index.ts
@@ -1,6 +1,6 @@
 /// <reference path="../@types/deno.d.ts" />
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts'
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.48.0'
 
 const allowedOrigin = Deno.env.get('SITE_URL') ?? 'https://turnidipalco.it';
 

--- a/supabase/functions/dev-access/index.ts
+++ b/supabase/functions/dev-access/index.ts
@@ -1,6 +1,6 @@
 /// <reference path="../@types/deno.d.ts" />
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.48.0';
 
 const allowedOrigin = Deno.env.get('SITE_URL') ?? 'https://turnidipalco.it';
 


### PR DESCRIPTION
## Intent

Pin `@supabase/supabase-js` to the exact version `2.48.0` in the two Supabase Edge Functions that were using a floating `@2` range, bringing them in line with every other function in the project.

## Key Changes

- `supabase/functions/cleanup-events/index.ts`: `@supabase/supabase-js@2` → `@supabase/supabase-js@2.48.0`
- `supabase/functions/dev-access/index.ts`: `@supabase/supabase-js@2` → `@supabase/supabase-js@2.48.0`

The pinned version `2.48.0` was confirmed by reading `supabase/functions/ticket-activation/index.ts`, which already uses the exact pin and serves as the project-wide reference.

## Root Cause

Both files imported `@supabase/supabase-js@2` (semver-major-pinned), which allows esm.sh to silently resolve any newer `2.x` release at cold-start. If a breaking 2.x release ships, these functions would fail non-deterministically while all other functions (pinned at `2.48.0`) continue to work.

## Testing Performed

- Verified the target version matches the one used by all other Edge Functions in the repo.
- No logic changes: the import is identical at runtime on `2.48.0` as it is on `@2` today.

Closes #1506

---
_Generated by [Claude Code](https://claude.ai/code/session_01ES7FJKpxiCBKKZXem65Y8i)_