### PR TITLE
fix(import-atcl-lazio): guard String.fromCodePoint against out-of-range code points

### DIFF
--- a/supabase/functions/import-atcl-lazio/index.ts
+++ b/supabase/functions/import-atcl-lazio/index.ts
@@ -68,10 +68,12 @@ const HTML_ENTITIES: Record<string, string> = {
 };
 
 function decodeHtmlEntities(text: string): string {
-  // Decode numeric entities (decimal and hex)
+  // Decode numeric entities (decimal and hex).
+  // Guard String.fromCodePoint with try-catch: the hex pattern is unbounded and
+  // values above 0x10FFFF throw a RangeError that would crash the Edge Function.
   return text
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (match, hex) => { try { return String.fromCodePoint(parseInt(hex, 16)); } catch { return match; } })
+    .replace(/&#(\d+);/g, (match, dec) => { try { return String.fromCodePoint(parseInt(dec, 10)); } catch { return match; } })
     .replace(/&([a-zA-Z]+);/g, (match, name) => HTML_ENTITIES[name] ?? HTML_ENTITIES[name.toLowerCase()] ?? match);
 }
 


### PR DESCRIPTION
## Summary

- Wraps both numeric-entity `String.fromCodePoint` calls in `try-catch` in `supabase/functions/import-atcl-lazio/index.ts`
- Out-of-range code points (> 0x10FFFF) now keep the original entity verbatim instead of throwing an uncaught `RangeError` that crashes the Edge Function with a 500 and silently skips all event imports
- Mirrors the guard already present in `apps/mobile/src/state/store.tsx` lines 1046–1050

## Test plan

- [ ] Trigger `import-atcl-lazio` against a page containing `&#x200000;` (an out-of-range entity) — confirm the import succeeds and the entity is kept verbatim in the title/description
- [ ] Normal import with valid entities (e.g. `&egrave;`, `&#232;`, `&#xE8;`) still decodes correctly
- [ ] No regression in the existing ATCL import pipeline

Closes #1509

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYhrFoc1Cx3sm5AEU22Bkk)_