### PR TITLE
fix: validate eventId format in create_deep_link action

### DIFF
--- a/supabase/functions/event-links/index.ts
+++ b/supabase/functions/event-links/index.ts
@@ -170,6 +170,12 @@ serve(async (req) => {
       return json({ error: 'eventId obbligatorio' }, 400);
     }
 
+    // Apply the same format validation used by all other actions so malformed
+    // or unbounded eventId values are rejected before reaching the DB (closes #1566).
+    if (!EVENT_ID_PATTERN.test(eventId)) {
+      return json({ error: 'eventId non valido' }, 400);
+    }
+
     if (rawRoleId !== null && !VALID_ROLE_IDS.has(rawRoleId)) {
       return json({ error: 'roleId non valido' }, 400);
     }


### PR DESCRIPTION
Closes #1566

## What changed and why

In `supabase/functions/event-links/index.ts`, the `create_deep_link` action now applies the same `EVENT_ID_PATTERN` regex (`/\b([A-Za-z]{2,10}-\d{1,6})\b/`) to `eventId` that all other actions already use. The check is inserted immediately after the existing "eventId obbligatorio" guard, before the DB query.

Previously this action accepted any string of unbounded length or arbitrary format and passed it directly to the PostgreSQL `eq('id', eventId)` query. The added validation aligns `create_deep_link` with the rest of the function and rejects malformed input early.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4qm3SoUX5GNE7b3tBcdEK)_