### PR TITLE
fix: attendee_id ownership check in ticket-activation (closes #1580, closes #1582)

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -62,11 +62,11 @@ serve(async (req) => {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  // 1. Nullify reserved_by BEFORE any destructive deletes (closes #1529).
+  // 1. Nullify reserved_by and attendee_id BEFORE any destructive deletes (closes #1529).
   //
   // ticket_activations rows where activated_by is set belong to another user's
-  // attendance record and are NOT deleted; instead their reserved_by column is
-  // cleared so the deleted user's UUID no longer appears (GDPR Art. 17).
+  // attendance record and are NOT deleted; instead their reserved_by and attendee_id
+  // columns are cleared so the deleted user's UUID no longer appears (GDPR Art. 17).
   //
   // Running this step first means that if it fails, no game data has been
   // destroyed yet and an "aborted" error is genuinely accurate. Doing it after
@@ -85,16 +85,35 @@ serve(async (req) => {
     );
   }
 
+  // Nullify attendee_id on tickets already activated (preserve attendance record,
+  // remove personal identifier). Non-fatal sibling of the reserved_by nullify above.
+  const { error: nullifyAttendeeError } = await adminClient
+    .from('ticket_activations')
+    .update({ attendee_id: null })
+    .eq('attendee_id', userId)
+    .not('activated_by', 'is', null);
+  if (nullifyAttendeeError) {
+    console.error('delete-my-account: failed to nullify attendee_id on activated tickets', nullifyAttendeeError.message);
+    return errorResponse(
+      'Account deletion aborted: could not nullify attendee ticket references. Please retry.',
+      500,
+    );
+  }
+
   // 2. Delete game data (cascade-safe: ordered by FK dependencies)
   //
-  // ticket_activations is deleted twice — once by activated_by (tickets the
-  // user activated) and once by reserved_by (tickets the user generated as an
-  // admin but that were never activated). Without the reserved_by delete,
-  // unactivated tickets from a deleted admin remain in the DB and can still be
-  // scanned and activated by anyone, violating GDPR Art. 17 (closes #1385).
+  // ticket_activations is deleted by multiple keys:
+  //   activated_by — tickets the user activated (their attendance records)
+  //   reserved_by  — tickets the user generated as an admin but were never activated
+  //   attendee_id  — unactivated tickets assigned to this attendee (GDPR Art. 17)
+  //
+  // Without the reserved_by and attendee_id deletes, unactivated tickets from a
+  // deleted user remain in the DB and can still be scanned/activated by anyone
+  // (closes #1385, extends GDPR cleanup to attendee_id).
   const tablesToDelete = [
     { table: 'ticket_activations', key: 'activated_by' },
     { table: 'ticket_activations', key: 'reserved_by' },
+    { table: 'ticket_activations', key: 'attendee_id' },
     { table: 'activity_completions', key: 'user_id' },
     { table: 'user_badges', key: 'user_id' },
     { table: 'planned_participations', key: 'user_id' },
@@ -107,11 +126,11 @@ serve(async (req) => {
   let failedTable: string | null = null;
 
   for (const { table, key } of tablesToDelete) {
-    // For the reserved_by pass, skip rows already activated by another user so
-    // their attendance record is preserved (fixes #1444).
+    // For the reserved_by and attendee_id passes, skip rows already activated by
+    // another user so their attendance record is preserved (fixes #1444).
     const baseQuery = adminClient.from(table).delete().eq(key, userId);
     const deleteQuery =
-      table === 'ticket_activations' && key === 'reserved_by'
+      table === 'ticket_activations' && (key === 'reserved_by' || key === 'attendee_id')
         ? baseQuery.is('activated_by', null)
         : baseQuery;
     const { error } = await deleteQuery;
@@ -156,10 +175,11 @@ serve(async (req) => {
     console.error('delete-my-account: storage cleanup timed out or failed (non-fatal)', storageError);
   }
 
-  // Final sweep: nullify any reserved_by references that survived the delete loop.
-  // Closes the TOCTOU window where a ticket was activated between step 1 (nullify
-  // activated tickets) and step 2 (delete unactivated tickets): such a ticket would
-  // have been skipped by both steps, leaving the deleted user's UUID in reserved_by.
+  // Final sweep: nullify any reserved_by or attendee_id references that survived
+  // the delete loop. Closes the TOCTOU window where a ticket was activated between
+  // step 1 (nullify activated tickets) and step 2 (delete unactivated tickets):
+  // such a ticket would have been skipped by both steps, leaving the deleted
+  // user's UUID in reserved_by or attendee_id.
   // Non-fatal — log and continue so the auth user is still removed (closes #1543).
   const { error: finalNullifyError } = await adminClient
     .from('ticket_activations')
@@ -167,6 +187,14 @@ serve(async (req) => {
     .eq('reserved_by', userId);
   if (finalNullifyError) {
     console.error('delete-my-account: failed to nullify surviving reserved_by references', finalNullifyError.message);
+  }
+
+  const { error: finalNullifyAttendeeError } = await adminClient
+    .from('ticket_activations')
+    .update({ attendee_id: null })
+    .eq('attendee_id', userId);
+  if (finalNullifyAttendeeError) {
+    console.error('delete-my-account: failed to nullify surviving attendee_id references', finalNullifyAttendeeError.message);
   }
 
   // 3. Delete the auth user (must be last — only reached if all data was cleaned)

--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -125,6 +125,7 @@ serve(async (req: Request) => {
         eventID?: unknown;
         ticketNumber?: unknown;
         date?: unknown;
+        attendeeId?: unknown;
       };
 
       // Lowercase circuit on write so it matches the lowercase comparison used by
@@ -142,10 +143,24 @@ serve(async (req: Request) => {
         return jsonResponse({ error: 'Missing hash or payload' }, 400);
       }
 
+      // Optional: UUID of the attendee this ticket was issued to. When provided,
+      // activate_by_details enforces that the caller matches this ID, preventing
+      // IDOR ticket theft while still allowing legitimate attendee self-activation
+      // (closes #1582). Must be a valid UUID; invalid values are silently ignored.
+      const rawAttendeeId = typeof normalizedPayload.attendeeId === 'string'
+        ? normalizedPayload.attendeeId.trim()
+        : null;
+      const attendeeId = rawAttendeeId &&
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(rawAttendeeId)
+        ? rawAttendeeId
+        : null;
+
       // Insert new ticket activation record (unassigned).
       // reserved_by records the generating admin's user ID so that
       // delete-my-account can clean up unactivated tickets when the admin
       // deletes their account (GDPR Art. 17, closes #1385).
+      // attendee_id records the intended recipient so activate_by_details can
+      // enforce attendee-bound ownership (closes #1582).
       const { error: insertError } = await supabase.from('ticket_activations').insert({
         hash: normalizedHash,
         circuit,
@@ -154,6 +169,7 @@ serve(async (req: Request) => {
         ticket_number: ticketNumber,
         date,
         reserved_by: authenticatedUser?.id ?? null,
+        attendee_id: attendeeId,
       });
 
       if (insertError) {
@@ -272,7 +288,7 @@ serve(async (req: Request) => {
       if (action === 'activate_by_details') {
         const { data: ticket, error: lookupError } = await supabase
           .from('ticket_activations')
-          .select('hash, reserved_by')
+          .select('hash, attendee_id')
           .eq('event_id', payload.eventID)
           .eq('ticket_number', payload.ticketNumber)
           .maybeSingle();
@@ -283,11 +299,11 @@ serve(async (req: Request) => {
           return jsonResponse({ ok: false, error: 'Ticket non trovato.' }, 200);
         }
 
-        // IDOR check: verify the ticket was reserved by the authenticated user (closes #1578).
-        // activate_by_ticket_number already enforces this check (#1565/#1574); apply the
-        // same guard here so that knowing another user's event+ticket-number pair does not
-        // allow stealing and consuming their pre-reserved ticket.
-        if (ticket.reserved_by !== resolvedUserId) {
+        // IDOR guard: enforce ownership only when attendee_id was recorded at
+        // reservation time (new tickets). When attendee_id IS NULL (pre-migration
+        // rows or reservations without a known recipient), the check is skipped
+        // for backward compatibility. Closes #1580 and #1582.
+        if (ticket.attendee_id !== null && ticket.attendee_id !== resolvedUserId) {
           return jsonResponse({ error: 'Accesso negato: questo ticket non appartiene all\'utente corrente.' }, 403);
         }
 

--- a/supabase/migrations/20260813000000_ticket_activations_attendee_id.sql
+++ b/supabase/migrations/20260813000000_ticket_activations_attendee_id.sql
@@ -1,0 +1,16 @@
+-- Adds attendee_id to ticket_activations to support attendee-bound ownership
+-- check in activate_by_details (closes #1582, unblocks attendee activation
+-- regression fix for #1580).
+--
+-- reserve_hash now accepts an optional attendeeId payload param (the intended
+-- recipient's user UUID). activate_by_details enforces
+-- ticket.attendee_id = caller when the column is non-NULL; rows without
+-- attendee_id (pre-migration or reservations without a known recipient) are
+-- allowed through for backward compatibility.
+
+ALTER TABLE public.ticket_activations
+  ADD COLUMN IF NOT EXISTS attendee_id UUID REFERENCES auth.users(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS ticket_activations_attendee_id_idx
+  ON public.ticket_activations (attendee_id)
+  WHERE attendee_id IS NOT NULL;


### PR DESCRIPTION
## Summary

Implements **Option A** from #1582 — adds an `attendee_id` column to `ticket_activations` so `activate_by_details` can enforce attendee-bound ownership without breaking legitimate attendee self-activation.

### Root cause recap

`reserved_by` records the **admin** who called `reserve_hash`. The IDOR fix in #1578/#1579 applied a `reserved_by === caller` guard to `activate_by_details`, which is called by **attendees**. Those are always different people → always 403 (regression documented in #1580).

Removing the guard reintroduced the IDOR (#1581, closed). Neither state was safe to ship. The correct fix requires a dedicated attendee field (#1582).

## Changes

### `supabase/migrations/20260813000000_ticket_activations_attendee_id.sql` (new)
- Adds `attendee_id UUID REFERENCES auth.users(id) ON DELETE SET NULL` — nullable for backward compat with existing rows.
- Adds partial index `WHERE attendee_id IS NOT NULL` for cleanup queries.

### `supabase/functions/ticket-activation/index.ts`
- **`reserve_hash`**: accepts optional `payload.attendeeId` (UUID-validated); stored in `attendee_id` at insert time. Invalid or missing values are silently treated as `null`.
- **`activate_by_details`**: replaces the broken `reserved_by !== resolvedUserId` check with:
  - `ticket.attendee_id !== null && ticket.attendee_id !== resolvedUserId → 403`
  - When `attendee_id IS NULL` (pre-migration rows), the check is skipped for backward compatibility.

### `supabase/functions/delete-my-account/index.ts`
- Step 1: also nullifies `attendee_id` on already-activated tickets (GDPR Art. 17, personal identifier removed while preserving attendance record).
- Delete loop: adds `{ table: 'ticket_activations', key: 'attendee_id' }` to remove unactivated tickets assigned to the deleted attendee.
- Final sweep: also nullifies surviving `attendee_id` references (closes TOCTOU window alongside `reserved_by`, extends #1543 fix).

## Security properties after this fix

| Scenario | Before #1578 | After #1578/#1579 | After this PR |
|---|---|---|---|
| Attendee activates own ticket (attendee_id set) | ✅ allowed | ❌ always 403 | ✅ allowed |
| Attacker activates another's ticket (attendee_id set) | ❌ IDOR | ❌ also blocked (but blocks owner too) | ✅ blocked |
| Pre-migration ticket (no attendee_id) | ✅ allowed | ❌ always 403 | ✅ allowed (backward compat) |

## Testing

- New tickets: set `attendeeId` in `reserve_hash` payload; verify `activate_by_details` succeeds for the correct attendee and returns 403 for any other authenticated user.
- Pre-migration tickets (no `attendee_id`): verify `activate_by_details` still works for any authenticated caller.
- `activate_by_ticket_number` (admin path): unchanged — `reserved_by` guard remains in place.
- Account deletion: verify `attendee_id` is nullified on activated tickets and unactivated tickets are deleted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeAgNsY4zFGuZwm8Moakb5)_