### PR TITLE
fix: add reserved_by IDOR guard to activate_by_details

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -272,7 +272,7 @@ serve(async (req: Request) => {
       if (action === 'activate_by_details') {
         const { data: ticket, error: lookupError } = await supabase
           .from('ticket_activations')
-          .select('hash')
+          .select('hash, reserved_by')
           .eq('event_id', payload.eventID)
           .eq('ticket_number', payload.ticketNumber)
           .maybeSingle();
@@ -282,6 +282,15 @@ serve(async (req: Request) => {
         if (!ticket) {
           return jsonResponse({ ok: false, error: 'Ticket non trovato.' }, 200);
         }
+
+        // IDOR check: verify the ticket was reserved by the authenticated user (closes #1578).
+        // activate_by_ticket_number already enforces this check (#1565/#1574); apply the
+        // same guard here so that knowing another user's event+ticket-number pair does not
+        // allow stealing and consuming their pre-reserved ticket.
+        if (ticket.reserved_by !== resolvedUserId) {
+          return jsonResponse({ error: 'Accesso negato: questo ticket non appartiene all\'utente corrente.' }, 403);
+        }
+
         targetHash = ticket.hash;
 
         if (targetHash == null) {


### PR DESCRIPTION
Closes #1578

Applies the same `reserved_by` ownership check to `activate_by_details` that was already added to `activate_by_ticket_number` in #1565/#1574. Without this guard, any authenticated user knowing another user's event+ticket-number pair could steal and activate their pre-reserved ticket.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcAMqpNSxMWFv7o3qASZD1)_