### PR TITLE
fix: remove reserved_by IDOR guard from activate_by_details

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -272,7 +272,7 @@ serve(async (req: Request) => {
       if (action === 'activate_by_details') {
         const { data: ticket, error: lookupError } = await supabase
           .from('ticket_activations')
-          .select('hash, reserved_by')
+          .select('hash')
           .eq('event_id', payload.eventID)
           .eq('ticket_number', payload.ticketNumber)
           .maybeSingle();
@@ -281,14 +281,6 @@ serve(async (req: Request) => {
 
         if (!ticket) {
           return jsonResponse({ ok: false, error: 'Ticket non trovato.' }, 200);
-        }
-
-        // IDOR check: verify the ticket was reserved by the authenticated user (closes #1578).
-        // activate_by_ticket_number already enforces this check (#1565/#1574); apply the
-        // same guard here so that knowing another user's event+ticket-number pair does not
-        // allow stealing and consuming their pre-reserved ticket.
-        if (ticket.reserved_by !== resolvedUserId) {
-          return jsonResponse({ error: 'Accesso negato: questo ticket non appartiene all\'utente corrente.' }, 403);
         }
 
         targetHash = ticket.hash;


### PR DESCRIPTION
Closes #1580

## Summary

Reverts the `reserved_by` ownership check that was added to `activate_by_details` in #1579 (fix for #1578).

**Why it was wrong:** `activate_by_details` is the **attendee** activation path — called from `useQrHandlers.ts:201` when a user scans a `manual-ticket:<eventId>:<ticketNumber>` QR code. The caller is a regular authenticated user. However, `reserved_by` is written by `reserve_hash` (admin-only), storing the **admin's** user ID for GDPR cleanup purposes (#1385). The check `reserved_by !== resolvedUserId` always differs for attendees → always 403.

**What stays the same:** The identical check in `activate_by_ticket_number` is retained. That action has no mobile client callers and is effectively an admin-only path, where the "same admin who reserved it can activate it" invariant is correct.

**Security posture of `activate_by_details`:** The manual-ticket path relies on `event_id + ticket_number` being a private credential — both values come from external ticketing systems (TicketOne etc.) and are not enumerable. This is the same trust model as the hash path but with a shorter credential; the design accepts this tradeoff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcAMqpNSxMWFv7o3qASZD1)_