### PR TITLE
Move AbortController.abort() to finally in AI service functions (#1618)

### DIFF
--- a/apps/mobile/src/services/ai.ts
+++ b/apps/mobile/src/services/ai.ts
@@ -236,8 +236,6 @@ export async function requestAiSupport({
       title: 'Supporto rallentato',
       message: 'Il servizio di supporto sta impiegando troppo tempo a rispondere.',
     });
-  } catch (error) {
-    throw error;
   } finally {
     controller.abort();
     cleanupExternalAbort?.();
@@ -365,8 +363,6 @@ export async function requestAiIssue({
       title: 'Segnalazione rallentata',
       message: 'L invio della segnalazione sta impiegando troppo tempo.',
     });
-  } catch (error) {
-    throw error;
   } finally {
     controller.abort();
   }

--- a/apps/mobile/src/services/ai.ts
+++ b/apps/mobile/src/services/ai.ts
@@ -237,9 +237,9 @@ export async function requestAiSupport({
       message: 'Il servizio di supporto sta impiegando troppo tempo a rispondere.',
     });
   } catch (error) {
-    controller.abort();
     throw error;
   } finally {
+    controller.abort();
     cleanupExternalAbort?.();
   }
 }
@@ -366,7 +366,8 @@ export async function requestAiIssue({
       message: 'L invio della segnalazione sta impiegando troppo tempo.',
     });
   } catch (error) {
-    controller.abort();
     throw error;
+  } finally {
+    controller.abort();
   }
 }


### PR DESCRIPTION
## Summary

- In `requestAiSupport` and `requestAiIssue`, `controller.abort()` was only called inside the `catch` block, so on the happy path the `AbortController` was never cleaned up.
- Moved `controller.abort()` to the `finally` block in both functions so the signal is always cancelled after the request settles, freeing any abort-event listeners.

## Changes

- `apps/mobile/src/services/ai.ts`: moved `controller.abort()` from `catch` to `finally` in both `requestAiSupport` and `requestAiIssue` (fixes #1618).

## Test plan

- [ ] Verify AI chat requests complete normally with no console errors.
- [ ] Verify that a timed-out or failed request still aborts the underlying fetch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_