### PR TITLE
fix: preserve leaderboard state on transient fetch error (closes #1517)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -2583,7 +2583,6 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           setLeaderboard(nextLeaderboard);
         } catch (error) {
           console.warn('Supabase leaderboard fetch failed', error);
-          setLeaderboard([]);
         } finally {
           setLeaderboardLoading(false);
         }


### PR DESCRIPTION
## Summary

Removes `setLeaderboard([])` from the `catch` block of `refreshLeaderboard` in `apps/mobile/src/state/store.tsx`.

Previously, any transient network error (timeout, flaky connection) would clear the leaderboard list, showing users an empty ranking even though valid data had already been loaded. The fix preserves last-known-good data and only clears the list on explicit logout (which already calls `setLeaderboard([])` in the logout path).

## Changes

- `apps/mobile/src/state/store.tsx` — removed one line (`setLeaderboard([])`) from the `catch` block of `refreshLeaderboard` (line ~2586).

## Test plan

- [ ] Simulate a leaderboard fetch failure (disable network mid-session) and verify the previously loaded list remains visible instead of being replaced with an empty state.
- [ ] Verify that logout still clears the leaderboard (the logout path at line ~5351 retains its own `setLeaderboard([])`).

Closes #1517

---
_Generated by [Claude Code](https://claude.ai/code/session_013mmGwMw3fePcSvJiC7y64i)_