### PR TITLE
fix: verify ticket ownership in activate_by_ticket_number to prevent IDOR

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -290,7 +290,7 @@ serve(async (req: Request) => {
       } else if (action === 'activate_by_ticket_number') {
         let query = supabase
           .from('ticket_activations')
-          .select('hash, event_id, ticket_number')
+          .select('hash, event_id, ticket_number, user_id')
           .eq('ticket_number', payload.ticketNumber);
 
         if (payload.circuit !== undefined && payload.circuit !== null && payload.circuit !== '') {
@@ -319,6 +319,11 @@ serve(async (req: Request) => {
 
         if (tickets.length > 1) {
           return jsonResponse({ ok: false, error: 'Ticket number non univoco. Specifica Circuito o Evento.' }, 200);
+        }
+
+        // IDOR check: verify the ticket belongs to the authenticated user (closes #1565).
+        if (tickets[0].user_id !== resolvedUserId) {
+          return jsonResponse({ error: 'Accesso negato: questo ticket non appartiene all\'utente corrente.' }, 403);
         }
 
         targetHash = tickets[0].hash;


### PR DESCRIPTION
Closes #1565

## What changed and why

In the `activate_by_ticket_number` action inside `supabase/functions/ticket-activation/index.ts`, the ticket lookup query now also selects the `user_id` column. After resolving a unique ticket by ticket number, the handler checks that `ticket.user_id` matches `resolvedUserId` (the verified JWT identity of the caller). If the ticket belongs to a different user a 403 response is returned immediately, before any activation update is attempted.

Without this check any authenticated user who knew another user's ticket number could steal that ticket by calling this action.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4qm3SoUX5GNE7b3tBcdEK)_