### PR TITLE
fix: use reserved_by instead of user_id in IDOR guard for activate_by_ticket_number

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -290,7 +290,7 @@ serve(async (req: Request) => {
       } else if (action === 'activate_by_ticket_number') {
         let query = supabase
           .from('ticket_activations')
-          .select('hash, event_id, ticket_number, user_id')
+          .select('hash, event_id, ticket_number, reserved_by')
           .eq('ticket_number', payload.ticketNumber);
 
         if (payload.circuit !== undefined && payload.circuit !== null && payload.circuit !== '') {
@@ -321,8 +321,11 @@ serve(async (req: Request) => {
           return jsonResponse({ ok: false, error: 'Ticket number non univoco. Specifica Circuito o Evento.' }, 200);
         }
 
-        // IDOR check: verify the ticket belongs to the authenticated user (closes #1565).
-        if (tickets[0].user_id !== resolvedUserId) {
+        // IDOR check: verify the ticket was reserved by the authenticated user (closes #1565).
+        // reserve_hash stores the reserving admin's id in `reserved_by`; `user_id` is
+        // never written and is therefore always null, causing the old check to fire for
+        // every caller (closes #1574).
+        if (tickets[0].reserved_by !== resolvedUserId) {
           return jsonResponse({ error: 'Accesso negato: questo ticket non appartiene all\'utente corrente.' }, 403);
         }
 


### PR DESCRIPTION
Closes #1574

## What was fixed

`activate_by_ticket_number` permanently returned 403 for every caller because the IDOR guard introduced for #1565 compared `tickets[0].user_id` against the authenticated user's ID, but `reserve_hash` never writes the `user_id` column — it writes `reserved_by`. As a result `user_id` was always `null`, and the strict inequality `null !== resolvedUserId` was always `true`, blocking every legitimate activation.

**Fix:** The SELECT query now fetches `reserved_by` instead of `user_id`, and the guard compares `tickets[0].reserved_by !== resolvedUserId` — the column that `reserve_hash` actually populates.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBSH2Jf7jovB95P3hDbbor)_