### PR TITLE
fix: cancel requestAnimationFrame IDs on unmount in Leaderboard (closes #1519)

### DIFF
--- a/apps/mobile/src/components/screens/Leaderboard.tsx
+++ b/apps/mobile/src/components/screens/Leaderboard.tsx
@@ -14,6 +14,7 @@ export function Leaderboard({ onSelectEntry }: LeaderboardProps) {
   const rowRefs = useRef(new Map<string, HTMLDivElement>());
   const previousRowTops = useRef(new Map<string, number>());
   const timerIdsRef = useRef<number[]>([]);
+  const rafIdsRef = useRef<number[]>([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -32,8 +33,10 @@ export function Leaderboard({ onSelectEntry }: LeaderboardProps) {
   );
 
   useLayoutEffect(() => {
-    animateRowTransitions(sorted, rowRefs, previousRowTops, timerIdsRef);
+    animateRowTransitions(sorted, rowRefs, previousRowTops, timerIdsRef, rafIdsRef);
     return () => {
+      rafIdsRef.current.forEach(id => cancelAnimationFrame(id));
+      rafIdsRef.current = [];
       timerIdsRef.current.forEach(id => clearTimeout(id));
       timerIdsRef.current = [];
     };
@@ -172,6 +175,7 @@ function animateRowTransitions(
   rowRefs: React.MutableRefObject<Map<string, HTMLDivElement>>,
   previousRowTops: React.MutableRefObject<Map<string, number>>,
   timerIdsRef: React.MutableRefObject<number[]>,
+  rafIdsRef: React.MutableRefObject<number[]>,
 ) {
   const nextRowIds = new Set(sorted.map(e => e.id));
 
@@ -184,12 +188,14 @@ function animateRowTransitions(
       rowNode.style.transition = 'none';
       rowNode.style.transform = `translateY(${deltaY}px)`;
       rowNode.style.willChange = 'transform';
-      requestAnimationFrame(() => {
+      const rafId = requestAnimationFrame(() => {
+        rafIdsRef.current = rafIdsRef.current.filter(id => id !== rafId);
         rowNode.style.transition = 'transform 380ms cubic-bezier(0.22, 1, 0.36, 1)';
         rowNode.style.transform = 'translateY(0)';
         const timerId = window.setTimeout(() => { rowNode.style.willChange = ''; }, 400);
         timerIdsRef.current.push(timerId);
       });
+      rafIdsRef.current.push(rafId);
     }
   }
 


### PR DESCRIPTION
## Summary

Adds a `rafIdsRef` to track all `requestAnimationFrame` handles created by `animateRowTransitions` and cancels them in `useLayoutEffect` cleanup, before clearing `timerIdsRef`.

**Root cause:** `requestAnimationFrame(() => { ... timerIdsRef.current.push(timerId); })` was called without saving the returned ID. The `useLayoutEffect` cleanup only cancelled `setTimeout` IDs in `timerIdsRef`, but any pending RAF could still fire after unmount — mutating detached DOM nodes and pushing new `setTimeout` IDs into an already-reset `timerIdsRef`.

**Fix:**
- Added `rafIdsRef = useRef<number[]>([])` in the component
- Passed it to `animateRowTransitions` alongside `timerIdsRef`
- Saved each `requestAnimationFrame` return value into `rafIdsRef`; removed the ID from the ref on fire (self-cleanup)
- Cleanup now calls `cancelAnimationFrame` on all pending RAF IDs before clearing `timerIdsRef`

## Changes

- `apps/mobile/src/components/screens/Leaderboard.tsx` — new `rafIdsRef`, updated `animateRowTransitions` signature and cleanup.

## Test plan

- [ ] Open Leaderboard while data is loading; verify row animations play correctly when data arrives.
- [ ] Navigate away mid-animation and verify no console errors from stale RAF callbacks mutating detached nodes.
- [ ] Verify that animations still complete correctly when the component stays mounted.

Closes #1519

---
_Generated by [Claude Code](https://claude.ai/code/session_013mmGwMw3fePcSvJiC7y64i)_