### PR TITLE
fix: replace nextProfileRef pattern in completeNarrativeChoice/startCourse/completeCourse (closes #1547)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -4961,16 +4961,13 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       // synchronously afterward, which is safe because the ref write happens
       // inside the updater body (before the next line after setState executes
       // in any React scheduler tick that matters for us).
-      const nextProfileRef: { current: ReturnType<typeof applyRewards> | null } = { current: null };
-      setState((prev: GameState) => {
-        const computed = applyRewards(prev.profile, rewards, 'activity');
-        nextProfileRef.current = computed;
-        return { ...prev, profile: computed };
-      });
-
       // 1b. Persist updated profile to server so XP/cachet/reputation survive
-      // a page reload (closes #1200, #1377).
-      if (nextProfileRef.current) persistProfile(nextProfileRef.current);
+      // a page reload. Compute from render-time snapshot first so persistProfile
+      // is called synchronously — React 18 defers the setState updater, making
+      // nextProfileRef.current still null when read immediately after setState()
+      // (closes #1200, #1377, #1547; same pattern as completeOnboarding / #1535).
+      persistProfile(applyRewards(state.profile, rewards, 'activity'));
+      setState((prev: GameState) => ({ ...prev, profile: applyRewards(prev.profile, rewards, 'activity') }));
 
       // 2. Persist to narrative_history (append-only, RLS-scoped to user).
       // Best-effort: a failed insert does not roll back local rewards. Without
@@ -4995,7 +4992,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
       return { ok: true, rewards };
     },
-    [authUserId, persistProfile]
+    [authUserId, persistProfile, state.profile]
   );
 
   const resetProgress = useCallback(async () => {
@@ -5242,13 +5239,11 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       // since they gate on game-logic invariants rather than numeric values that
       // could race. The state transition itself uses prev.profile.
       const startedAt = new Date().toISOString();
-      const nextProfileRef: { current: PlayerProfile | null } = { current: null };
-      setState((prev) => {
-        const p = prev.profile;
+      const computeStartedProfile = (p: PlayerProfile): PlayerProfile => {
         const pSkills = p.skills ?? { precision: 0, presence: 0, creativity: 0, leadership: 0 };
         const pActiveCourses = p.activeCourses ?? {};
         const pCompletedCourses = p.completedCourses ?? {};
-        const next: PlayerProfile = {
+        return {
           ...p,
           // Clamp to 0: the guard above uses the render-time snapshot, so a
           // concurrent mutation could reduce prev.cachet below costCachet before
@@ -5256,17 +5251,13 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           cachet: Math.max(0, p.cachet - course.costCachet),
           skills: pSkills,
           completedCourses: pCompletedCourses,
-          activeCourses: {
-            ...pActiveCourses,
-            [courseId]: startedAt,
-          },
+          activeCourses: { ...pActiveCourses, [courseId]: startedAt },
         };
-        nextProfileRef.current = next;
-        return { ...prev, profile: next };
-      });
-
-      // Sync course state to Supabase so a page refresh doesn't reset progress.
-      if (nextProfileRef.current) persistProfile(nextProfileRef.current);
+      };
+      // Persist synchronously from render-time snapshot; re-derive from prev
+      // inside setState so concurrent mutations are not clobbered (closes #1547).
+      persistProfile(computeStartedProfile(state.profile));
+      setState((prev) => ({ ...prev, profile: computeStartedProfile(prev.profile) }));
 
       return { ok: true };
     },
@@ -5316,16 +5307,14 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       // Compute nextProfile inside the setState updater using prev.profile so
       // concurrent profile mutations are not silently clobbered (closes #1378).
       const completedAt = new Date().toISOString();
-      const nextProfileRef: { current: PlayerProfile | null } = { current: null };
-      setState((prev) => {
-        const p = prev.profile;
+      const courseRewards: Rewards = { xp: xpGained, cachet: 0, reputation: 0 };
+      const computeCompletedProfile = (p: PlayerProfile): PlayerProfile => {
         const pSkills = p.skills ?? { precision: 0, presence: 0, creativity: 0, leadership: 0 };
         const pActiveCourses = p.activeCourses ?? {};
         const pCompletedCourses = p.completedCourses ?? {};
 
         // Applica XP tramite lo stesso helper usato dalle attività.
-        const rewards: Rewards = { xp: xpGained, cachet: 0, reputation: 0 };
-        const profileWithXp = applyRewards(p, rewards, 'activity');
+        const profileWithXp = applyRewards(p, courseRewards, 'activity');
 
         const updatedSkills = {
           ...pSkills,
@@ -5335,21 +5324,17 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         // Rimuovi dai corsi attivi e aggiungi ai completati.
         const { [courseId]: _removed, ...remainingActive } = pActiveCourses;
 
-        const next: PlayerProfile = {
+        return {
           ...profileWithXp,
           skills: updatedSkills,
-          completedCourses: {
-            ...pCompletedCourses,
-            [courseId]: completedAt,
-          },
+          completedCourses: { ...pCompletedCourses, [courseId]: completedAt },
           activeCourses: remainingActive,
         };
-        nextProfileRef.current = next;
-        return { ...prev, profile: next };
-      });
-
-      // Sync completed skills and cooldown timestamps to Supabase.
-      if (nextProfileRef.current) persistProfile(nextProfileRef.current);
+      };
+      // Persist synchronously from render-time snapshot; re-derive from prev
+      // inside setState so concurrent mutations are not clobbered (closes #1547).
+      persistProfile(computeCompletedProfile(state.profile));
+      setState((prev) => ({ ...prev, profile: computeCompletedProfile(prev.profile) }));
 
       return { ok: true, xpGained, skillGained, pointsGained };
     },


### PR DESCRIPTION
## Intent

Closes #1547. Three store functions — `completeNarrativeChoice`, `startCourse`, `completeCourse` — use the same `nextProfileRef`-inside-setState anti-pattern that was already fixed in `completeOnboarding` (#1535). In React 18, the `setState` updater is deferred to the commit phase; reading `nextProfileRef.current` immediately after `setState()` always returns `null`, so `persistProfile` is silently skipped and XP/cachet/skills are lost on page reload.

## Root cause

```typescript
const nextProfileRef = { current: null };
setState((prev) => { nextProfileRef.current = compute(prev); return ...; });
if (nextProfileRef.current) persistProfile(nextProfileRef.current); // always null in React 18
```

## Key changes

`apps/mobile/src/state/store.tsx`

All three functions now follow the `completeOnboarding` pattern:

1. **Compute from the render-time snapshot** (`state.profile`) synchronously and call `persistProfile` immediately — no deferred updater involved.
2. **`setState` re-derives from `prev.profile`** — preserves any concurrent mutations that arrived between the render and the commit.
3. `completeNarrativeChoice`: extracted a local `computeStartedProfile` helper; also added `state.profile` to its `useCallback` deps (it was missing, which would have staled the closure even if the ref pattern had worked).
4. `startCourse` / `completeCourse`: extracted `computeStartedProfile` / `computeCompletedProfile` local helpers; `state.profile` was already in their deps.

## Testing

- Start a course, reload: cachet deduction and `activeCourses` entry survive reload.
- Complete a course, reload: XP gain, skill point, `completedCourses` entry survive reload.
- Complete a narrative choice, reload: XP/cachet/reputation survive reload.

---
_Generated by [Claude Code](https://claude.ai/code/session_01181f8uGNno5pd3u5JW1tb6)_