### PR TITLE
fix: sanitize AI-generated setFlags in clampRewards (closes #1610)

### DIFF
--- a/apps/mobile/src/gameplay/narrative.ts
+++ b/apps/mobile/src/gameplay/narrative.ts
@@ -376,6 +376,17 @@ function safeInt(value: unknown, fallback: number): number {
   return Number.isFinite(n) ? n : fallback;
 }
 
+const FLAG_RE = /^[a-z][a-z0-9_]{0,59}$/;
+const MAX_FLAGS = 4;
+
+function sanitizeFlags(flags: unknown): string[] | undefined {
+  if (!Array.isArray(flags)) return undefined;
+  const valid = (flags as unknown[])
+    .filter((f): f is string => typeof f === 'string' && FLAG_RE.test(f))
+    .slice(0, MAX_FLAGS);
+  return valid.length > 0 ? valid : undefined;
+}
+
 function clampRewards(scene: NarrativeScene): NarrativeScene {
   return {
     ...scene,
@@ -390,6 +401,7 @@ function clampRewards(scene: NarrativeScene): NarrativeScene {
             ? { reputation: Math.min(3, Math.max(0, safeInt(choice.outcome.rewards.reputation, 0))) }
             : {}),
         },
+        setFlags: sanitizeFlags(choice.outcome.setFlags),
       },
     })),
   };


### PR DESCRIPTION
## Summary

- Adds `FLAG_RE` regex and `MAX_FLAGS` constant to validate narrative flag identifiers
- Adds `sanitizeFlags()` helper that strips invalid or excess flags from AI-generated `setFlags` arrays
- Applies sanitization inside `clampRewards()` so untrusted Maxwell-generated flag names cannot bypass narrative gating or inject arbitrary strings into game state

## Details

AI-generated narrative choices arrive via Maxwell and are spread directly into `choice.outcome` without validating the `setFlags` field. A malformed or adversarially crafted response could inject arbitrary strings (e.g. `"__proto__"`, excessively long keys, or privileged flag names) into the player's flag store, bypassing narrative gating checks.

The fix:
- Allows only flags matching `/^[a-z][a-z0-9_]{0,59}$/` (lowercase, alphanumeric + underscore, 1–60 chars)
- Caps the number of flags per choice at 4 (`MAX_FLAGS`)
- Returns `undefined` (no flags set) if the array is entirely invalid, rather than an empty array that would still write to state

Closes #1610.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_