### PR TITLE
fix: disable both planning buttons during in-flight save or clear (closes #1615)

### DIFF
--- a/apps/mobile/src/components/screens/EventDetails.tsx
+++ b/apps/mobile/src/components/screens/EventDetails.tsx
@@ -252,7 +252,7 @@ export function EventDetails({
               variant="primary"
               size="md"
               onClick={() => handleSavePlanning()}
-              disabled={isSavingPlanning}
+              disabled={isSavingPlanning || isClearingPlanning}
             >
               {planning ? 'Aggiorna pianificazione' : 'Salva pianificazione'}
             </Button>
@@ -261,7 +261,7 @@ export function EventDetails({
                 variant="ghost"
                 size="md"
                 onClick={() => handleClearPlanning()}
-                disabled={isClearingPlanning}
+                disabled={isSavingPlanning || isClearingPlanning}
               >
                 Cancella pianificazione
               </Button>


### PR DESCRIPTION
## Summary

Prevents a concurrent-operation race on the "Salva pianificazione" / "Cancella pianificazione" buttons in `EventDetails`.

## Details

Each button only disabled itself while its own operation was in-flight: "Aggiorna pianificazione" checked `isSavingPlanning`, "Cancella pianificazione" checked `isClearingPlanning`. A user who tapped "Salva" and then quickly tapped "Cancella" before the save resolved would fire both `onSavePlanning` and `onClearPlanning` concurrently — the last to finish would win, leaving the UI in an inconsistent state.

## Fix

Both buttons now disable when `isSavingPlanning || isClearingPlanning`, so only one operation can be initiated at a time.

Closes #1615.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_