### PR TITLE
fix: clear signupInProgressRef with 10s safety-net timer if SIGNED_IN never fires (closes #1546)

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -163,7 +163,10 @@ export function useAuth(
         });
         updateProfile({ name: displayName, email });
         onAuthChange('welcome'); // Flow will continue to role-selection
-        // signupInProgressRef is cleared by the SIGNED_IN listener below.
+        // Safety net: if SIGNED_IN never fires (WebSocket failure, token not
+        // issued), clear the ref so future logins navigate to 'home' (closes #1546).
+        setTimeout(() => { signupInProgressRef.current = false; }, 10_000);
+        // signupInProgressRef is also cleared by the SIGNED_IN listener below.
     }, [onAuthChange, updateProfile]);
 
     // Set to true immediately before a voluntary signOut so the SIGNED_OUT


### PR DESCRIPTION
## Intent

Closes #1546. `signupInProgressRef` is set `true` before `supabase.auth.signUp()` and is expected to be cleared by the `SIGNED_IN` auth-state listener. If the WebSocket connection fails and `SIGNED_IN` never fires, the ref stays `true` permanently. On the next login the listener reads `isSignupEvent = true`, sets `navigateTo = undefined`, and the authenticated user is never redirected to home.

## Key changes

`apps/mobile/src/hooks/useAuth.ts`

- After `onAuthChange('welcome')` in the successful signup path, added `setTimeout(() => { signupInProgressRef.current = false; }, 10_000)`.
- The timeout is a safety net only — when `SIGNED_IN` fires normally (within milliseconds), the listener clears the ref first and the timer fires on an already-`false` value (no-op).
- 10 seconds is long enough for a slow but successful handshake and short enough to not block a login attempt that follows immediately after a connectivity hiccup.

## Testing

- Normal signup: `SIGNED_IN` fires, clears ref, timer fires harmlessly.
- `SIGNED_IN` delayed/missing: ref clears after 10s, subsequent login navigates to `home` correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01181f8uGNno5pd3u5JW1tb6)_