### PR TITLE
fix: return allowed:false on audit insert failure in dev-access

### DIFF
--- a/supabase/functions/dev-access/index.ts
+++ b/supabase/functions/dev-access/index.ts
@@ -141,7 +141,7 @@ serve(async (req) => {
   const { error: insertError } = await adminClient.from('dev_access_audit').insert(auditEntry);
   if (insertError) {
     console.error('Dev access audit insert failed', insertError.message);
-    return jsonResponse({ error: 'Audit logging unavailable. Access denied.' }, 503);
+    return jsonResponse({ allowed: false, reason: 'Audit logging unavailable. Access denied.' }, 503);
   }
 
   return jsonResponse({ allowed: false, reason: 'Accesso non autorizzato.' }, 403);


### PR DESCRIPTION
## Summary

Closes #1553

When the audit log insert into `dev_access_audit` fails, the catch block was returning `{ error: string }` instead of the expected `{ allowed: boolean }` shape defined by `DevAccessResponse`. Any client checking `result.allowed === false` on a 503 response would read `undefined` (falsy but not `false`) and could mistakenly treat it as an access grant.

## Changes

- **`supabase/functions/dev-access/index.ts`** (line 144): Changed the error response in the audit-insert catch block from `{ error: '...' }` to `{ allowed: false, reason: '...' }` with HTTP status 503, matching the `DevAccessResponse` type throughout.

## Testing

- Clients checking `result.allowed === false` on a 503 now correctly receive `false` and treat the response as an access denial.
- The `jsonResponse` helper's TypeScript signature is satisfied — no longer passing an incompatible object shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDBjnYxybajxsv4qdpE1gW)_