### PR TITLE
fix: cancel signup safety-net timer on unmount in useAuth (closes #1558)

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -165,7 +165,9 @@ export function useAuth(
         onAuthChange('welcome'); // Flow will continue to role-selection
         // Safety net: if SIGNED_IN never fires (WebSocket failure, token not
         // issued), clear the ref so future logins navigate to 'home' (closes #1546).
-        setTimeout(() => { signupInProgressRef.current = false; }, 10_000);
+        // Timer ID stored in signupTimerRef so it can be cancelled on unmount (fixes #1558).
+        if (signupTimerRef.current !== null) clearTimeout(signupTimerRef.current);
+        signupTimerRef.current = setTimeout(() => { signupInProgressRef.current = false; }, 10_000);
         // signupInProgressRef is also cleared by the SIGNED_IN listener below.
     }, [onAuthChange, updateProfile]);
 
@@ -177,6 +179,9 @@ export function useAuth(
     // listener does not overwrite the 'welcome' navigation with 'home' when
     // Supabase returns an immediate session (fixes #1445).
     const signupInProgressRef = useRef(false);
+    // Stores the ID of the 10-second safety-net timer so it can be cancelled
+    // when the component unmounts (fixes #1558).
+    const signupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const handleLogoutAction = useCallback(async () => {
         setAuthError(null);
@@ -304,6 +309,7 @@ export function useAuth(
         return () => {
             mounted = false;
             authListener?.subscription.unsubscribe();
+            if (signupTimerRef.current !== null) clearTimeout(signupTimerRef.current);
         };
     }, []);
 


### PR DESCRIPTION
## Summary

Fixes #1558.

`handleSignup` schedules a 10-second safety-net timer (`setTimeout`) to reset `signupInProgressRef` if `SIGNED_IN` never fires. The timer ID was not captured and never cleared, so if the component unmounted within 10 seconds of a successful signup, the callback fired on the dead instance.

**Fix:**
- Added `signupTimerRef` (a `useRef`) to store the timer ID.
- `handleSignup` now clears any previous timer before scheduling a new one (prevents stacking on rapid re-signup).
- The existing `useEffect` cleanup (which already unsubscribes the auth listener) now also calls `clearTimeout(signupTimerRef.current)`.

## Changes

- `apps/mobile/src/hooks/useAuth.ts`: added `signupTimerRef`, captured timer ID in `handleSignup`, and added `clearTimeout` in `useEffect` cleanup.

## Test plan

- [ ] Complete a signup where Supabase returns an immediate session (email confirmation disabled).
- [ ] Navigate away within 10 seconds; confirm no React warnings about setState on unmounted component.
- [ ] Confirm `signupInProgressRef` is still reset correctly on subsequent logins.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KL3pspmM3SsY8c3yDSXPB2)_