### PR TITLE
fix: reset signupInProgressRef when signUp throws (closes #1599)

### DIFF
--- a/apps/mobile/src/hooks/useAuth.ts
+++ b/apps/mobile/src/hooks/useAuth.ts
@@ -121,16 +121,25 @@ export function useAuth(
 
         const redirectTo = resolveAuthRedirectTo();
         signupInProgressRef.current = true;
-        const { data, error } = await supabase.auth.signUp({
-            email,
-            password,
-            options: {
-                // is_minor viene letto dal trigger handle_new_user che, per i
-                // minorenni, imposta leaderboard_visible=false (classifica opt-in).
-                data: { name, is_minor: isMinor },
-                ...(redirectTo ? { emailRedirectTo: redirectTo } : {}),
-            },
-        });
+        let signupResult: Awaited<ReturnType<typeof supabase.auth.signUp>>;
+        try {
+            signupResult = await supabase.auth.signUp({
+                email,
+                password,
+                options: {
+                    // is_minor viene letto dal trigger handle_new_user che, per i
+                    // minorenni, imposta leaderboard_visible=false (classifica opt-in).
+                    data: { name, is_minor: isMinor },
+                    ...(redirectTo ? { emailRedirectTo: redirectTo } : {}),
+                },
+            });
+        } catch (err) {
+            // Reset the flag so future SIGNED_IN events are not misidentified
+            // as a signup transition (closes #1599).
+            signupInProgressRef.current = false;
+            throw err;
+        }
+        const { data, error } = signupResult;
         if (error) {
             signupInProgressRef.current = false;
             setAuthError(translateAuthError(error));


### PR DESCRIPTION
## Summary

`signupInProgressRef.current` is set to `true` just before `supabase.auth.signUp()` is called. Every normal exit path (error returned, no session, no identities, success) resets it — but if `signUp` throws (e.g. network failure, unexpected SDK error), the flag is never cleared. A stuck `true` value causes the subsequent `SIGNED_IN` listener to skip navigation to `'home'` on the next successful login, silently trapping the user on the welcome screen.

## Fix

Wrap the `supabase.auth.signUp()` call in a `try/catch`. On throw, reset `signupInProgressRef.current` to `false` before re-throwing so the UI's existing error handler surfaces the message normally.

Closes #1599.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_