### PR TITLE
fix: ICS sanitization and UTC timestamps in EventDetails

### DIFF
--- a/apps/mobile/src/components/screens/EventDetails.tsx
+++ b/apps/mobile/src/components/screens/EventDetails.tsx
@@ -82,15 +82,19 @@ export function EventDetails({
     setCalendarError(null);
     const endDate = new Date(startDate.getTime() + 2 * 60 * 60 * 1000);
     const pad = (n: number) => String(n).padStart(2, '0');
+    // Use UTC methods and append Z so the timestamp is unambiguous for calendar
+    // clients in any timezone (closes #1567).
     const formatDate = (value: Date) =>
-      `${value.getFullYear()}${pad(value.getMonth() + 1)}${pad(value.getDate())}T${pad(value.getHours())}${pad(value.getMinutes())}${pad(value.getSeconds())}`;
+      `${value.getUTCFullYear()}${pad(value.getUTCMonth() + 1)}${pad(value.getUTCDate())}T${pad(value.getUTCHours())}${pad(value.getUTCMinutes())}${pad(value.getUTCSeconds())}Z`;
     const icsLines = [
       'BEGIN:VCALENDAR',
       'VERSION:2.0',
       'PRODID:-//Turni di Palco//Event//IT',
       'CALSCALE:GREGORIAN',
       'BEGIN:VEVENT',
-      `UID:${event.id}@turni-di-palco`,
+      // Sanitize event.id in the UID field for consistency with event.name and
+      // event.theatre (closes #1568).
+      `UID:${sanitizeIcsText(event.id)}@turni-di-palco`,
       `SUMMARY:${sanitizeIcsText(event.name)}`,
       `LOCATION:${sanitizeIcsText(event.theatre)}`,
       `DTSTART:${formatDate(startDate)}`,


### PR DESCRIPTION
Closes #1567
Closes #1568

## What changed and why

Both fixes are in `handleAddToCalendar` inside `apps/mobile/src/components/screens/EventDetails.tsx`.

**#1567 — UTC timestamps**: `formatDate` previously used local `Date` getters (`.getFullYear()`, `.getHours()`, etc.) producing floating local time with no timezone indicator. Calendar clients on non-Europe/Rome devices would interpret the time in the viewer's local timezone, placing the event at the wrong wall-clock time. The function now uses UTC getters (`.getUTCFullYear()`, `.getUTCHours()`, etc.) and appends `Z`, producing a valid UTC datetime stamp that is unambiguous everywhere.

**#1568 — UID field sanitization**: `event.id` was interpolated raw into the `UID:` ICS field while `event.name` and `event.theatre` already pass through `sanitizeIcsText()`. The UID line now also calls `sanitizeIcsText(event.id)` for consistency, preventing ICS injection via a malformed event id.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4qm3SoUX5GNE7b3tBcdEK)_