### PR TITLE
fix: call persistProfile before setState in completeOnboarding/updateProfile (closes #1535)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4332,45 +4332,57 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
   const completeOnboarding = useCallback(
     (variant: 'full' | 'skipped_qr' | 'skipped_manual', xpReward?: number) => {
       const completedAt = new Date().toISOString();
-      // Compute nextProfile inside the setState updater using prev.profile so
-      // concurrent profile mutations are not silently clobbered (closes #1378).
-      // A plain object ref captures the computed value for persistProfile without
-      // relying on the potentially-deferred updater running synchronously.
-      const nextProfileRef: { current: PlayerProfile | null } = { current: null };
+      // Compute next profile from the render-time snapshot so persistProfile can
+      // be called synchronously. The ref-inside-updater pattern was broken: React
+      // 18 (createRoot) defers useState updaters to the commit phase, so
+      // nextProfileRef.current was always null when checked after setState()
+      // (closes #1535, regression of #1312).
+      let next: PlayerProfile = {
+        ...state.profile,
+        onboardingCompletedAt: completedAt,
+        onboardingVariant: variant,
+      };
+      if (xpReward && xpReward > 0) {
+        next = applyRewards(next, { xp: xpReward, cachet: 0, reputation: 0 }, 'activity');
+      }
+      persistProfile(next);
+      // The updater re-derives from prev.profile so that any concurrent profile
+      // mutation between this render and the next commit is not clobbered
+      // (same trade-off as startCourse, closes #1378).
       setState((prev: GameState) => {
-        let next: PlayerProfile = {
+        let nextFromPrev: PlayerProfile = {
           ...prev.profile,
           onboardingCompletedAt: completedAt,
           onboardingVariant: variant,
         };
         if (xpReward && xpReward > 0) {
-          next = applyRewards(next, { xp: xpReward, cachet: 0, reputation: 0 }, 'activity');
+          nextFromPrev = applyRewards(nextFromPrev, { xp: xpReward, cachet: 0, reputation: 0 }, 'activity');
         }
-        nextProfileRef.current = next;
-        return { ...prev, profile: next };
+        return { ...prev, profile: nextFromPrev };
       });
-      if (nextProfileRef.current) persistProfile(nextProfileRef.current);
     },
-    [persistProfile],
+    [persistProfile, state.profile],
   );
 
   const updateProfile = useCallback(
     (updates: Partial<Pick<PlayerProfile, 'name' | 'email' | 'roleId' | 'profileImage' | 'leaderboardVisible'>>) => {
-      // Compute nextProfile inside the setState updater using prev.profile so
-      // concurrent profile mutations are not silently clobbered (closes #1378).
-      const nextProfileRef: { current: PlayerProfile | null } = { current: null };
+      // Compute from render-time snapshot for persistProfile (closes #1535).
+      const nextRole =
+        updates.roleId && catalogRolesRef.current.some((role: Role) => role.id === updates.roleId)
+          ? updates.roleId
+          : state.profile.roleId;
+      const next: PlayerProfile = { ...state.profile, ...updates, roleId: nextRole ?? state.profile.roleId };
+      persistProfile(next);
+      // Updater re-derives from prev.profile to preserve concurrent mutations.
       setState((prev: GameState) => {
-        const nextRole =
+        const prevRole =
           updates.roleId && catalogRolesRef.current.some((role: Role) => role.id === updates.roleId)
             ? updates.roleId
             : prev.profile.roleId;
-        const next: PlayerProfile = { ...prev.profile, ...updates, roleId: nextRole ?? prev.profile.roleId };
-        nextProfileRef.current = next;
-        return { ...prev, profile: next };
+        return { ...prev, profile: { ...prev.profile, ...updates, roleId: prevRole ?? prev.profile.roleId } };
       });
-      if (nextProfileRef.current) persistProfile(nextProfileRef.current);
     },
-    [persistProfile]
+    [persistProfile, state.profile],
   );
 
   const registerTurn = useCallback(


### PR DESCRIPTION
## Summary

- Moves `persistProfile` call before `setState` in both `completeOnboarding` and `updateProfile`
- Replaces the broken `nextProfileRef` pattern with a direct computation from `state.profile`
- The `setState` updater still re-derives from `prev.profile` to avoid clobbering concurrent mutations
- Adds `state.profile` to the `useCallback` dependency arrays for both functions

## Problem

`nextProfileRef` was populated inside the `setState` updater, but React 18 (`createRoot`) defers updater functions to the commit phase — they don't run synchronously at the point of the `setState(fn)` call. The `if (nextProfileRef.current) persistProfile(...)` guard always evaluated to `false`, so `persistProfile` was silently never called after `completeOnboarding` or `updateProfile`.

Profile changes (name, email, role, avatar, leaderboard flag, onboarding state) were applied to local React state but never synced to Supabase. On app close before another sync trigger, those changes were lost.

This is a recurrence of the pattern tracked in #1312 ("capturedProfileRef pattern is broken").

## Fix approach

Compute the next profile from the render-time `state.profile` snapshot **before** calling `setState`, then call `persistProfile` synchronously with the result. The `setState` updater independently re-derives the profile from `prev.profile` (the freshest state at commit time) to preserve any concurrent mutations that may have occurred between the render and the commit — the same trade-off documented in `startCourse` (closes #1378).

## Test plan

- [ ] Complete onboarding → profile changes are visible in Supabase after page refresh
- [ ] Update profile (name/role/avatar) → changes persist after page refresh
- [ ] Complete onboarding with XP reward → XP is reflected in Supabase profile

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7ek39FEem46XVhueifjFd)_