### PR TITLE
fix: validate APP_REPO format to prevent path-traversal in app-version (closes #1560)

### DIFF
--- a/supabase/functions/app-version/index.ts
+++ b/supabase/functions/app-version/index.ts
@@ -65,6 +65,11 @@ serve(async (req) => {
 
   const appVersion = Deno.env.get('APP_VERSION') ?? '0.0.5';
   const repo = Deno.env.get('APP_REPO') ?? 'ATCL-Lazio/Turni-di-Palco';
+  // Validate repo format to prevent path-traversal of the GITHUB_TOKEN (fixes #1560).
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+    console.error('[app-version] Invalid APP_REPO value:', repo);
+    return errorResponse('Service misconfigured', 500);
+  }
   const githubToken = Deno.env.get('GITHUB_TOKEN');
 
   let payload: { limit?: number } = {};


### PR DESCRIPTION
## Summary

Fixes #1560.

`app-version` interpolated the `APP_REPO` env var directly into a GitHub API URL with no format validation. A value containing path-traversal sequences (e.g. `owner/repo/../../users`) would redirect the authenticated request — including the `Authorization: Bearer <GITHUB_TOKEN>` header — to an unintended GitHub API endpoint.

Exploitability requires operator misconfiguration or a compromised secrets store; the value is server-side only and not user-controlled. A simple regex guard eliminates the risk entirely.

**Fix:** Added a `^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$` check immediately after reading `APP_REPO`. Invalid values return 500 and log server-side before any outbound request is made.

## Changes

- `supabase/functions/app-version/index.ts`: regex validation of `APP_REPO` before constructing the GitHub API URL.

## Test plan

- [ ] Valid `APP_REPO` (e.g. `ATCL-Lazio/Turni-di-Palco`) — changelog loads normally.
- [ ] Malformed `APP_REPO` (e.g. `owner/repo/../../users`) — function returns 500 without making any GitHub request.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KL3pspmM3SsY8c3yDSXPB2)_