### PR TITLE
fix: close TOCTOU race in delete-my-account reserved_by nullify (closes #1543)

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -156,6 +156,19 @@ serve(async (req) => {
     console.error('delete-my-account: storage cleanup timed out or failed (non-fatal)', storageError);
   }
 
+  // Final sweep: nullify any reserved_by references that survived the delete loop.
+  // Closes the TOCTOU window where a ticket was activated between step 1 (nullify
+  // activated tickets) and step 2 (delete unactivated tickets): such a ticket would
+  // have been skipped by both steps, leaving the deleted user's UUID in reserved_by.
+  // Non-fatal — log and continue so the auth user is still removed (closes #1543).
+  const { error: finalNullifyError } = await adminClient
+    .from('ticket_activations')
+    .update({ reserved_by: null })
+    .eq('reserved_by', userId);
+  if (finalNullifyError) {
+    console.error('delete-my-account: failed to nullify surviving reserved_by references', finalNullifyError.message);
+  }
+
   // 3. Delete the auth user (must be last — only reached if all data was cleaned)
   const { error: deleteUserError } = await adminClient.auth.admin.deleteUser(userId);
   if (deleteUserError) {


### PR DESCRIPTION
## Intent

Closes the TOCTOU window in `delete-my-account` where a `ticket_activations` row could escape both the step-1 nullify and the step-2 delete, leaving the deleted user's UUID in `reserved_by` permanently — a GDPR Art. 17 violation.

## Root cause

- **Step 1** (nullify `reserved_by`) filters `.not('activated_by', 'is', null)` — only touches already-activated tickets.  
- **Step 2** (delete `ticket_activations` by `reserved_by`) filters `.is('activated_by', null)` — only touches unactivated tickets.  
- If a ticket is activated _between_ Steps 1 and 2, it was unactivated during Step 1 (skipped) and is activated during Step 2 (skipped). Result: `reserved_by` still holds the deleted user's UUID.

## Key changes

`supabase/functions/delete-my-account/index.ts`

- Added an unconditional final nullify (`UPDATE ticket_activations SET reserved_by = NULL WHERE reserved_by = userId`) after the storage cleanup block and before `adminClient.auth.admin.deleteUser`.
- Non-fatal: logs the error but continues so the auth user is still removed — a stuck `reserved_by` reference is preferable to leaving the auth account alive.

## Testing

- Manual: verify that accounts can still be deleted successfully end-to-end.
- Edge case: the new query is idempotent and runs even when no tickets are in the race window (no-op).

---
_Generated by [Claude Code](https://claude.ai/code/session_01181f8uGNno5pd3u5JW1tb6)_