### PR TITLE
fix: guard onSuccess timer with isMountedRef in EventConfirmation (closes #1545)

### DIFF
--- a/apps/mobile/src/components/screens/EventConfirmation.tsx
+++ b/apps/mobile/src/components/screens/EventConfirmation.tsx
@@ -33,9 +33,11 @@ export function EventConfirmation({
   const [isOffline, setIsOffline] = useState(() => typeof navigator !== 'undefined' && navigator.onLine === false);
   const successTimeoutRef = useRef<number | null>(null);
   const isSubmittingRef = useRef(false);
+  const isMountedRef = useRef(true);
 
   useEffect(() => {
     return () => {
+      isMountedRef.current = false;
       if (successTimeoutRef.current !== null) window.clearTimeout(successTimeoutRef.current);
     };
   }, []);
@@ -74,7 +76,10 @@ export function EventConfirmation({
       if (!result.ok) { setConfirmError(result.error); return; }
       setConfirmResult(result);
       setIsSuccess(true);
-      successTimeoutRef.current = window.setTimeout(() => onSuccess(), 1500);
+      // Guard against the component unmounting during the await above (closes #1545).
+      if (isMountedRef.current) {
+        successTimeoutRef.current = window.setTimeout(() => onSuccess(), 1500);
+      }
     } catch (error) {
       setConfirmError(error instanceof Error ? error.message : 'Errore durante la registrazione turno.');
     } finally {


### PR DESCRIPTION
## Intent

Closes #1545. If the component unmounts while `await onConfirm()` is in flight, the existing cleanup effect fires and tries to clear `successTimeoutRef` (which is still `null`). Execution then resumes after the `await`, sets the timer unconditionally, and `onSuccess()` fires from an unmounted component — potentially triggering a navigation or state update on a dead tree.

## Key changes

`apps/mobile/src/components/screens/EventConfirmation.tsx`

- Added `isMountedRef = useRef(true)`.
- Cleanup effect now sets `isMountedRef.current = false` before clearing the timeout, so any resumed async path can detect the unmount.
- `window.setTimeout(() => onSuccess(), 1500)` is now guarded by `if (isMountedRef.current)` — if the component is already gone, the callback is never scheduled.

## Testing

- Normal path: confirm succeeds, component is mounted → timer fires → `onSuccess()` is called. No regression.
- Unmount-during-await: component navigates away while the server call is in flight → timer is never set → no stale callback.

---
_Generated by [Claude Code](https://claude.ai/code/session_01181f8uGNno5pd3u5JW1tb6)_