### PR TITLE
fix: add pending turn to local state in offline registerTurn path (closes #1528)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4539,11 +4539,11 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         // offline, before the queue flushes (closes #1528).
         setState((prev: GameState) => {
           const alreadyPresent = prev.turns.some((t) => t.id === pendingTurnRecord.id);
-          return {
-            turns: alreadyPresent
-              ? prev.turns.map((t) => (t.id === pendingTurnRecord.id ? { ...t, ...pendingTurnRecord } : t))
-              : [pendingTurnRecord, ...prev.turns].slice(0, MAX_TURNS),
-          };
+          const nextTurns = (alreadyPresent
+            ? prev.turns.map((t) => (t.id === pendingTurnRecord.id ? { ...t, ...pendingTurnRecord } : t))
+            : [pendingTurnRecord, ...prev.turns]
+          ).slice(0, MAX_TURNS);
+          return { ...prev, turns: nextTurns };
         });
         setTurnSyncFeedback({
           syncStatus: 'pending',

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4534,6 +4534,17 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           boostRequested,
         });
         enqueueSupabaseMutation(queuedMutation);
+        // Mirror the online-RPC-failure path: add the pending turn to local
+        // state immediately so it appears in history while the device is
+        // offline, before the queue flushes (closes #1528).
+        setState((prev: GameState) => {
+          const alreadyPresent = prev.turns.some((t) => t.id === pendingTurnRecord.id);
+          return {
+            turns: alreadyPresent
+              ? prev.turns.map((t) => (t.id === pendingTurnRecord.id ? { ...t, ...pendingTurnRecord } : t))
+              : [pendingTurnRecord, ...prev.turns].slice(0, MAX_TURNS),
+          };
+        });
         setTurnSyncFeedback({
           syncStatus: 'pending',
           boostRequested,


### PR DESCRIPTION
## Problem

In the `isNavigatorOffline()` branch of `registerTurn` (line 4530), the code enqueued the mutation and returned `ok: true` but never called `setState` to add `pendingTurnRecord` to `state.turns`. The turn was absent from every history/list view until connectivity was restored and the queue flushed.

This was inconsistent with the online-but-RPC-failed path (line 4629) which correctly inserts `pendingTurnRecord` into state immediately.

## Fix

Added a `setState` call inside the offline branch to insert `pendingTurnRecord` into `state.turns` immediately (with the same dedup guard used in the online fallback path).

## Files changed

- `apps/mobile/src/state/store.tsx` — add `setState` in offline early-return branch

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzZtnDe7BKWNY8VMRLvwCM)_