### PR TITLE
fix(narrative): remove external AbortSignal listener after internal timeout fires

### DIFF
--- a/apps/mobile/src/gameplay/narrative.ts
+++ b/apps/mobile/src/gameplay/narrative.ts
@@ -510,6 +510,8 @@ export async function fetchScene(
     ? window.setTimeout(() => controller.abort(), MAXWELL_FETCH_TIMEOUT_MS)
     : null;
 
+  let cleanupExternalAbort: (() => void) | null = null;
+
   const combinedSignal = options?.signal
     ? (() => {
         const merged = new AbortController();
@@ -519,6 +521,7 @@ export async function fetchScene(
           const abort = () => merged.abort();
           controller.signal.addEventListener('abort', abort, { once: true });
           options.signal!.addEventListener('abort', abort, { once: true });
+          cleanupExternalAbort = () => options.signal!.removeEventListener('abort', abort);
         }
         return merged.signal;
       })()
@@ -536,7 +539,10 @@ export async function fetchScene(
       if (timeoutId !== null) window.clearTimeout(timeoutId);
       return null;
     }
-  })().finally(() => inflightSceneFetch.delete(inflightKey));
+  })().finally(() => {
+    cleanupExternalAbort?.();
+    inflightSceneFetch.delete(inflightKey);
+  });
 
   inflightSceneFetch.set(inflightKey, p);
   return p;


### PR DESCRIPTION
## Summary

- Adds a `cleanupExternalAbort` callback in `apps/mobile/src/gameplay/narrative.ts` `fetchScene`
- When the merged AbortController is created from an internal timeout + external `options.signal`, the listener on `options.signal` is now removed in the `.finally()` block
- Prevents an orphaned closure on the parent component's AbortController that held `merged` alive until the parent signal fired

The fix follows the same pattern already used in `apps/mobile/src/services/ai.ts`.

## Test plan

- [ ] Trigger a Maxwell narrative fetch that times out internally (mock or wait 12 s) — verify no lingering listener on the caller's AbortController
- [ ] Cancel via `options.signal` before timeout — `merged.abort()` still fires immediately
- [ ] Normal narrative fetch with `options.signal` completes successfully and the external listener is cleaned up

Closes #1510

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYhrFoc1Cx3sm5AEU22Bkk)_