### PR TITLE
fix: use result-ref instead of stale let-vars in registerTurn local/demo path (closes #1523)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4444,20 +4444,19 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       );
 
       if (!isSupabaseConfigured || !supabase || !authUserId) {
-        // Capture results of the setState updater for use in feedback after commit.
-        // All token/boost logic runs inside the updater so it always operates on
-        // the latest prev state, eliminating the stale-read race condition.
-        let localBoostApplied = false;
-        let localBoostRejectionReason: string | null = null;
-        let localRewards = computeTurnRewards(event, roleId);
-        let localTokenAtcl = 0;
-        let localTurnRecord: TurnRecord = buildTurnRecordFromPayload(
-          turnRegisterPayload,
-          localRewards,
-          'synced',
-          false,
-          null
-        );
+        // Use a ref to capture results computed inside the setState updater so
+        // that reads after setState() see the correct values regardless of when
+        // React schedules the updater — same pattern as startCourse/completeCourse
+        // (closes #1523).
+        type LocalDemoResult = {
+          boostApplied: boolean;
+          boostRejectionReason: string | null;
+          rewards: Rewards;
+          tokenAtcl: number;
+          turnRecord: TurnRecord;
+        };
+        const localResultRef: { current: LocalDemoResult | null } = { current: null };
+
         setState((prev: GameState) => {
           let boostApplied = false;
           let boostRejectionReason: string | null = null;
@@ -4484,12 +4483,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             boostApplied,
             boostRejectionReason
           );
-          // Capture results for feedback (last updater call wins, which is correct)
-          localBoostApplied = boostApplied;
-          localBoostRejectionReason = boostRejectionReason;
-          localRewards = rewards;
-          localTokenAtcl = nextTokenAtcl;
-          localTurnRecord = turnRecord;
+          // Capture results via ref — last updater invocation wins, which is
+          // correct because the final call determines the committed state.
+          localResultRef.current = { boostApplied, boostRejectionReason, rewards, tokenAtcl: nextTokenAtcl, turnRecord };
           const rewardedProfile = applyRewards(prev.profile, rewards, 'turn');
           return {
             profile: {
@@ -4500,12 +4496,14 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             turns: [turnRecord, ...prev.turns].slice(0, MAX_TURNS),
           };
         });
-        const localSyncStatus: TurnSyncStatus = boostRequested && !localBoostApplied ? 'failed_boost_fallback' : 'synced';
+
+        const local = localResultRef.current!;
+        const localSyncStatus: TurnSyncStatus = boostRequested && !local.boostApplied ? 'failed_boost_fallback' : 'synced';
         setTurnSyncFeedback({
           syncStatus: localSyncStatus,
           boostRequested,
-          boostApplied: localBoostApplied,
-          boostRejectionReason: localBoostRejectionReason,
+          boostApplied: local.boostApplied,
+          boostRejectionReason: local.boostRejectionReason,
           eventName: event.name,
           createdAt: Date.now(),
           geolocationAvailable: Boolean(geolocationSnapshot),
@@ -4514,11 +4512,11 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           ok: true,
           syncStatus: localSyncStatus,
           boostRequested,
-          boostApplied: localBoostApplied,
-          boostRejectionReason: localBoostRejectionReason,
-          rewards: localRewards,
-          tokenBalanceAfter: localTokenAtcl,
-          turn: localTurnRecord,
+          boostApplied: local.boostApplied,
+          boostRejectionReason: local.boostRejectionReason,
+          rewards: local.rewards,
+          tokenBalanceAfter: local.tokenAtcl,
+          turn: local.turnRecord,
         };
       }
 


### PR DESCRIPTION
## Problem

In the local/demo path of `registerTurn` (no Supabase / no auth), five `let` variables (`localBoostApplied`, `localBoostRejectionReason`, `localRewards`, `localTokenAtcl`, `localTurnRecord`) were declared with default values, mutated inside the `setState` updater, then read after `setState()` returned. In React 18, the updater is not guaranteed to be called synchronously from async contexts, meaning all five reads saw their initial defaults. The result was `boostApplied` always `false`, rewards never boosted, and both `setTurnSyncFeedback` and the return value incorrect.

## Fix

Replaced the five stale `let` variables with a single `localResultRef` object that is assigned inside the updater and read after `setState()` returns — the same pattern used in `startCourse`/`completeCourse` (issue #1361). The state transition logic inside the updater is unchanged; only the mechanism for surfacing results to the caller was restructured.

## Files changed

- `apps/mobile/src/state/store.tsx` — `registerTurn` local/demo branch refactored (net -2 lines)

## Testing

- Run the app in demo mode (no Supabase configured).
- Register a turn with `boostRequested: true` while having at least 1 `tokenAtcl`.
- Verify the returned `boostApplied` is `true`, the XP/cachet rewards are 10% boosted, and `tokenBalanceAfter` is decremented by 1.
- Verify `setTurnSyncFeedback` reflects the correct boost outcome in the UI.
- Repeat with `tokenAtcl === 0` and confirm `boostRejectionReason` is `'insufficient_token_balance'`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJXGX29pbezvH7uDF82gn3)_