### PR TITLE
fix: guard setHasHydratedRemote behind isMounted in no-email auth path (closes #1557)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3938,7 +3938,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
             // Fix #1127 (Bug 2): set hasHydratedRemote=true before returning so
             // the guard doesn't stay false permanently after the error is dismissed,
             // which would block sync operations and certain effects indefinitely.
-            setHasHydratedRemote(true);
+            // Guard added for #1557: isMounted check must precede the call so the
+            // setter is not invoked on an unmounted instance (provider race window).
+            if (isMounted) setHasHydratedRemote(true);
             return;
           }
 


### PR DESCRIPTION
## Summary

Fixes #1557.

In `loadRemoteState`'s `useEffect`, the `else if (!profileRow)` branch (anonymous/no-email auth) called `setHasHydratedRemote(true)` and then immediately returned — placing it **before** the `if (!isMounted) return;` guard at line 3945, making that guard dead code for this path.

If the store provider unmounts between the async `profiles.insert` call and this line, the setter fires on the unmounted instance.

**Fix:** Wrap the call in `if (isMounted)` so it is consistent with every other state setter in the same effect.

## Changes

- `apps/mobile/src/state/store.tsx`: added `isMounted` guard around `setHasHydratedRemote(true)` in the no-email auth early-return path.

## Test plan

- [ ] Sign in with an anonymous/no-email Supabase session; confirm app still unblocks normally.
- [ ] Rapid unmount of the store provider while `profiles.insert` is in-flight should not produce React warnings about setState on unmounted component.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KL3pspmM3SsY8c3yDSXPB2)_