### PR TITLE
Always use server-assigned sequence in normalizeLogEntry (#1613)

### DIFF
--- a/supabase/functions/mobile-logs/index.ts
+++ b/supabase/functions/mobile-logs/index.ts
@@ -82,10 +82,10 @@ function normalizeLogEntry(rawEntry: unknown, index: number): NormalizedLogEntry
   // Always use the server-side timestamp; ignore any client-supplied createdAt
   // to preserve audit trail integrity (closes #1569).
   const createdAt = Date.now();
-  const sequence =
-    typeof rawEntry.sequence === 'number' && Number.isFinite(rawEntry.sequence)
-      ? rawEntry.sequence
-      : index + 1;
+  // Always use the server-assigned position; ignoring any client-supplied
+  // sequence prevents a malicious or buggy client from manipulating log ordering
+  // in stored records (closes #1613).
+  const sequence = index + 1;
 
   return {
     id,


### PR DESCRIPTION
## Summary

- `normalizeLogEntry` in `mobile-logs` accepted the client-supplied `sequence` field when it was a finite number, allowing a malicious or buggy client to inject arbitrary ordering values into stored log records.
- Changed to always use `index + 1` (the entry's position in the batch), matching the pattern already used for `createdAt`.

## Changes

- `supabase/functions/mobile-logs/index.ts`: removed the client-value branch from `sequence` assignment; always use `index + 1` (fixes #1613).

## Test plan

- [ ] Send a log batch with a `sequence` field set to an out-of-order value; verify stored records use 1, 2, 3… in insertion order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_