### PR TITLE
fix: count attemptCountRef per round played in ActivityMinigame (closes #1611)

### DIFF
--- a/apps/mobile/src/components/screens/ActivityMinigame.tsx
+++ b/apps/mobile/src/components/screens/ActivityMinigame.tsx
@@ -197,7 +197,6 @@ function TimingMinigame({ config, activityTitle, statBenefits, onComplete, onCan
       window.clearTimeout(feedbackTimeoutRef.current);
       feedbackTimeoutRef.current = null;
     }
-    attemptCountRef.current += 1;
     if (startedAtRef.current == null) startedAtRef.current = Date.now();
     setFeedback(null);
     setProgress(0);
@@ -210,6 +209,7 @@ function TimingMinigame({ config, activityTitle, statBenefits, onComplete, onCan
   const handleStop = () => {
     if (phase !== 'playing' || hasStoppedRef.current) return;
     hasStoppedRef.current = true;
+    attemptCountRef.current += 1;
 
     const result = computeRoundScore(round.target, progress, round.tolerance);
     const nextScores = [...roundScores, result.score];
@@ -376,7 +376,6 @@ function AudioMinigame({ config, activityTitle, statBenefits, onComplete, onCanc
   }, []);
 
   const handleStart = () => {
-    attemptCountRef.current += 1;
     if (startedAtRef.current == null) startedAtRef.current = Date.now();
     setFeedback(null);
     setLevel([50]);
@@ -391,6 +390,7 @@ function AudioMinigame({ config, activityTitle, statBenefits, onComplete, onCanc
 
   const handleConfirm = () => {
     if (phase !== 'adjust') return;
+    attemptCountRef.current += 1;
     const hit = level[0] ?? 0;
     const result = computeRoundScore(round.target, hit, round.tolerance);
     const nextScores = [...roundScores, result.score];


### PR DESCRIPTION
## Summary

`attemptCountRef` in both `TimingMinigame` and `AudioMinigame` was always reported as `1` because it was incremented only in `handleStart`, which is called exactly once per minigame session (on the initial "Inizia minigioco" click). Subsequent rounds start automatically via a timeout — `handleStart` is never called again.

## Fix

- Remove the increment from `handleStart` in both components
- Add `attemptCountRef.current += 1` to `handleStop` (TimingMinigame) and `handleConfirm` (AudioMinigame), so each round interaction is counted
- A 3-round minigame now reports `attempts: 3` instead of always `1`

Closes #1611.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_