### PR TITLE
fix: gate skill multipliers on activity type in computeActivityRewards

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -15,6 +15,7 @@ import {
   getXpToNextLevel,
   getStatMultiplier,
   getLeadershipCachetMultiplier,
+  STAT_EFFECTS,
 } from '../../../../shared/config/balancing';
 import {
   COURSES_CATALOG,
@@ -1280,15 +1281,25 @@ export function computeActivityRewards(
   const reputationBonus = override?.reputationBonus ?? 0;
 
   // Applica bonus skill derivati dai corsi completati (Issue #327).
+  // Gate each multiplier on the activity type, mirroring computeRewardBreakdown
+  // in role-effects.ts (closes #1594). Leadership is global (always applied).
   let skillXpMult = 1;
   let skillCachetMult = 1;
   if (skills) {
-    skillXpMult =
-      getStatMultiplier('presence', 'xp', skills.presence) *
-      getStatMultiplier('creativity', 'xp', skills.creativity);
-    skillCachetMult =
-      getStatMultiplier('precision', 'cachet', skills.precision) *
-      getLeadershipCachetMultiplier(skills.leadership);
+    const presenceActivities = STAT_EFFECTS.presence.affectedActivities as readonly string[];
+    const creativityActivities = STAT_EFFECTS.creativity.affectedActivities as readonly string[];
+    const precisionActivities = STAT_EFFECTS.precision.affectedActivities as readonly string[];
+    const presenceMult = presenceActivities.includes(activity.id)
+      ? getStatMultiplier('presence', 'xp', skills.presence)
+      : 1;
+    const creativityMult = creativityActivities.includes(activity.id)
+      ? getStatMultiplier('creativity', 'xp', skills.creativity)
+      : 1;
+    skillXpMult = presenceMult * creativityMult;
+    const precisionMult = precisionActivities.includes(activity.id)
+      ? getStatMultiplier('precision', 'cachet', skills.precision)
+      : 1;
+    skillCachetMult = precisionMult * getLeadershipCachetMultiplier(skills.leadership);
   }
 
   return {

--- a/apps/mobile/src/test/courses.test.ts
+++ b/apps/mobile/src/test/courses.test.ts
@@ -35,6 +35,13 @@ const SKILLS_BASELINE = { precision: 50, presence: 50, creativity: 50, leadershi
 const SKILLS_HIGH = { precision: 100, presence: 100, creativity: 100, leadership: 100 };
 const SKILLS_ZERO = { precision: 0, presence: 0, creativity: 0, leadership: 0 };
 
+// Activity-type-specific fixtures for gated-multiplier tests.
+// STAT_EFFECTS gates each skill bonus on activity.id; use IDs from the canonical
+// affectedActivities lists so the multiplier actually fires.
+const MOCK_PRESENCE_ACTIVITY: Activity = { ...MOCK_ACTIVITY, id: 'recitazione' };
+const MOCK_CREATIVITY_ACTIVITY: Activity = { ...MOCK_ACTIVITY, id: 'palco' };
+const MOCK_PRECISION_ACTIVITY: Activity = { ...MOCK_ACTIVITY, id: 'luci' };
+
 // ─── Test catalogo ─────────────────────────────────────────────────────────────
 
 describe('courses — catalogo', () => {
@@ -102,8 +109,8 @@ describe('computeActivityRewards — bonus skill (Issue #327)', () => {
   });
 
   it('skill alte (100) danno XP maggiore del baseline', () => {
-    const baseline = computeActivityRewards(MOCK_ACTIVITY, null, SKILLS_BASELINE);
-    const high = computeActivityRewards(MOCK_ACTIVITY, null, SKILLS_HIGH);
+    const baseline = computeActivityRewards(MOCK_PRESENCE_ACTIVITY, null, SKILLS_BASELINE);
+    const high = computeActivityRewards(MOCK_PRESENCE_ACTIVITY, null, SKILLS_HIGH);
     expect(high.xp).toBeGreaterThan(baseline.xp);
   });
 
@@ -114,28 +121,30 @@ describe('computeActivityRewards — bonus skill (Issue #327)', () => {
   });
 
   it('il bonus XP è calcolato da presence e creativity', () => {
-    // Solo presence alta, creativity baseline.
-    const onlyPresence = computeActivityRewards(MOCK_ACTIVITY, null, {
+    // Solo presence alta, creativity baseline — su un'attività di tipo presence.
+    const onlyPresence = computeActivityRewards(MOCK_PRESENCE_ACTIVITY, null, {
       ...SKILLS_BASELINE,
       presence: 100,
     });
-    expect(onlyPresence.xp).toBeGreaterThan(MOCK_ACTIVITY.xpReward);
+    expect(onlyPresence.xp).toBeGreaterThan(MOCK_PRESENCE_ACTIVITY.xpReward);
 
-    // Solo creativity alta, presence baseline.
-    const onlyCreativity = computeActivityRewards(MOCK_ACTIVITY, null, {
+    // Solo creativity alta, presence baseline — su un'attività di tipo creativity.
+    const onlyCreativity = computeActivityRewards(MOCK_CREATIVITY_ACTIVITY, null, {
       ...SKILLS_BASELINE,
       creativity: 100,
     });
-    expect(onlyCreativity.xp).toBeGreaterThan(MOCK_ACTIVITY.xpReward);
+    expect(onlyCreativity.xp).toBeGreaterThan(MOCK_CREATIVITY_ACTIVITY.xpReward);
   });
 
   it('il bonus cachet è calcolato da precision e leadership', () => {
-    const onlyPrecision = computeActivityRewards(MOCK_ACTIVITY, null, {
+    // Precision è type-gated: serve un'attività in precision.affectedActivities.
+    const onlyPrecision = computeActivityRewards(MOCK_PRECISION_ACTIVITY, null, {
       ...SKILLS_BASELINE,
       precision: 100,
     });
-    expect(onlyPrecision.cachet).toBeGreaterThan(MOCK_ACTIVITY.cachetReward);
+    expect(onlyPrecision.cachet).toBeGreaterThan(MOCK_PRECISION_ACTIVITY.cachetReward);
 
+    // Leadership è globale (nessun gate sull'activity type).
     const onlyLeadership = computeActivityRewards(MOCK_ACTIVITY, null, {
       ...SKILLS_BASELINE,
       leadership: 100,


### PR DESCRIPTION
Closes #1594

`computeActivityRewards` was applying the `presence` and `creativity` XP multipliers, and the `precision` cachet multiplier, unconditionally to every activity regardless of type.

The canonical `computeRewardBreakdown` in `role-effects.ts` already correctly gates each multiplier on the activity's type via `PRESENCE_ACTIVITIES`, `CREATIVITY_ACTIVITIES`, and `PRECISION_ACTIVITIES` lists sourced from `STAT_EFFECTS` in the balancing config. This fix brings `computeActivityRewards` into alignment with the same gating logic.

Leadership remains unconditional (global cachet multiplier), consistent with `computeRewardBreakdown`.

Changes:
- Import `STAT_EFFECTS` from the shared balancing config
- Gate `presence` XP multiplier on `STAT_EFFECTS.presence.affectedActivities`
- Gate `creativity` XP multiplier on `STAT_EFFECTS.creativity.affectedActivities`
- Gate `precision` cachet multiplier on `STAT_EFFECTS.precision.affectedActivities`

---
_Generated by [Claude Code](https://claude.ai/code/session_018SdHrhevatA3JQR9t74fHV)_