### PR TITLE
fix: skip setAuthReady on WatchdogTimeoutError in restoreSession catch (closes #1527)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -22,7 +22,7 @@ import {
   COURSE_COOLDOWN_MS,
   type CourseSkill,
 } from '../gameplay/courses';
-import { withMobileWatchdog } from '../services/mobile-watchdog';
+import { withMobileWatchdog, WatchdogTimeoutError } from '../services/mobile-watchdog';
 import {
   applyMobileFeatureFlagOverrides,
   MOBILE_FEATURE_FLAGS_DEFAULTS,
@@ -3141,7 +3141,14 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
     restoreSession().catch((err) => {
       console.error('[restoreSession] unexpected error', err);
-      if (isMounted) setAuthReady(true);
+      // For WatchdogTimeoutError: withMobileWatchdog already showed the error
+      // overlay; the in-flight Supabase call continues and will trigger
+      // onAuthStateChange (below) which sets both authUserId and authReady
+      // correctly — setting authReady=true here without authUserId would
+      // produce a phantom logged-out state window (closes #1527).
+      if (isMounted && !(err instanceof WatchdogTimeoutError)) {
+        setAuthReady(true);
+      }
     });
 
     const { data: authListener } = supabase!.auth.onAuthStateChange((_event, session) => {


### PR DESCRIPTION
## Problem

When `withMobileWatchdog` fires its timeout during `restoreSession`, the catch block called `setAuthReady(true)` without ever calling `setAuthUserId`. This created a window where `authReady === true` and `authUserId === null`, causing route guards to treat an authenticated user as logged out.

The `onAuthStateChange` listener registered immediately after correctly sets both `authUserId` and `authReady` once the in-flight Supabase call settles — but the premature `setAuthReady(true)` in the catch could already have triggered a login redirect.

## Fix

- Import `WatchdogTimeoutError` from `mobile-watchdog`
- In the `.catch()` block, only call `setAuthReady(true)` for non-watchdog errors
- For `WatchdogTimeoutError`, the error overlay is already shown by `withMobileWatchdog`; `onAuthStateChange` will set both `authUserId` and `authReady` correctly when Supabase finishes

## Files changed

- `apps/mobile/src/state/store.tsx` — import + guarded catch block

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzZtnDe7BKWNY8VMRLvwCM)_