### PR TITLE
Use constant-time comparison for service-role key in import functions (#1614)

### DIFF
--- a/supabase/functions/import-atcl-lazio/index.ts
+++ b/supabase/functions/import-atcl-lazio/index.ts
@@ -211,6 +211,20 @@ const jsonResponse = (body: Record<string, unknown>, status = 200) =>
     headers: { ...corsHeaders, 'Content-Type': 'application/json' },
   });
 
+// Constant-time comparison to prevent timing-based inference of the
+// service-role key length or content (closes #1614).
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+  if (aBytes.length !== bBytes.length) return false;
+  let result = 0;
+  for (let i = 0; i < aBytes.length; i++) {
+    result |= aBytes[i] ^ bBytes[i];
+  }
+  return result === 0;
+}
+
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
@@ -237,7 +251,8 @@ serve(async (req) => {
   // Service-role key allows the control-plane to call this function without a user session.
   // The non-empty check prevents an empty-string SUPABASE_SERVICE_ROLE_KEY from
   // accidentally matching an empty Bearer token and bypassing auth (closes #1131).
-  if (!serviceKey || callerToken !== serviceKey) {
+  // timingSafeStringEqual is used to prevent timing-based inference of the key (closes #1614).
+  if (!serviceKey || !timingSafeStringEqual(callerToken, serviceKey)) {
     const userClient = createClient(supabaseUrl, anonKey, {
       global: { headers: { Authorization: authHeader } },
       auth: { autoRefreshToken: false, persistSession: false },

--- a/supabase/functions/import-spazio-rossellini/index.ts
+++ b/supabase/functions/import-spazio-rossellini/index.ts
@@ -216,6 +216,20 @@ const jsonResponse = (body: Record<string, unknown>, status = 200) =>
     headers: { ...corsHeaders, 'Content-Type': 'application/json' },
   });
 
+// Constant-time comparison to prevent timing-based inference of the
+// service-role key length or content (closes #1614).
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+  if (aBytes.length !== bBytes.length) return false;
+  let result = 0;
+  for (let i = 0; i < aBytes.length; i++) {
+    result |= aBytes[i] ^ bBytes[i];
+  }
+  return result === 0;
+}
+
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
@@ -243,7 +257,8 @@ serve(async (req) => {
   // Service-role key allows the control-plane to call this function without a user session.
   // The non-empty check prevents an empty-string SUPABASE_SERVICE_ROLE_KEY from
   // accidentally matching an empty Bearer token and bypassing auth (closes #1131).
-  if (!serviceKey || callerToken !== serviceKey) {
+  // timingSafeStringEqual is used to prevent timing-based inference of the key (closes #1614).
+  if (!serviceKey || !timingSafeStringEqual(callerToken, serviceKey)) {
     const userClient = createClient(supabaseUrl, anonKey, {
       global: { headers: { Authorization: authHeader } },
       auth: { autoRefreshToken: false, persistSession: false },


### PR DESCRIPTION
## Summary

- Both `import-atcl-lazio` and `import-spazio-rossellini` compared the caller's Bearer token against the Supabase service-role key using `!==`, which is subject to V8 string comparison short-circuiting.
- A timing attack could (in theory) allow an attacker to infer the key length or byte values by measuring response time differences across many requests.
- Added `timingSafeStringEqual()` (XOR-reduction over UTF-8 bytes) to both functions and replaced the `!==` check.

## Changes

- `supabase/functions/import-atcl-lazio/index.ts`: added `timingSafeStringEqual` and used it in the service-role key guard (fixes #1614).
- `supabase/functions/import-spazio-rossellini/index.ts`: same change.

## Test plan

- [ ] Service-role key bearer token still grants access.
- [ ] Invalid token still falls through to JWT verification path.
- [ ] Empty bearer token with empty `SUPABASE_SERVICE_ROLE_KEY` still rejected (non-empty guard preserved).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_