### PR TITLE
fix(ticket-activation): make reserve_hash idempotent for same admin on retry

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -157,8 +157,20 @@ serve(async (req: Request) => {
       });
 
       if (insertError) {
-        // Primary key collision -> hash already reserved by another process.
         if ((insertError as { code?: string }).code === '23505') {
+          // Primary key collision: hash already exists. Check if this admin
+          // reserved it themselves — a common case when the HTTP response was
+          // lost mid-flight and the client retries. Return success so the
+          // client can continue instead of showing a misleading "duplicate"
+          // error (closes #1511).
+          const { data: existing } = await supabase
+            .from('ticket_activations')
+            .select('reserved_by')
+            .eq('hash', normalizedHash)
+            .maybeSingle();
+          if (existing?.reserved_by === authenticatedUser?.id) {
+            return jsonResponse({ reserved: true }, 200);
+          }
           return jsonResponse({ reserved: false, error: 'Hash already exists' }, 200);
         }
         throw insertError;


### PR DESCRIPTION
## Summary

- On a `23505` primary key conflict in `reserve_hash`, the edge function now fetches the existing row's `reserved_by`
- If it matches the requesting admin's user ID, returns `{ reserved: true }` (idempotent retry after network loss)
- If it belongs to a different user, returns `{ reserved: false }` as before

This fixes the scenario where an admin's `generateTicketQr` call succeeds server-side but the HTTP response is lost: the client retried but received a misleading "Ticket già presente su Supabase" error instead of continuing normally.

## Test plan

- [ ] Admin generates a QR ticket, simulate network loss on the response (DevTools offline → back online), retry — should succeed without error
- [ ] Two different admins try to reserve the same hash (genuine conflict) — second gets `{ reserved: false }` as expected
- [ ] Same admin retries immediately (no network error, just user spam) — still succeeds idempotently

Closes #1511

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYhrFoc1Cx3sm5AEU22Bkk)_