### PR TITLE
fix: guard dev-access against null JSON body

### DIFF
--- a/supabase/functions/dev-access/index.ts
+++ b/supabase/functions/dev-access/index.ts
@@ -101,7 +101,10 @@ serve(async (req) => {
 
   let payload: { path?: string } = {};
   try {
-    payload = await req.json();
+    const parsed = await req.json();
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      payload = parsed as { path?: string };
+    }
   } catch {
     payload = {};
   }


### PR DESCRIPTION
## Summary

Fixes #1604.

`req.json()` can return `null` for a valid JSON `"null"` body without throwing. The previous code assigned the result directly to `payload`, then accessed `payload.path` ~35 lines later, causing a `TypeError` and a 500 response.

## Changes

- `supabase/functions/dev-access/index.ts`: validate the parsed JSON before assigning to `payload`; fall back to `{}` when the result is `null`, a non-object, or an array.

## Test plan

- `curl -X POST <url>/functions/v1/dev-access -H 'Content-Type: application/json' -d 'null'` → 401 (no auth) instead of 500
- Normal object body `{"path":"/admin"}` still works as before

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_