### PR TITLE
fix: override client-supplied createdAt with server timestamp in mobile-logs

### DIFF
--- a/supabase/functions/mobile-logs/index.ts
+++ b/supabase/functions/mobile-logs/index.ts
@@ -79,10 +79,9 @@ function normalizeLogEntry(rawEntry: unknown, index: number): NormalizedLogEntry
     typeof rawEntry.id === 'string' && rawEntry.id.trim()
       ? rawEntry.id.trim()
       : `client-log-${Date.now()}-${index}`;
-  const createdAt =
-    typeof rawEntry.createdAt === 'number' && Number.isFinite(rawEntry.createdAt)
-      ? rawEntry.createdAt
-      : Date.now();
+  // Always use the server-side timestamp; ignore any client-supplied createdAt
+  // to preserve audit trail integrity (closes #1569).
+  const createdAt = Date.now();
   const sequence =
     typeof rawEntry.sequence === 'number' && Number.isFinite(rawEntry.sequence)
       ? rawEntry.sequence


### PR DESCRIPTION
Closes #1569

## What changed and why

In `supabase/functions/mobile-logs/index.ts`, `normalizeLogEntry` previously accepted and stored a client-supplied `createdAt` value when it was a finite number. This allowed any client to backdate or forward-date log entries, corrupting the audit trail in the same way that `clientUserId` was already fixed (see closes #1301 comment in the same file).

The fix removes the conditional and always assigns `createdAt = Date.now()`, consistent with how `clientUserId` is handled via the verified JWT identity. Client-supplied timestamp values are now silently ignored.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4qm3SoUX5GNE7b3tBcdEK)_