### PR TITLE
fix: include attendee_id ticket_activations in GDPR Art. 15/20 export

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -5493,6 +5493,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
     let shopPurchases: unknown[] = [];
     let ticketActivationsActivated: unknown[] = [];
     let ticketActivationsReserved: unknown[] = [];
+    let ticketActivationsAttendee: unknown[] = [];
     if (isSupabaseConfigured && supabase && authUserId) {
       const [
         { data: turnsData, error: turnsError },
@@ -5501,6 +5502,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
         { data: shopData, error: shopError },
         { data: ticketActivatedData, error: ticketActivatedError },
         { data: ticketReservedData, error: ticketReservedError },
+        { data: ticketAttendeeData, error: ticketAttendeeError },
       ] = await Promise.all([
         supabase
           .from('turns')
@@ -5542,6 +5544,15 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
           .eq('reserved_by', authUserId)
           .order('created_at', { ascending: false })
           .limit(10000),
+        // Tickets assigned to this user as a named attendee (attendee_id).
+        // Deleted by delete-my-account under attendee_id but previously missing
+        // from the Art. 15/20 export — restores GDPR symmetry (closes #1595).
+        supabase
+          .from('ticket_activations')
+          .select('*')
+          .eq('attendee_id', authUserId)
+          .order('created_at', { ascending: false })
+          .limit(10000),
       ]);
       // Fail loudly if any query errors so the user is not shown a silently
       // incomplete GDPR export (fixes #1253).
@@ -5552,6 +5563,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       if (shopError) queryErrors.push({ table: 'shop_purchases', error: shopError });
       if (ticketActivatedError) queryErrors.push({ table: 'ticket_activations(activated_by)', error: ticketActivatedError });
       if (ticketReservedError) queryErrors.push({ table: 'ticket_activations(reserved_by)', error: ticketReservedError });
+      if (ticketAttendeeError) queryErrors.push({ table: 'ticket_activations(attendee_id)', error: ticketAttendeeError });
       if (queryErrors.length > 0) {
         const tables = queryErrors.map((e) => e.table).join(', ');
         notifyCriticalError(
@@ -5592,6 +5604,9 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       if (Array.isArray(ticketReservedData)) {
         ticketActivationsReserved = ticketReservedData;
       }
+      if (Array.isArray(ticketAttendeeData)) {
+        ticketActivationsAttendee = ticketAttendeeData;
+      }
     }
 
     const data = {
@@ -5624,6 +5639,7 @@ export function GameStateProvider({ children }: { children: React.ReactNode }) {
       shopPurchases,
       ticketActivationsActivated,
       ticketActivationsReserved,
+      ticketActivationsAttendee,
       badges,
       theatreReputation,
       plannedEvents: eventPlans,


### PR DESCRIPTION
Closes #1595

`exportUserData` fetched `ticket_activations` rows under `activated_by` and `reserved_by` but not `attendee_id`. The `delete-my-account` edge function deletes under all three keys, so tickets assigned to a user as a named attendee were deleted on account deletion but never returned in the GDPR Art. 15/20 data export — breaking symmetry between Art. 17 (erasure) and Art. 15/20 (access/portability).

Changes:
- Add a third `ticket_activations` query filtered on `attendee_id` to the `Promise.all` in `exportUserData`
- Add error reporting for the new query (consistent with existing fail-loud pattern from #1253)
- Assign the result to `ticketActivationsAttendee` and include it in the exported JSON payload

---
_Generated by [Claude Code](https://claude.ai/code/session_018SdHrhevatA3JQR9t74fHV)_