### PR TITLE
fix: subscribe isOffline to online/offline events in EventConfirmation (closes #1518)

### DIFF
--- a/apps/mobile/src/components/screens/EventConfirmation.tsx
+++ b/apps/mobile/src/components/screens/EventConfirmation.tsx
@@ -30,6 +30,7 @@ export function EventConfirmation({
   const [boostRequested, setBoostRequested] = useState(false);
   const [confirmResult, setConfirmResult] = useState<Extract<ConfirmTurnResult, { ok: true }> | null>(null);
   const [confirmError, setConfirmError] = useState<string | null>(null);
+  const [isOffline, setIsOffline] = useState(() => typeof navigator !== 'undefined' && navigator.onLine === false);
   const successTimeoutRef = useRef<number | null>(null);
   const isSubmittingRef = useRef(false);
 
@@ -39,8 +40,18 @@ export function EventConfirmation({
     };
   }, []);
 
+  useEffect(() => {
+    const onOnline = () => setIsOffline(false);
+    const onOffline = () => setIsOffline(true);
+    window.addEventListener('online', onOnline);
+    window.addEventListener('offline', onOffline);
+    return () => {
+      window.removeEventListener('online', onOnline);
+      window.removeEventListener('offline', onOffline);
+    };
+  }, []);
+
   const roleId = (role?.id ?? 'attore') as RoleId;
-  const isOffline = typeof navigator !== 'undefined' && navigator.onLine === false;
 
   const resolvedRewards = useMemo(() => event ? computeTurnRewards(event, roleId) : { xp: 0, reputation: 0, cachet: 0 }, [event, roleId]);
   const boostedPreviewRewards = useMemo(() => ({


### PR DESCRIPTION
## Summary

Replaces the stale render-time `const isOffline` in `EventConfirmation.tsx` with reactive state that subscribes to `window` `online`/`offline` events.

**Before:** `const isOffline = typeof navigator !== 'undefined' && navigator.onLine === false;` — evaluated once at render time and never updated. If connectivity changes while the dialog is open, the boost card and reward preview show stale data.

**After:** `useState` initialised from `navigator.onLine` + a `useEffect` that attaches/detaches `online`/`offline` listeners and cleans them up on unmount. The component now re-renders immediately when connectivity changes.

## Changes

- `apps/mobile/src/components/screens/EventConfirmation.tsx` — converted `isOffline` from a plain const to reactive state with event listener subscription.

## Test plan

- [ ] Open the EventConfirmation dialog while online; verify boost card shows online state.
- [ ] Disable network while the dialog is open; verify boost card switches to offline message without reopening the dialog.
- [ ] Re-enable network; verify the card switches back to online state.
- [ ] Unmount the component (cancel the dialog); verify no errors from stale listeners.

Closes #1518

---
_Generated by [Claude Code](https://claude.ai/code/session_013mmGwMw3fePcSvJiC7y64i)_