### PR TITLE
fix: validate activate_hash format with hex-64 regex (closes #1544)

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -257,6 +257,18 @@ serve(async (req: Request) => {
       // SELECT + UPDATE … RETURNING in one statement (see issue #1304).
       let targetHash = hash;
 
+      // Validate hash format for activate_hash (closes #1544).
+      // reserve_hash and resolve_hash already enforce /^[0-9a-f]{64}$/ but
+      // activate_hash only checked !hash (truthy), allowing malformed input to
+      // reach the UPDATE query and potentially trigger unexpected DB behaviour.
+      if (action === 'activate_hash') {
+        const normalizedHash = typeof hash === 'string' ? hash.trim().toLowerCase() : '';
+        if (!/^[0-9a-f]{64}$/.test(normalizedHash)) {
+          return jsonResponse({ ok: false, error: 'Hash non valido.' }, 200);
+        }
+        targetHash = normalizedHash;
+      }
+
       if (action === 'activate_by_details') {
         const { data: ticket, error: lookupError } = await supabase
           .from('ticket_activations')


### PR DESCRIPTION
## Intent

Closes #1544. The `activate_hash` action accepted any truthy string as a hash, unlike `reserve_hash` and `resolve_hash` which both enforce `/^[0-9a-f]{64}$/`. This allowed malformed input to reach the UPDATE query.

## Key changes

`supabase/functions/ticket-activation/index.ts`

- After `let targetHash = hash;`, when `action === 'activate_hash'`, normalize (trim + lowercase) the hash and validate it against `/^[0-9a-f]{64}$/`.
- Returns `{ ok: false, error: 'Hash non valido.' }` (same format as `resolve_hash`) for invalid input.
- Also stores the normalized form into `targetHash`, making the hash consistent with the values inserted by `reserve_hash` (which also lowercases before storing).

## Testing

- Valid 64-char hex hash → proceeds to UPDATE as before.
- Short/malformed string → returns `{ ok: false, error: 'Hash non valido.' }` immediately, no DB query.

---
_Generated by [Claude Code](https://claude.ai/code/session_01181f8uGNno5pd3u5JW1tb6)_