### PR TITLE
fix: clear OFFLINE_SYNC_SERVER_LOG_QUEUE_KEY in resetState on logout (closes #1524)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -5372,6 +5372,12 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     // blank default state to the DB if called before the next remote hydration
     // completes (closes #1132).
     setHasHydratedRemote(false);
+    // Clear the offline server-log queue so that a new user logging in on the
+    // same device does not have the previous user's queued logs flushed under
+    // their identity (closes #1524).
+    if (typeof window !== 'undefined') {
+      try { window.localStorage.removeItem(OFFLINE_SYNC_SERVER_LOG_QUEUE_KEY); } catch { /* ignore */ }
+    }
   }, []);
 
   // GDPR Art. 17 – Diritto alla cancellazione: elimina account e tutti i dati utente.


### PR DESCRIPTION
## Problem

`resetState()` (called on every logout) resets all React state but never clears `localStorage`. The key `OFFLINE_SYNC_SERVER_LOG_QUEUE_KEY` (`'tdp-mobile-offline-sync-server-logs-v1'`) remained intact across logouts. When a new user logged in, `flushMirroredClientLogsToServer()` picked up those stale entries and uploaded them under the new user's JWT, attributing previous-user logs to the wrong account.

## Fix

Added `localStorage.removeItem(OFFLINE_SYNC_SERVER_LOG_QUEUE_KEY)` inside `resetState()`, wrapped in the same `typeof window !== 'undefined'` + try/catch guard used elsewhere in this file. This mirrors how `deleteAccount` already clears `tdp-*` keys from `localStorage`.

## Files changed

- `apps/mobile/src/state/store.tsx` — 6 lines added to `resetState`

## Testing

- Log in as User A, perform actions that queue offline server logs.
- Log out (triggering `resetState`).
- Verify `localStorage.getItem('tdp-mobile-offline-sync-server-logs-v1')` returns `null`.
- Log in as User B and confirm no upload of User A's logs occurs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJXGX29pbezvH7uDF82gn3)_