### PR TITLE
Fix unbounded localManualActivationStore growth (#1600)

### DIFF
--- a/apps/mobile/src/services/ticket-activation.ts
+++ b/apps/mobile/src/services/ticket-activation.ts
@@ -82,6 +82,16 @@ function cleanupOldRecords() {
         localManualActivationStore.delete(key);
       }
     }
+    // If still oversized after time-based prune (all entries within last 8 h),
+    // evict the oldest entries until the store is within MAX_STORE_SIZE (closes #1600).
+    if (localManualActivationStore.size > MAX_STORE_SIZE) {
+      const sorted = Array.from(localManualActivationStore.entries()).sort(
+        (a, b) =>
+          new Date(a[1].activatedAtIso).getTime() - new Date(b[1].activatedAtIso).getTime(),
+      );
+      const toDelete = sorted.slice(0, sorted.length - MAX_STORE_SIZE);
+      for (const [key] of toDelete) localManualActivationStore.delete(key);
+    }
     if (import.meta.env.DEV) {
       console.info(
         '[ticket-activation] localManualActivationStore pruned; size now:',


### PR DESCRIPTION
## Summary

- After the 8-hour time-based prune in `cleanupOldRecords`, `localManualActivationStore` could still exceed `MAX_STORE_SIZE` if all entries were activated within the last 8 hours (e.g. a long uninterrupted shift with high scan volume).
- Added a fallback size-cap: sort remaining entries by `activatedAtIso` and evict the oldest until the store is within `MAX_STORE_SIZE`.

## Changes

- `apps/mobile/src/services/ticket-activation.ts`: added size-cap eviction after time-based prune in `cleanupOldRecords` (fixes #1600).

## Test plan

- [ ] Manual: simulate >1000 activations within 8 hours in a single session; verify `localManualActivationStore.size` does not exceed `MAX_STORE_SIZE` after cleanup runs.
- [ ] Verify session-dedup still works for entries kept after eviction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_