### PR TITLE
fix: add authUserId guard to flushMirroredClientLogsToServer (closes #1515)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -2599,6 +2599,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
   const flushMirroredClientLogsToServer = useCallback(async () => {
     if (!isSupabaseConfigured || !supabase || !shouldMirrorOfflineSyncLogsToServer()) return;
+    if (!authUserId) return;
     if (offlineServerLogSyncInFlightRef.current) return;
     if (isNavigatorOffline()) return;
 


### PR DESCRIPTION
Closes #1515

## Summary
`flushMirroredClientLogsToServer` was missing an `!authUserId` guard. The `setInterval`-based useEffect that drives it every 8 seconds has `flushMirroredClientLogsToServer` in its dependency array (so the interval is recreated when auth state changes), but the function itself would still proceed when `authUserId` is `null` — calling `supabase.functions.invoke('mobile-logs', …)` without a valid JWT, getting a 401, silently swallowing it, and repeating every 8 seconds.

Added `if (!authUserId) return;` immediately after the existing Supabase/feature-flag guards so the function exits early whenever the user is not authenticated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcC3hEjARpz5JE2T9AVum4)_