### PR TITLE
fix: bind error in ChangePassword catch block for logging (closes #1534)

### DIFF
--- a/apps/mobile/src/components/screens/ChangePassword.tsx
+++ b/apps/mobile/src/components/screens/ChangePassword.tsx
@@ -90,7 +90,9 @@ export function ChangePassword({
       }, 1500);
       // Keep isSubmitting=true for the full 1500ms navigation delay so the
       // button stays disabled and a second submission cannot be triggered.
-    } catch {
+    } catch (err) {
+      if (!isMountedRef.current) return;
+      console.error('[ChangePassword] password update failed', err);
       setIsSubmitting(false);
       setErrorMessage('Impossibile aggiornare la password. Riprova più tardi.');
     }


### PR DESCRIPTION
## Summary

- Adds error binding to the `catch` block in `ChangePassword.handleSubmit`
- Logs the actual error via `console.error` so failures are visible in diagnostics
- Adds `isMountedRef.current` guard on the catch path (already present on success path)

## Problem

`catch { ... }` with no binding silently discards the actual error thrown by `onChangePassword`. This makes it impossible to distinguish wrong-current-password errors from network failures or Supabase-specific rejections in logs or crash reporters.

## Fix

```diff
-} catch {
+} catch (err) {
+  if (!isMountedRef.current) return;
+  console.error('[ChangePassword] password update failed', err);
   setIsSubmitting(false);
   setErrorMessage('Impossibile aggiornare la password. Riprova più tardi.');
 }
```

The user-facing message stays generic as intended; the error is now available for debugging.

## Test plan

- [ ] Submit with wrong current password → generic error message shown, actual error logged to console
- [ ] Submit with valid passwords → success message and navigation back after 1500ms
- [ ] Simulate network failure → generic error message shown

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7ek39FEem46XVhueifjFd)_