### PR TITLE
fix: check evaluate_my_badges RPC error in refreshBadges (closes #1536)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -2507,7 +2507,11 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       async () => {
         setBadgesLoading(true);
         try {
-          await supabase!.rpc('evaluate_my_badges');
+          const { error: rpcError } = await supabase!.rpc('evaluate_my_badges');
+          if (rpcError) {
+            console.error('[refreshBadges] evaluate_my_badges RPC failed', rpcError.message);
+            return;
+          }
           const { data, error } = await supabase!
             .from('my_badges')
             .select('id,title,description,icon,metric,threshold,is_hidden,unlocked_at,seen_at,unlocked')


### PR DESCRIPTION
## Summary

- Destructures the return value of `supabase.rpc('evaluate_my_badges')` to capture `rpcError`
- Returns early and logs the error if the RPC fails, skipping the subsequent SELECT
- Prevents stale badge rows from being shown as if evaluation succeeded

## Problem

`await supabase!.rpc('evaluate_my_badges')` discarded its return value entirely. When the RPC call failed (network error, DB error, permission denied), the error was silently swallowed and execution continued to SELECT from `my_badges`. The SELECT returned stale, previously-evaluated rows, so users saw outdated badge state with no indication that the refresh had actually failed.

## Fix

```diff
-await supabase!.rpc('evaluate_my_badges');
+const { error: rpcError } = await supabase!.rpc('evaluate_my_badges');
+if (rpcError) {
+  console.error('[refreshBadges] evaluate_my_badges RPC failed', rpcError.message);
+  return;
+}
 const { data, error } = await supabase!.from('my_badges').select('...');
```

## Test plan

- [ ] Normal flow: badges are refreshed and displayed correctly
- [ ] Simulate RPC failure (revoke function permissions): `refreshBadges` returns early, no stale badge update shown, error logged to console

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7ek39FEem46XVhueifjFd)_