### PR TITLE
Use anchored regex to validate eventId in create_deep_link (#1612)

### DIFF
--- a/supabase/functions/event-links/index.ts
+++ b/supabase/functions/event-links/index.ts
@@ -11,6 +11,11 @@ const corsHeaders = {
 };
 
 const EVENT_ID_PATTERN = /\b([A-Za-z]{2,10}-(?:\d{1,6}|[A-Za-z][A-Za-z0-9]*(?:-[A-Za-z0-9]+)*))\b/;
+// Anchored variant used for full-string validation (e.g. create_deep_link).
+// EVENT_ID_PATTERN uses \b word-boundaries for substring extraction from URLs
+// and QR payloads, but \b alone allows values like "AB-123/extra" to pass;
+// the anchored pattern rejects anything that is not exactly a valid event ID.
+const EVENT_ID_FULL_PATTERN = /^[A-Za-z]{2,10}-(?:\d{1,6}|[A-Za-z][A-Za-z0-9]*(?:-[A-Za-z0-9]+)*)$/;
 
 const VALID_ROLE_IDS = new Set(['attore', 'luci', 'fonico', 'attrezzista', 'palco', 'rspp', 'dramaturg']);
 
@@ -170,9 +175,9 @@ serve(async (req) => {
       return json({ error: 'eventId obbligatorio' }, 400);
     }
 
-    // Apply the same format validation used by all other actions so malformed
-    // or unbounded eventId values are rejected before reaching the DB (closes #1566).
-    if (!EVENT_ID_PATTERN.test(eventId)) {
+    // Use the anchored pattern so that a value containing a valid-looking
+    // substring (e.g. "AB-123/../../etc") is rejected in full (closes #1612).
+    if (!EVENT_ID_FULL_PATTERN.test(eventId)) {
       return json({ error: 'eventId non valido' }, 400);
     }
 


### PR DESCRIPTION
## Summary

- `EVENT_ID_PATTERN` uses `\b` word-boundaries designed for substring extraction from QR payloads and URLs.
- When used with `.test()` for full-string validation in the `create_deep_link` action, word-boundary matching allowed values like `"AB-123/../../etc"` to pass because `\b` only requires a word/non-word transition at each end — not that the entire string matches.
- Added `EVENT_ID_FULL_PATTERN` (`^...$`) with the same character rules but anchored, and switched the `create_deep_link` validation to use it.

## Changes

- `supabase/functions/event-links/index.ts`: added `EVENT_ID_FULL_PATTERN` and replaced `EVENT_ID_PATTERN.test(eventId)` with `EVENT_ID_FULL_PATTERN.test(eventId)` in the `create_deep_link` action (fixes #1612).

## Test plan

- [ ] `AB-12345` → passes validation.
- [ ] `AB-12345/extra` → rejected with 400.
- [ ] `AB-12345 suffix` → rejected with 400.
- [ ] `AB-WORD-SUB` → passes validation.
- [ ] `toolong-12345` (prefix > 10 chars) → rejected with 400.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_