### PR TITLE
fix: make final nullify sweep fatal to prevent orphaned UUIDs

### DIFF
--- a/supabase/functions/delete-my-account/index.ts
+++ b/supabase/functions/delete-my-account/index.ts
@@ -180,13 +180,16 @@ serve(async (req) => {
   // step 1 (nullify activated tickets) and step 2 (delete unactivated tickets):
   // such a ticket would have been skipped by both steps, leaving the deleted
   // user's UUID in reserved_by or attendee_id.
-  // Non-fatal — log and continue so the auth user is still removed (closes #1543).
+  //
+  // Fatal — if either sweep fails, the auth user must NOT be deleted, because the
+  // stranded UUID would have no recovery path (violates GDPR Art. 17).
   const { error: finalNullifyError } = await adminClient
     .from('ticket_activations')
     .update({ reserved_by: null })
     .eq('reserved_by', userId);
   if (finalNullifyError) {
-    console.error('delete-my-account: failed to nullify surviving reserved_by references', finalNullifyError.message);
+    console.error('delete-my-account: failed to nullify surviving reserved_by references — aborting auth user deletion', finalNullifyError.message);
+    return errorResponse('Impossibile rimuovere tutti i riferimenti ai biglietti. Riprova più tardi.', 500);
   }
 
   const { error: finalNullifyAttendeeError } = await adminClient
@@ -194,7 +197,8 @@ serve(async (req) => {
     .update({ attendee_id: null })
     .eq('attendee_id', userId);
   if (finalNullifyAttendeeError) {
-    console.error('delete-my-account: failed to nullify surviving attendee_id references', finalNullifyAttendeeError.message);
+    console.error('delete-my-account: failed to nullify surviving attendee_id references — aborting auth user deletion', finalNullifyAttendeeError.message);
+    return errorResponse('Impossibile rimuovere tutti i riferimenti ai biglietti. Riprova più tardi.', 500);
   }
 
   // 3. Delete the auth user (must be last — only reached if all data was cleaned)


### PR DESCRIPTION
## Summary

Makes the final nullify sweep (reserved_by, attendee_id) in delete-my-account fatal instead of non-fatal.

## Problem

The final sweep was non-fatal: if it failed (transient DB error, timeout, RLS conflict), the auth user was still deleted. The deleted user's UUID remained in 	icket_activations.reserved_by or ttendee_id with no recovery path, violating GDPR Art. 17 (right to erasure).

## Concrete failure scenario

1. Admin reserves a ticket → ticket is activated between sweep steps
2. Both sweep steps skip it (TOCTOU window closed by the sweep, but sweep fails transiently)
3. Auth user deleted. UUID stranded.

## Fix

Both nullify operations now return 500 before deleting the auth user if they fail. The user can retry the deletion. The auth user is preserved until all PII references are cleaned.

Closes #1606