### PR TITLE
fix: gate confirm-password error on non-empty password in Signup form

### DIFF
--- a/apps/mobile/src/components/screens/Signup.tsx
+++ b/apps/mobile/src/components/screens/Signup.tsx
@@ -43,8 +43,12 @@ export function Signup({ onBack, onSignup, onLogin, onViewTerms, onViewPrivacy, 
       if (age === null) newErrors.birthDate = 'Inserisci una data di nascita valida';
       else if (age < MIN_SIGNUP_AGE) newErrors.birthDate = `Devi avere almeno ${MIN_SIGNUP_AGE} anni per registrarti`;
     }
-    if (!password) newErrors.password = 'Password richiesta'; else if (password.length < 8) newErrors.password = 'La password deve avere almeno 8 caratteri';
-    if (password !== confirmPassword) newErrors.confirmPassword = 'Le password non corrispondono';
+    if (!password) {
+      newErrors.password = 'Password richiesta';
+    } else {
+      if (password.length < 8) newErrors.password = 'La password deve avere almeno 8 caratteri';
+      if (password !== confirmPassword) newErrors.confirmPassword = 'Le password non corrispondono';
+    }
     if (!acceptTerms) newErrors.terms = 'Devi accettare i termini e la privacy';
     if (Object.keys(newErrors).length > 0) { setErrors(newErrors); isSubmittingRef.current = false; return; }
     setSubmitError(null);


### PR DESCRIPTION
## Summary

Fixes #1617.

The confirm-password mismatch check in `Signup.tsx` ran unconditionally. When the password field was empty but the confirm field had content, the form showed two error messages simultaneously: "Password richiesta" and "Le password non corrispondono" — a contradictory pair that confuses users into editing the wrong field.

## Changes

- `apps/mobile/src/components/screens/Signup.tsx`: The `confirmPassword !== password` check now only runs when `password` is non-empty, matching the logical invariant that two passwords can only "not match" when both have been entered.

## Test plan

- Submit form with empty password and non-empty confirm → only "Password richiesta" shown, confirm field has no error
- Submit with password < 8 chars → only password length error shown
- Submit with matching passwords ≥ 8 chars → no errors
- Submit with mismatched passwords ≥ 8 chars → confirm error shown

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_