### PR TITLE
fix: allow activate_by_ticket_number for tickets with null reserved_by

### DIFF
--- a/supabase/functions/ticket-activation/index.ts
+++ b/supabase/functions/ticket-activation/index.ts
@@ -350,7 +350,10 @@ serve(async (req: Request) => {
         // reserve_hash stores the reserving admin's id in `reserved_by`; `user_id` is
         // never written and is therefore always null, causing the old check to fire for
         // every caller (closes #1574).
-        if (tickets[0].reserved_by !== resolvedUserId) {
+        // Allow activation when reserved_by IS NULL (legacy/migrated tickets or tickets
+        // whose generating admin deleted their account) so they are not permanently
+        // locked out — closes #1605.
+        if (tickets[0].reserved_by !== null && tickets[0].reserved_by !== resolvedUserId) {
           return jsonResponse({ error: 'Accesso negato: questo ticket non appartiene all\'utente corrente.' }, 403);
         }
 


### PR DESCRIPTION
## Summary

Fixes #1605.

`activate_by_ticket_number` in `ticket-activation` rejected any ticket whose `reserved_by` column is `NULL` with a permanent 403, because `null !== userId` is always `true`. Tickets can have `null` in `reserved_by` due to legacy/migrated data or because the generating admin deleted their account (the `delete-my-account` GDPR cleanup nullifies that column).

## Changes

- `supabase/functions/ticket-activation/index.ts`: Skip the IDOR ownership check when `reserved_by IS NULL` (the ticket is not bound to any specific admin) so the caller can proceed with activation.

## Test plan

- Ticket with `reserved_by = NULL` → activation succeeds
- Ticket with `reserved_by = other_user_id` and caller is `some_user_id` → still 403
- Ticket with `reserved_by = caller_id` → activation succeeds as before

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_