### PR TITLE
fix: return 503 when dev-access audit log insert fails (closes #1537)

### DIFF
--- a/supabase/functions/dev-access/index.ts
+++ b/supabase/functions/dev-access/index.ts
@@ -141,6 +141,7 @@ serve(async (req) => {
   const { error: insertError } = await adminClient.from('dev_access_audit').insert(auditEntry);
   if (insertError) {
     console.error('Dev access audit insert failed', insertError.message);
+    return jsonResponse({ error: 'Audit logging unavailable. Access denied.' }, 503);
   }
 
   return jsonResponse({ allowed: false, reason: 'Accesso non autorizzato.' }, 403);


### PR DESCRIPTION
## Summary

- Returns HTTP 503 when the `dev_access_audit` insert fails instead of silently continuing to a 403
- Ensures callers and monitoring systems can detect when audit logging is unavailable

## Problem

When the `dev_access_audit` insert failed (e.g. during a DB outage), the error was only logged to `console.error` and a normal 403 was returned. From the caller's perspective this looked like a successful deny decision. During a DB outage, every unauthorized access attempt went completely unrecorded in the audit trail with no signal to the caller or any monitoring system.

## Fix

```diff
 if (insertError) {
   console.error('Dev access audit insert failed', insertError.message);
+  return jsonResponse({ error: 'Audit logging unavailable. Access denied.' }, 503);
 }
```

A 503 signals explicitly that the access was denied AND that the audit record was not written, so clients can retry, alert, or fall back accordingly.

## Test plan

- [ ] Normal unauthorized access: 403 returned, audit record inserted
- [ ] Simulate DB failure (revoke insert permission): 503 returned instead of 403, error logged

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7ek39FEem46XVhueifjFd)_