### PR TITLE
fix: make final nullify sweep fatal to prevent GDPR orphaned UUIDs

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -180,13 +180,18 @@ serve(async (req) => {
   // step 1 (nullify activated tickets) and step 2 (delete unactivated tickets):
   // such a ticket would have been skipped by both steps, leaving the deleted
   // user's UUID in reserved_by or attendee_id.
-  // Non-fatal — log and continue so the auth user is still removed (closes #1543).
+  // Fatal — if either sweep fails, abort before deleting the auth user so the
+  // UUID is not stranded in ticket_activations (GDPR Art. 17, closes #1606).
   const { error: finalNullifyError } = await adminClient
     .from('ticket_activations')
     .update({ reserved_by: null })
     .eq('reserved_by', userId);
   if (finalNullifyError) {
     console.error('delete-my-account: failed to nullify surviving reserved_by references', finalNullifyError.message);
+    return errorResponse(
+      'Cancellazione non completata: impossibile rimuovere i riferimenti ticket (reserved_by). Riprova o contatta il supporto.',
+      500,
+    );
   }
 
   const { error: finalNullifyAttendeeError } = await adminClient
@@ -195,6 +200,10 @@ serve(async (req) => {
     .eq('attendee_id', userId);
   if (finalNullifyAttendeeError) {
     console.error('delete-my-account: failed to nullify surviving attendee_id references', finalNullifyAttendeeError.message);
+    return errorResponse(
+      'Cancellazione non completata: impossibile rimuovere i riferimenti ticket (attendee_id). Riprova o contatta il supporto.',
+      500,
+    );
   }
 
   // 3. Delete the auth user (must be last — only reached if all data was cleaned)


### PR DESCRIPTION
## Summary

Fixes #1606.

The "final nullify sweep" in `delete-my-account` closes a TOCTOU window where a ticket activated between step 1 (nullify activated rows) and step 2 (delete unactivated rows) would survive both steps with the deleted user's UUID still in `reserved_by` / `attendee_id`. Previously these sweeps were non-fatal: if they failed, the function logged the error and deleted the auth user anyway, leaving orphaned UUIDs with no recovery path (GDPR Art. 17 violation).

## Changes

- `supabase/functions/delete-my-account/index.ts`: Both final nullify sweeps now return 500 on failure, aborting before auth user deletion. The user can retry and the sweep will succeed on the next attempt (the ticket is still in the DB at that point).

## Test plan

- Normal deletion with no TOCTOU race: behaviour unchanged, user deleted successfully
- Simulated DB failure during final sweep: function now returns 500 with a clear message; auth user NOT deleted; UUID not stranded
- Re-request after transient failure: sweep succeeds, auth user deleted

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_