### PR TITLE
Add magic-byte validation to uploadProfileImage (#1603)

### DIFF
--- a/apps/mobile/src/services/storage.ts
+++ b/apps/mobile/src/services/storage.ts
@@ -7,6 +7,25 @@ const MAX_PROFILE_IMAGE_BYTES = 5 * 1024 * 1024;
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+// Verify actual file content via magic bytes so that a caller cannot spoof the
+// MIME type by setting file.type to 'image/jpeg' on a non-image payload (#1602).
+async function hasImageMagicBytes(file: File): Promise<boolean> {
+  if (file.size < 4) return false;
+  const header = await file.slice(0, 12).arrayBuffer();
+  const b = new Uint8Array(header);
+  // JPEG: FF D8 FF
+  if (b[0] === 0xFF && b[1] === 0xD8 && b[2] === 0xFF) return true;
+  // PNG: 89 50 4E 47
+  if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4E && b[3] === 0x47) return true;
+  // GIF: GIF8
+  if (b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x38) return true;
+  // WebP: RIFF at [0-3] and WEBP at [8-11]
+  if (b.length >= 12 &&
+      b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46 &&
+      b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50) return true;
+  return false;
+}
+
 export async function uploadProfileImage(userId: string, file: File): Promise<string> {
   return withMobileWatchdog(async () => {
     if (!supabase) throw new Error('Supabase non configurato');
@@ -16,6 +35,9 @@ export async function uploadProfileImage(userId: string, file: File): Promise<st
     }
 
     if (!file.type.startsWith(ALLOWED_IMAGE_MIME_PREFIX)) {
+      throw new Error('Formato immagine non valido');
+    }
+    if (!await hasImageMagicBytes(file)) {
       throw new Error('Formato immagine non valido');
     }
     if (file.size > MAX_PROFILE_IMAGE_BYTES) {


### PR DESCRIPTION
## Summary

- `file.type` is a client-controlled hint; setting it to `'image/jpeg'` on any payload bypasses the MIME prefix check at line 18.
- Added `hasImageMagicBytes()` which reads the first 12 bytes of the file and checks against known image signatures (JPEG `FF D8 FF`, PNG `89 50 4E 47`, GIF `GIF8`, WebP `RIFF…WEBP`).
- The magic-byte check is applied alongside the existing `file.type` prefix check so both must pass.

## Changes

- `apps/mobile/src/services/storage.ts`: added `hasImageMagicBytes()` and wired it into `uploadProfileImage` (fixes #1603).

## Test plan

- [ ] Upload a valid JPEG/PNG — succeeds.
- [ ] Rename a text file to `.jpg`, set `type: 'image/jpeg'` — rejected with "Formato immagine non valido".
- [ ] Upload a WebP — succeeds.