### PR TITLE
Fix resolveGenre IN EVIDENZA fallback and formatTime fabricated time (#1584 #1585)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -335,7 +335,7 @@ type DbEventRow = {
   name: string;
   theatre: string;
   event_date: string;
-  event_time: string;
+  event_time: string | null;
   genre: string;
   base_rewards?: { xp?: number; reputation?: number; cachet?: number } | null;
   focus_role?: string | null;

--- a/supabase/functions/import-spazio-rossellini/index.ts
+++ b/supabase/functions/import-spazio-rossellini/index.ts
@@ -58,7 +58,7 @@ const formatDate = (details?: SpazioEvent['start_date_details'], fallback?: stri
   return null;
 };
 
-const formatTime = (details?: SpazioEvent['start_date_details'], fallback?: string) => {
+const formatTime = (details?: SpazioEvent['start_date_details'], fallback?: string): string | null => {
   if (details?.hour != null && details?.minutes != null) {
     return `${String(details.hour).padStart(2, '0')}:${String(details.minutes).padStart(2, '0')}`;
   }
@@ -66,19 +66,23 @@ const formatTime = (details?: SpazioEvent['start_date_details'], fallback?: stri
     const [, timePart] = fallback.split(' ');
     if (timePart) return timePart.slice(0, 5);
   }
-  return '20:30';
+  return null;
 };
 
 const resolveGenre = (categories: SpazioEvent['categories'] = [], allowedSlugs: Set<string>) => {
+  const isInEvidenza = (c: { name?: string; slug?: string }) =>
+    (c?.name ?? '').toString().toUpperCase() === 'IN EVIDENZA' || (c?.slug ?? '').toString() === 'in-evidenza';
   const preferred = categories.find((category) => {
     const name = (category?.name ?? '').toString();
     const slug = (category?.slug ?? '').toString();
     if (!name) return false;
-    if (name.toUpperCase() === 'IN EVIDENZA' || slug === 'in-evidenza') return false;
+    if (isInEvidenza(category)) return false;
     if (allowedSlugs.size > 0 && !allowedSlugs.has(slug)) return false;
     return true;
   });
-  return (preferred?.name ?? categories[0]?.name ?? 'Teatro').toString();
+  if (preferred) return preferred.name!.toString();
+  const fallback = categories.find((c) => !isInEvidenza(c) && !!(c?.name ?? '').toString());
+  return (fallback?.name ?? 'Teatro').toString();
 };
 
 const fetchSitemapUrls = async (): Promise<Set<string> | null> => {

--- a/supabase/migrations/20260813100000_events_event_time_nullable.sql
+++ b/supabase/migrations/20260813100000_events_event_time_nullable.sql
@@ -1,0 +1,4 @@
+-- Make event_time nullable so imports can store events with no published time
+-- rather than fabricating a placeholder value. The stored procedures already
+-- handle NULL event_time via COALESCE(event_time, '23:59:59').
+ALTER TABLE public.events ALTER COLUMN event_time DROP NOT NULL;


### PR DESCRIPTION
## Intent

Fix two data-quality bugs in the Spazio Rossellini import function that produce wrong genre labels and fabricated event times.

## Key changes

**`supabase/functions/import-spazio-rossellini/index.ts`**

- **`resolveGenre` (#1584)**: the fallback `categories[0]?.name` could return `'IN EVIDENZA'` when `preferred` was null and the spotlight category was first. Extracted an `isInEvidenza` helper and applied the same exclusion to the fallback lookup, so the genre always falls back to `'Teatro'` rather than the spotlight label.

- **`formatTime` (#1585)**: removed the hardcoded `'20:30'` default. Events with no published time now store `null` instead of a fabricated placeholder. Return type narrowed to `string | null`.

**`supabase/migrations/20260813100000_events_event_time_nullable.sql`**

- `ALTER TABLE public.events ALTER COLUMN event_time DROP NOT NULL` — required for the `formatTime` fix. All stored procedures already handle `NULL event_time` via `COALESCE(event_time, '23:59:59')`.

**`apps/mobile/src/state/store.tsx`**

- `DbEventRow.event_time` typed as `string | null` to reflect the now-nullable column. `normalizeText()` (already accepts `null | undefined`) converts it to `''` before mapping to `GameEvent.time: string`.

## Testing performed

- `resolveGenre`: confirmed the `isInEvidenza` check is applied both in the `preferred` finder and the `fallback` finder.
- `formatTime`: `null` is returned only when neither `start_date_details` nor the `start_date` fallback string contains a time component.
- TypeScript: `normalizeText(row.event_time)` returns `string` for any input including `null`, so `GameEvent.time: string` remains satisfied.

Closes #1584
Closes #1585

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeAgNsY4zFGuZwm8Moakb5)_