### PR TITLE
Strip email from saveState in demo mode to avoid persisting PII (#1601)

### DIFF
--- a/apps/mobile/src/state/store.tsx
+++ b/apps/mobile/src/state/store.tsx
@@ -2081,7 +2081,12 @@ function loadState(): GameState {
 function saveState(state: GameState) {
   if (typeof window === 'undefined') return;
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    // In demo mode (no Supabase) the user has not authenticated; do not
+    // persist their email address to localStorage (GDPR / PII hygiene, closes #1601).
+    const persisted = isSupabaseConfigured
+      ? state
+      : { ...state, profile: { ...state.profile, email: '' } };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted));
   } catch {
     // ignore storage errors
   }


### PR DESCRIPTION
## Summary

- `saveState` in `store.tsx` serialized the entire `GameState` — including `profile.email` — to `localStorage` unconditionally.
- When Supabase is not configured (demo mode), the user has not authenticated, so writing their email to local storage is unintentional PII storage.
- `saveState` now clears `profile.email` before persisting when `isSupabaseConfigured` is false.

## Changes

- `apps/mobile/src/state/store.tsx`: guard `saveState` to omit `profile.email` when `!isSupabaseConfigured` (fixes #1601).

## Test plan

- [ ] In demo mode (Supabase not configured), verify `localStorage` entry does not contain an email address after entering one in the login form.
- [ ] In production mode (Supabase configured), verify profile including email is persisted as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_