### PR TITLE
fix: remove dead matchedEvent variable in manual ticket entry path

### DIFF
--- a/apps/mobile/src/handlers/useQrHandlers.ts
+++ b/apps/mobile/src/handlers/useQrHandlers.ts
@@ -111,7 +111,6 @@ export function useQrHandlers(deps: QrHandlerDeps) {
       // Do not reject if the event is absent from the local cache: the server-side
       // activation call in handleEventConfirm will perform its own lookup and return
       // a proper error if the event truly does not exist (closes #1342).
-      const matchedEvent = events.find(event => event.id === normalizedEventId);
 
       setPendingTicketActivation({ mode: 'manual', eventId: normalizedEventId, ticketNumber: normalizedTicketNumber });
       setConfirmationEventOverride(mapActivatedEvent(normalizedEventId, events) ?? null);


### PR DESCRIPTION
Closes #1593

Removes the dead `matchedEvent` variable at line 114 that was computed (via `events.find`) and immediately discarded without being used. This was a leftover from an incomplete refactoring: `mapActivatedEvent` already performs the same catalog lookup internally, so the redundant assignment was both misleading and unnecessary.

The `mapActivatedEvent(normalizedEventId, events)` call on the next line is correct for the manual path — it returns the event from the local catalog if present, or `null` if not (since no server-side `eventPayload` is available before the confirmation stage in the manual flow).

---
_Generated by [Claude Code](https://claude.ai/code/session_018SdHrhevatA3JQR9t74fHV)_