### PR TITLE
Fix authReady stuck permanently false on total network failure (#1587)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3143,7 +3143,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       );
     };
 
-    let authReadyFallbackId: ReturnType<typeof window.setTimeout> | null = null;
+    let authReadyFallbackId: number | null = null;
 
     restoreSession().catch((err) => {
       console.error('[restoreSession] unexpected error', err);

--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -3143,6 +3143,8 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       );
     };
 
+    let authReadyFallbackId: ReturnType<typeof window.setTimeout> | null = null;
+
     restoreSession().catch((err) => {
       console.error('[restoreSession] unexpected error', err);
       // For WatchdogTimeoutError: withMobileWatchdog already showed the error
@@ -3153,9 +3155,22 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       if (isMounted && !(err instanceof WatchdogTimeoutError)) {
         setAuthReady(true);
       }
+      // Safety net: on total network failure the in-flight Supabase call never
+      // completes, so onAuthStateChange never fires and authReady stays false
+      // forever. Fall back to ready after an additional wait so the app
+      // eventually becomes usable even without connectivity (closes #1587).
+      if (err instanceof WatchdogTimeoutError) {
+        authReadyFallbackId = window.setTimeout(() => {
+          if (isMounted) setAuthReady(true);
+        }, 30_000);
+      }
     });
 
     const { data: authListener } = supabase!.auth.onAuthStateChange((_event, session) => {
+      if (authReadyFallbackId !== null) {
+        window.clearTimeout(authReadyFallbackId);
+        authReadyFallbackId = null;
+      }
       persistStoredSession(session ?? null);
       if (!isMounted) return;
       setAuthUserId(session?.user.id ?? null);
@@ -3164,6 +3179,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
 
     return () => {
       isMounted = false;
+      if (authReadyFallbackId !== null) window.clearTimeout(authReadyFallbackId);
       authListener?.subscription.unsubscribe();
     };
   }, []);


### PR DESCRIPTION
## Intent

Fix a freeze bug where the mobile app becomes unresponsive forever if the network is completely down during `restoreSession`.

## Key changes

**`apps/mobile/src/state/store.tsx`**

When `restoreSession` throws `WatchdogTimeoutError` (after 15 s), the existing code intentionally skips `setAuthReady(true)` because the in-flight Supabase call may still complete and trigger `onAuthStateChange` — which sets `authReady` correctly. On total network failure, however, the call never resolves, so `onAuthStateChange` never fires and `authReady` stays `false` forever.

Fix: introduce a `authReadyFallbackId` timer (30 s) set only in the `WatchdogTimeoutError` branch of the catch. If `onAuthStateChange` fires before it expires (the normal path), the timer is cancelled immediately. If it doesn't (total network failure), the fallback fires and sets `authReady = true` so the app becomes usable. The timer is also cleared in the `useEffect` cleanup to avoid state updates on unmounted components.

## Testing performed

- Happy path (normal session restore): `onAuthStateChange` fires, timer is cleared, no regression.
- Watchdog timeout but call eventually succeeds: same — `onAuthStateChange` fires and cancels the timer.
- Total network failure: fallback fires at +30 s after the watchdog, `authReady` becomes `true`, app is unblocked.

Closes #1587

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeAgNsY4zFGuZwm8Moakb5)_