### PR TITLE
Fix ticket consumed without turn recorded when event_time is null (#1586)

### DIFF
--- a/apps/mobile/src/handlers/useQrHandlers.ts
+++ b/apps/mobile/src/handlers/useQrHandlers.ts
@@ -47,7 +47,7 @@ function mapActivatedEvent(
   const theatre = String(eventPayload.theatre ?? '').trim();
   const date = String(eventPayload.event_date ?? '').trim();
   const time = String(eventPayload.event_time ?? '').trim();
-  if (!theatre || !date || !time) return undefined;
+  if (!theatre || !date) return undefined;
 
   const toNumber = (value: unknown) => {
     const parsed = Number(value);


### PR DESCRIPTION
## Intent

Fix a data-loss bug where a successfully activated ticket doesn't result in a registered turn when the event's `event_time` field is null or empty.

## Key changes

- `apps/mobile/src/handlers/useQrHandlers.ts`: removed `time` from the required-fields guard in `mapActivatedEvent`. Previously, a null/empty `event_time` caused the function to return `undefined`, leaving `registerTurn` without an `eventOverride` and silently dropping the turn even though the ticket was consumed.

## Testing performed

- Code review: confirmed `GameEvent.time` accepts an empty string, so no downstream type errors.
- The turn-recording path (`handleEventConfirm`) still receives a valid `eventOverride` for events with a missing time.

Closes #1586

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeAgNsY4zFGuZwm8Moakb5)_