### PR TITLE
Sanitize manual ticket input in QRScanner before building composite (#1616)

### DIFF
--- a/apps/mobile/src/components/screens/QRScanner.tsx
+++ b/apps/mobile/src/components/screens/QRScanner.tsx
@@ -152,7 +152,11 @@ export function QRScanner({ onClose, onScan, events = [] }: QRScannerProps) {
   const handleManualSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!manualTicket.trim() || !manualEventId.trim()) { setScanError('Inserisci sia ID Evento che Numero Ticket.'); return; }
-    await handleScanAttempt(`manual-ticket:${manualEventId}:${manualTicket}`);
+    // Strip characters that would break the colon-delimited composite or inject
+    // unexpected segments into the protocol string (closes #1616).
+    const safeTicket = manualTicket.trim().replace(/[^A-Za-z0-9\- ]/g, '');
+    if (!safeTicket) { setScanError('Formato biglietto non valido.'); return; }
+    await handleScanAttempt(`manual-ticket:${manualEventId}:${safeTicket}`);
   };
 
   return (


### PR DESCRIPTION
## Summary

- `handleManualSubmit` in `QRScanner.tsx` interpolated the raw `manualTicket` value directly into the colon-delimited composite string (`manual-ticket:eventId:ticket`).
- A ticket number containing a colon (e.g. `"ABC:123"`) produces `"manual-ticket:eventId:ABC:123"`, which any consumer splitting on `:` at index 2 would truncate to `"ABC"`.
- Additionally, unvalidated input creates a segment-injection surface if parsing assumptions change.

Fixed by stripping non-alphanumeric characters (except hyphens and spaces) before building the composite, and rejecting an empty result with a user-visible error.

## Changes

- `apps/mobile/src/components/screens/QRScanner.tsx`: sanitize `manualTicket` with `replace(/[^A-Za-z0-9\- ]/g, '')` before building the composite string (fixes #1616).

## Test plan

- [ ] Valid ticket number (`"TKT-001"`) — submits normally.
- [ ] Ticket number with colon (`"ABC:123"`) — sanitized to `"ABC123"`, submits.
- [ ] Ticket number that reduces to empty string after sanitization — shows "Formato biglietto non valido." error.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRUn686NGxA5wjtmBx1CH6)_