### PR TITLE
fix: return 403 instead of 503 when audit insert fails in dev-access (closes #1559)

### DIFF
--- a/supabase/functions/dev-access/index.ts
+++ b/supabase/functions/dev-access/index.ts
@@ -140,8 +140,9 @@ serve(async (req) => {
 
   const { error: insertError } = await adminClient.from('dev_access_audit').insert(auditEntry);
   if (insertError) {
+    // Audit insert failed but the access decision (denied) is final regardless.
+    // Return 403, not 503 — 5xx signals clients to retry, which is wrong here (fixes #1559).
     console.error('Dev access audit insert failed', insertError.message);
-    return jsonResponse({ allowed: false, reason: 'Audit logging unavailable. Access denied.' }, 503);
   }
 
   return jsonResponse({ allowed: false, reason: 'Accesso non autorizzato.' }, 403);


### PR DESCRIPTION
## Summary

Fixes #1559.

When a denied user's audit-log insert failed (e.g. `dev_access_audit` table unavailable), the function previously returned **HTTP 503** ("Service Temporarily Unavailable"). Standard HTTP retry logic on 5xx responses would cause clients to loop indefinitely rather than accepting the denial.

The access decision — **denied** — is final and does not depend on whether the audit trail was written. The correct status is **403 Forbidden**.

**Fix:** Changed the audit-failure path to fall through to the normal `403` response and log the insert error server-side instead of returning early with a 503.

## Changes

- `supabase/functions/dev-access/index.ts`: audit insert error now logs and falls through to `return jsonResponse({ allowed: false, reason: 'Accesso non autorizzato.' }, 403)` instead of returning 503.

## Test plan

- [ ] Deny an unauthorized user while `dev_access_audit` is unavailable — should receive 403, not 503.
- [ ] Authorized users unaffected (audit insert path never reached for allowed users).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KL3pspmM3SsY8c3yDSXPB2)_