### PR TITLE
fix: parse date-only event dates as local time (closes #1609)

### DIFF
--- a/apps/mobile/src/components/screens/EventDetails.tsx
+++ b/apps/mobile/src/components/screens/EventDetails.tsx
@@ -326,7 +326,11 @@ function parseEventDateTime(dateValue: string, timeValue: string) {
 
   const isoCandidate = timeValue ? `${dateValue}T${timeValue}` : dateValue;
   let attemptedDate = new Date(isoCandidate);
-  if (!Number.isNaN(attemptedDate.getTime())) return attemptedDate;
+  // Skip the fast path for date-only strings (no timeValue): "YYYY-MM-DD" is
+  // parsed as UTC midnight per spec, shifting the calendar entry by 1-2 h on
+  // non-UTC devices. Only use the result when a time component is present, so
+  // the datetime is parsed as local time (closes #1609).
+  if (timeValue && !Number.isNaN(attemptedDate.getTime())) return attemptedDate;
 
   const normalized = dateValue
     .toLowerCase()


### PR DESCRIPTION
## Summary

Fixes a 1-2 hour offset in calendar entries generated for events with no explicit time component.

## Details

`parseEventDateTime` used a fast-path: `new Date(isoCandidate)` where `isoCandidate` is the raw `dateValue` string when no `timeValue` is available. Per the ECMAScript spec, a date-only string like `"2026-08-20"` is parsed as **UTC midnight**, not local midnight. On a device in Europe/Rome (UTC+1 or UTC+2), this shifts the generated `.ics` `DTSTART` by 1-2 hours relative to the intended date.

The fix: guard the fast-path return with `timeValue &&` — when no time component is provided, fall through to the existing `matchIso` branch, which constructs the `Date` from local-clock components via `new Date(year, month-1, day, h, m, 0, 0)`.

Closes #1609.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_